### PR TITLE
add EnvFileHelper to write .env files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :test do
   gem 'mocha', require: false
   gem 'minitest', '>= 5.0.0', require: false
   gem 'minitest-reporters', require: false
+  gem 'fakefs', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
     ast (2.4.0)
     builder (3.2.3)
     byebug (8.2.2)
+    fakefs (0.20.0)
     jaro_winkler (1.5.2)
     metaclass (0.0.4)
     minitest (5.11.3)
@@ -38,6 +39,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  fakefs
   minitest (>= 5.0.0)
   minitest-reporters
   mocha

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -3,8 +3,20 @@ require 'shopify_cli'
 module ShopifyCli
   module AppTypes
     class Node < ShopifyCli::Task
+      class << self
+        def env_file(key, secret, host)
+          <<~KEYS
+            SHOPIFY_API_KEY=#{key}
+            SHOPIFY_API_SECRET_KEY=#{secret}
+            SHOPIFY_DOMAIN=myshopify.io
+            HOST=#{host}
+          KEYS
+        end
+      end
+
       def call(*args)
         @name = args.shift
+        @ctx = args.shift
         @dir = File.join(Dir.pwd, @name)
         embedded_app
       end
@@ -18,16 +30,21 @@ module ShopifyCli
       def embedded_app
         ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', @name)
         ShopifyCli::Finalize.request_cd(@name)
+        ShopifyCli::Tasks::JsDeps.call(@dir)
+
         api_key = CLI::UI.ask('What is your Shopify API Key')
         api_secret = CLI::UI.ask('What is your Shopify API Secret')
-        write_env_file(api_key, api_secret)
-        ShopifyCli::Tasks::JsDeps.call(@dir)
-        puts CLI::UI.fmt(post_clone)
-      end
 
-      def write_env_file(api_key, api_secret)
-        File.write(File.join(@name, '.env'),
-          "SHOPIFY_API_KEY=#{api_key}\nSHOPIFY_API_SECRET_KEY=#{api_secret}")
+        # temporary metadata construction, will be replaced by data from Partners
+        @ctx.app_metadata = {
+          apiKey: api_key,
+          sharedSecret: api_secret,
+          host: 'host', # to be added with ngrok task
+        }
+
+        @keys = Helpers::EnvFileHelper.new(self, @ctx)
+        @keys.write('.env')
+        puts CLI::UI.fmt(post_clone)
       end
 
       def post_clone

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -15,11 +15,17 @@ module ShopifyCli
 
         return puts "not yet implemented" unless app_type
 
-        AppTypeRegistry.build(app_type, @name)
+        # we need the concept of "project" probably to hold path state
+        @ctx.root = File.join(Dir.pwd, @name)
+
+        AppTypeRegistry.build(app_type, @name, @ctx)
       end
 
       def self.help
-        "Bootstrap an app.\nUsage: {{command:#{ShopifyCli::TOOL_NAME} create <apptype> <appname>}}"
+        <<~HELP
+          Bootstrap an app.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} create <appname>}}
+        HELP
       end
     end
   end

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -3,6 +3,9 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Context
+    attr_writer :app_metadata
+    attr_accessor :root
+
     def initialize
       @env = ($original_env || ENV).clone
     end
@@ -10,6 +13,18 @@ module ShopifyCli
     def getenv(name)
       v = @env[name]
       v == '' ? nil : v
+    end
+
+    def print_task(text)
+      puts CLI::UI.fmt("{{yellow:*}} #{text}")
+    end
+
+    def write(fname, content)
+      File.write(File.join(@root, fname), content)
+    end
+
+    def puts(*args)
+      Kernel.puts(*args)
     end
 
     def method_missing(method, *args)
@@ -26,6 +41,10 @@ module ShopifyCli
       else
         super
       end
+    end
+
+    def app_metadata
+      @app_metadata ||= {}
     end
   end
 end

--- a/lib/shopify-cli/helpers/env_file_helper.rb
+++ b/lib/shopify-cli/helpers/env_file_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ShopifyCli
+  module Helpers
+    class EnvFileHelper
+      def initialize(app_type, ctx)
+        @ctx = ctx
+        key = ctx.app_metadata[:apiKey]
+        secret = ctx.app_metadata[:sharedSecret]
+        host = ctx.app_metadata[:host]
+        @env_content = app_type.class.env_file(key, secret, host)
+      end
+
+      def write(path)
+        @ctx.print_task('writing .env file')
+        @ctx.write(path, @env_content)
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -112,5 +112,6 @@ module ShopifyCli
 
   module Helpers
     autoload :GemHelper, 'shopify-cli/helpers/gem_helper'
