### PR TITLE
update command

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -17,5 +17,6 @@ module ShopifyCli
     register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev'
     register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system'
     register :Server, 'server', 'shopify-cli/commands/server'
+    register :Update, 'update', 'shopify-cli/commands/update'
   end
 end

--- a/lib/shopify-cli/commands/update.rb
+++ b/lib/shopify-cli/commands/update.rb
@@ -1,0 +1,56 @@
+require 'shopify-cli'
+
+module ShopifyCli
+  module Commands
+    class Update < ShopifyCli::Command
+      def self.help
+        "Update shopify-cli."
+      end
+
+      def call(_args, _name)
+        if File.exist?(File.expand_path('.git/HEAD.lock', ShopifyCli::ROOT))
+          err("failed!")
+          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
+          err("Try running {{green:dev update}}.")
+          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/HEAD.lock}} to continue.")
+          raise(ShopifyCli::AbortSilent)
+        end
+
+        if File.exist?(File.expand_path(".git/refs/heads/master.lock", ShopifyCli::ROOT))
+          err("failed!")
+          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
+          err("Try running {{green:dev update}}.")
+          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/refs/heads/master.lock}} to continue.")
+          raise(ShopifyCli::AbortSilent)
+        end
+
+        _, stat = CLI::Kit::System.capture2e('git', '-C', ShopifyCli::ROOT, 'fetch', 'origin', 'master')
+        unless stat.success?
+          raise(ShopifyCli::Abort, 'failed!')
+        end
+
+        commands = [
+          ['reset', '.'],
+          ['checkout', '.'],
+          ['checkout', '-f', '-B', 'master'],
+          ['reset', '--hard', 'FETCH_HEAD'],
+        ]
+        spin_group = CLI::UI::SpinGroup.new
+        spin_group.add('Updating shopify-cli') do |spinner|
+          commands.each do |args|
+            _, stat = CLI::Kit::System.capture2e('git', '-C', ShopifyCli::ROOT, *args)
+            raise(ShopifyCli::Abort, "command failed: #{args.join(' ')}") unless stat.success?
+          end
+          spinner.update_title('Updated shopify-cli')
+        end
+        spin_group.wait
+      end
+
+      def err(msg, newline: true)
+        method = newline ? :puts : :print
+        STDERR.send(method, CLI::UI.fmt("{{bold:{{red:#{msg}}}}}"))
+      end
+    end
+  end
+end
+

--- a/test/commands/update_test.rb
+++ b/test/commands/update_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+module ShopifyCli
+  module Commands
+    class UpdateTest < MiniTest::Test
+      include TestHelpers::Constants
+
+      def setup
+        super
+        @dir = Dir.mktmpdir
+        @command = ShopifyCli::Commands::Update.new
+        redefine_constant(ShopifyCli, :ROOT, @dir)
+        FileUtils.mkdir("#{ShopifyCli::ROOT}/.git")
+      end
+
+      def test_raises_if_git_process_running
+        File.write("#{ShopifyCli::ROOT}/.git/HEAD.lock", 'test')
+        io = capture_io do
+          assert_raises ShopifyCli::AbortSilent do
+            @command.call([], nil)
+          end
+        end
+        assert_match("It looks like another git operation is in progress", io.join)
+      end
+
+      def test_raises_if_git_branch_process_running
+        FileUtils.mkdir_p("#{ShopifyCli::ROOT}/.git/refs/heads")
+        File.write("#{ShopifyCli::ROOT}/.git/refs/heads/master.lock", 'test')
+        io = capture_io do
+          assert_raises ShopifyCli::AbortSilent do
+            @command.call([], nil)
+          end
+        end
+        assert_match("It looks like another git operation is in progress", io.join)
+      end
+
+      class Stat
+        def success?
+          true
+        end
+      end
+
+      def test_pulls_from_git
+        CLI::Kit::System.expects(:capture2e)
+          .returns([nil, Stat.new])
+          .times(5)
+
+        io = capture_io do
+          @command.call([], nil)
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,5 +15,6 @@ require 'byebug'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require_relative 'minitest_ext'
+require_relative 'test_helpers'
 
 require 'mocha/minitest'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module TestHelpers
+  autoload :Constants, 'test_helpers/constants'
+end

--- a/test/test_helpers/constants.rb
+++ b/test/test_helpers/constants.rb
@@ -1,0 +1,32 @@
+module TestHelpers
+  module Constants
+    protected
+
+    def redefine_constant(mod, constant, new_value)
+      @redefined_constants ||= []
+      @redefined_constants << [mod, constant, mod.const_get(constant)]
+      ignore_constant_redefined_warnings do
+        mod.const_set(constant, new_value)
+      end
+    end
+
+    def reset_constants
+      return unless @redefined_constants
+
+      @redefined_constants.each do |mod, constant, old_value|
+        ignore_constant_redefined_warnings do
+          mod.const_set(constant, old_value)
+        end
+      end
+
+      @redefine_constants = nil
+    end
+
+    def ignore_constant_redefined_warnings
+      warn_level = $VERBOSE
+      $VERBOSE = nil
+      yield
+      $VERBOSE = warn_level
+    end
+  end
+end


### PR DESCRIPTION
Closes #5 

Run `shopify update` to update an installed copy of this tool to the latest code. Existing installs will need to `cd $__shopify_cli_source_dir && git pull origin master`