### PR TITLE
move create app types to their own registry

### DIFF
--- a/lib/shopify-cli.rb
+++ b/lib/shopify-cli.rb
@@ -101,6 +101,8 @@ module ShopifyCli
   autoload :EntryPoint, 'shopify-cli/entry_point'
   autoload :Finalize,   'shopify-cli/finalize'
   autoload :Task,   'shopify-cli/task'
+  autoload :AppTypes, 'shopify-cli/app_types'
+  autoload :AppTypeRegistry, 'shopify-cli/app_type_registry'
 
   module Tasks
     register :Clone, 'clone', 'shopify-cli/tasks/clone'

--- a/lib/shopify-cli/app_type_registry.rb
+++ b/lib/shopify-cli/app_type_registry.rb
@@ -1,0 +1,27 @@
+require 'shopify-cli'
+
+module ShopifyCli
+  class AppTypeRegistry
+    class << self
+      def register(identifier, klass)
+        app_types[identifier] = klass
+      end
+
+      def build(identifer, *args)
+        app_types[identifer].call(*args)
+      end
+
+      def each(&enumerator)
+        app_types.each(&enumerator)
+      end
+
+      protected
+
+      def app_types
+        @app_types ||= {}
+      end
+    end
+  end
+
+  AppTypeRegistry.register(:node, AppTypes::Node)
+end

--- a/lib/shopify-cli/app_types.rb
+++ b/lib/shopify-cli/app_types.rb
@@ -1,0 +1,8 @@
+require 'shopify-cli'
+
+Dir.glob('./lib/shopify-cli/app_types/*.rb') { |f| require f }
+
+module ShopifyCli
+  module AppTypes
+  end
+end

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -1,0 +1,54 @@
+require 'shopify-cli'
+
+module ShopifyCli
+  module AppTypes
+    class Node < ShopifyCli::Task
+      def call(*args)
+        @name = args.shift
+        embedded_app
+      end
+
+      def self.description
+        'node embedded app'
+      end
+
+      protected
+
+      def embedded_app
+        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', @name)
+        api_key = CLI::UI.ask('What is your Shopify API Key')
+        api_secret = CLI::UI.ask('What is your Shopify API Secret')
+        write_env_file(api_key, api_secret)
+
+        CLI::UI::Frame.open('Installing dependencies...') do
+          yarn
+        end
+        puts CLI::UI.fmt(post_clone)
+        ShopifyCli::Finalize.request_cd(@name)
+      end
+
+      def write_env_file(api_key, api_secret)
+        File.write(File.join(@name, '.env'),
+          "SHOPIFY_API_KEY=#{api_key}\nSHOPIFY_API_SECRET_KEY=#{api_secret}")
+      end
+
+      def post_clone
+        "Run {{command:shopify server}} to start the app server"
+      end
+
+      def yarn
+        CLI::UI::Progress.progress do |bar|
+          success = CLI::Kit::System.system('npm install', chdir: @name) do |_out, err|
+            match = err.match(/(\d+)\/(\d+)/)
+            next unless match
+            percent = (match[1] / match[2] * 100).round(2)
+            bar.tick(set_percent: percent)
+          end.success?
+          return false unless success
+          bar.tick(set_percent: 1.0)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -8,53 +8,19 @@ module ShopifyCli
         return puts CLI::UI.fmt(self.class.help) unless @name
 
         app_type = CLI::UI::Prompt.ask('What type of app would you like to create?') do |handler|
-          handler.option('node embedded app') { |selection| 'embedded_app' }
+          AppTypeRegistry.each do |identifier, app_type|
+            handler.option(app_type.description) { |selection| identifier }
+          end
           handler.option('ruby embedded app') { |selection| return false }
         end
 
         return puts "not yet implemented" unless app_type
 
-        method(app_type).call
-      end
-
-      def embedded_app
-        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', @name)
-        api_key = CLI::UI.ask('What is your Shopify API Key')
-        api_secret = CLI::UI.ask('What is your Shopify API Secret')
-        write_env_file(api_key, api_secret)
-
-        CLI::UI::Frame.open('Installing dependencies...') do
-          yarn
-        end
-        puts CLI::UI.fmt(post_clone)
-        ShopifyCli::Finalize.request_cd(@name)
-      end
-
-      def post_clone
-        "Run {{command:shopify server}} to start the app server"
+        AppTypeRegistry.build(app_type, @name)
       end
 
       def self.help
         "Bootstrap an app.\nUsage: {{command:#{ShopifyCli::TOOL_NAME} create <apptype> <appname>}}"
-      end
-
-      def write_env_file(api_key, api_secret)
-        File.write(File.join(@name, '.env'),
-          "SHOPIFY_API_KEY=#{api_key}\nSHOPIFY_API_SECRET_KEY=#{api_secret}")
-      end
-
-      def yarn
-        CLI::UI::Progress.progress do |bar|
-          success = CLI::Kit::System.system('npm install', chdir: @name) do |_out, err|
-            match = err.match(/(\d+)\/(\d+)/)
-            next unless match
-            percent = (match[1] / match[2] * 100).round(2)
-            bar.tick(set_percent: percent)
-          end.success?
-          return false unless success
-          bar.tick(set_percent: 1.0)
-          true
-        end
       end
     end
   end

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module ShopifyCli
+  module AppTypes
+    class NodeTest < MiniTest::Test
+      def setup
+        @app = ShopifyCli::AppTypes::Node.new
+      end
+
+      def test_embedded_app_creation
+        ShopifyCli::Tasks::Clone.stubs(:call).with(
+          'git@github.com:shopify/webgen-embeddedapp.git',
+          'test-app'
+        )
+        CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
+        @app.expects(:write_env_file)
+        @app.expects(:yarn)
+        io = capture_io do
+          @app.call('test-app')
+        end
+        output = io.join
+
+        assert_match('Installing dependencies...', output)
+      end
+    end
+  end
+end

--- a/test/commands/create_test.rb
+++ b/test/commands/create_test.rb
@@ -24,21 +24,10 @@ module ShopifyCli
         assert_match('not yet implemented', io.join)
       end
 
-      def test_embedded_app_creation
-        CLI::UI::Prompt.expects(:ask).returns('embedded_app')
-        ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/webgen-embeddedapp.git',
-          'test-app'
-        )
-        CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
-        @command.expects(:write_env_file)
-        @command.expects(:yarn)
-        io = capture_io do
-          @command.call(['test-app'], nil)
-        end
-        output = io.join
-
-        assert_match('Installing dependencies...', output)
+      def test_implemented_option
+        CLI::UI::Prompt.expects(:ask).returns(:node)
+        ShopifyCli::AppTypes::Node.any_instance.stubs(:call).with('test-app')
+        @command.call(['test-app'], nil)
       end
     end
   end


### PR DESCRIPTION
This PR adds a new class for organizing types of apps to be constructed by the `create` command. Each type of app is implemented as an instance of a `Task` class and registered to `AppTypeRegistry`. The create command will now dynamically generate the choices for app creation based on this registry.