+    autoload :EnvFileHelper, 'shopify-cli/helpers/env_file_helper'
   end
 end

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -3,7 +3,10 @@ require 'test_helper'
 module ShopifyCli
   module AppTypes
     class NodeTest < MiniTest::Test
+      include TestHelpers::Context
+
       def setup
+        super
         @app = ShopifyCli::AppTypes::Node.new
       end
 
@@ -16,9 +19,16 @@ module ShopifyCli
           File.join(Dir.pwd, 'test-app')
         )
         CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
-        @app.expects(:write_env_file)
+        @context.expects(:write).with('.env',
+          <<~KEYS
+            SHOPIFY_API_KEY=apikey
+            SHOPIFY_API_SECRET_KEY=apisecret
+            SHOPIFY_DOMAIN=myshopify.io
+            HOST=host
+          KEYS
+        )
         io = capture_io do
-          @app.call('test-app')
+          @app.call('test-app', @context)
         end
         output = io.join
 

--- a/test/commands/create_test.rb
+++ b/test/commands/create_test.rb
@@ -3,8 +3,11 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class CreateTest < MiniTest::Test
+      include TestHelpers::Context
+
       def setup
-        @command = ShopifyCli::Commands::Create.new
+        super
+        @command = ShopifyCli::Commands::Create.new(@context)
       end
 
       def test_prints_help_with_no_name_argument
@@ -26,7 +29,7 @@ module ShopifyCli
 
       def test_implemented_option
         CLI::UI::Prompt.expects(:ask).returns(:node)
-        ShopifyCli::AppTypes::Node.any_instance.stubs(:call).with('test-app')
+        ShopifyCli::AppTypes::Node.any_instance.stubs(:call).with('test-app', @context)
         @command.call(['test-app'], nil)
       end
     end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyCli
+  class ContextTest < MiniTest::Test
+    include TestHelpers::FakeFS
+
+    def test_write_writes_to_file_in_project
+      ctx = Context.new
+      FakeFS do
+        ctx.root = Dir.mktmpdir
+        ctx.write('.env', 'foobar')
+        assert File.exist?(File.join(ctx.root, '.env'))
+      end
+    end
+  end
+end

--- a/test/shopify-cli/helpers/env_file_helper_test.rb
+++ b/test/shopify-cli/helpers/env_file_helper_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module ShopifyCli
+  module Helpers
+    class EnvFileHelperTest < MiniTest::Test
+      include TestHelpers::Context
+
+      class FakeCommand
+        class << self
+          def env_file(key, secret, host)
+            "#{key}, #{secret}, #{host}"
+          end
+        end
+      end
+
+      def test_write_writes_env_content_to_file
+        cmd = FakeCommand.new
+        @context.app_metadata = {
+          apiKey: 'key',
+          sharedSecret: 'secret',
+          host: 'host',
+        }
+        @context.expects(:write).with('.env', 'key, secret, host')
+        @context.expects(:print_task).with('writing .env file')
+        EnvFileHelper.new(cmd, @context).write('.env')
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,5 +16,6 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require_relative 'minitest_ext'
 require_relative 'test_helpers'
+require 'fakefs/safe'
 
 require 'mocha/minitest'

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module TestHelpers
+  autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :Constants, 'test_helpers/constants'
   autoload :Context, 'test_helpers/context'
   autoload :FakeContext, 'test_helpers/fake_context'

--- a/test/test_helpers/context.rb
+++ b/test/test_helpers/context.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module TestHelpers
   module Context
+    include TestHelpers::FakeFS
+
     def setup
       @context = TestHelpers::FakeContext.new
       @context.root = Dir.mktmpdir

--- a/test/test_helpers/fake_fs.rb
+++ b/test/test_helpers/fake_fs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+module TestHelpers
+  module FakeFS
+    def setup
+      ::FakeFS.activate!
+      super
+    end
+
+    def teardown
+      ::FakeFS.deactivate!
+      super
+    end
+  end
+end


### PR DESCRIPTION
Depends on #21 

This adds a Helper class that writes ENV files based on a template defined by each AppType and the app metadata returned from Partners (for now it just prompts for it). It also adds some methods to Context for writing files and printing info, which more behaviour from other Commands will be routed through in order to improve testing.