### PR TITLE
pass Context into Command instances

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module ShopifyCli
+  class Command < CLI::Kit::BaseCommand
+    attr_reader :ctx
+
+    def initialize(ctx = nil)
+      @ctx = ctx || ShopifyCli::Context.new
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -81,9 +81,7 @@ module ShopifyCli
 
   # The rest of this file outlines classes and modules required by the dev application and CLI kit framework.
   # To understand how this works, read https://github.com/Shopify/cli-kit/blob/master/lib/cli/kit.rb
-  autocall(:Config)  { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
-  autocall(:Command) { CLI::Kit::BaseCommand }
-
+  autocall(:Config)   { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
   autocall(:Executor) { CLI::Kit::Executor.new(log_file: LOG_FILE) }
   autocall(:Logger)   { CLI::Kit::Logger.new(debug_log_file: DEBUG_LOG_FILE) }
   autocall(:Resolver) do
@@ -99,6 +97,7 @@ module ShopifyCli
     )
   end
 
+  autoload :Command, 'shopify-cli/command'
   autoload :Context, 'shopify-cli/context'
   autoload :EntryPoint, 'shopify-cli/entry_point'
   autoload :Finalize, 'shopify-cli/finalize'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 module TestHelpers
   autoload :Constants, 'test_helpers/constants'
+  autoload :Context, 'test_helpers/context'
+  autoload :FakeContext, 'test_helpers/fake_context'
 end

--- a/test/test_helpers/context.rb
+++ b/test/test_helpers/context.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module TestHelpers
+  module Context
+    def setup
+      @context = TestHelpers::FakeContext.new
+      @context.root = Dir.mktmpdir
+      super
+    end
+
+    def teardown
+      @context = nil
+      super
+    end
+  end
+end

--- a/test/test_helpers/fake_context.rb
+++ b/test/test_helpers/fake_context.rb
@@ -1,0 +1,6 @@
+module TestHelpers
+  class FakeContext < ShopifyCli::Context
+    def puts(*args)
+    end
+  end
+end


### PR DESCRIPTION
This sets up a new base Command class that automatically adds a Context class instance to itself, allowing us to more easily inject a FakeContext for testing purposes as our commands and tasks get more complicated. The [same pattern is used in dev](https://github.com/Shopify/dev/blob/ccb92d9e1326c858b520c7cd1a124af47f8a7f5e/lib/dev/command.rb#L28-L30).