### PR TITLE
implement prerequisite task API

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -3,10 +3,23 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Command < CLI::Kit::BaseCommand
-    attr_reader :ctx
+    class << self
+      def prerequisite_task(*tasks)
+        tasks.each do |task|
+          prerequisite_tasks[task] = ShopifyCli::Tasks::Registry[task]
+        end
+      end
+
+      def prerequisite_tasks
+        @prerequisite_tasks ||= {}
+      end
+    end
 
     def initialize(ctx = nil)
       @ctx = ctx || ShopifyCli::Context.new
+      self.class.prerequisite_tasks.each do |_, task|
+        task.call(ctx)
+      end
     end
   end
 end

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -2,7 +2,10 @@ require 'shopify_cli'
 
 module ShopifyCli
   module Commands
-    Registry = CLI::Kit::CommandRegistry.new(
+    class CommandRegistry < CLI::Kit::CommandRegistry
+    end
+
+    Registry = CommandRegistry.new(
       default: 'help',
       contextual_resolver: nil
     )

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -3,6 +3,8 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Create < ShopifyCli::Command
+      prerequisite_task :tunnel
+
       def call(args, _name)
         @name = args.shift
         return puts CLI::UI.fmt(self.class.help) unless @name

--- a/lib/shopify-cli/register.rb
+++ b/lib/shopify-cli/register.rb
@@ -6,13 +6,4 @@ module ShopifyCli
     raise InvalidOverrideError, "\n\nCannot override using `register` in `dev`."\
       "Invalid Register: #{invalid_register}\n\n"
   end
-
-  module Tasks
-    TASKS = {}
-    def self.register(const, name, path)
-      ShopifyCli.invalid_register("Task: #{name} => #{path}") if TASKS[name]
-      autoload(const, path)
-      TASKS[name] = const
-    end
-  end
 end

--- a/lib/shopify-cli/tasks.rb
+++ b/lib/shopify-cli/tasks.rb
@@ -1,0 +1,26 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Tasks
+    class TaskRegistry
+      def initialize
+        @tasks = {}
+      end
+
+      def add(const, name)
+        @tasks[name] = const
+      end
+
+      def [](name)
+        @tasks[name]
+      end
+    end
+
+    Registry = TaskRegistry.new
+
+    def self.register(task, name, path)
+      autoload(task, path)
+      Registry.add(const_get(task), name)
+    end
+  end
+end

--- a/lib/shopify-cli/tasks/tunnel.rb
+++ b/lib/shopify-cli/tasks/tunnel.rb
@@ -1,0 +1,11 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Tasks
+    class Tunnel < ShopifyCli::Task
+      def call(ctx, *)
+        ctx.puts('success!')
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -98,16 +98,19 @@ module ShopifyCli
   end
 
   autoload :Command, 'shopify-cli/command'
+  autoload :CommandRegistry, 'shopify-cli/command_registry'
   autoload :Context, 'shopify-cli/context'
   autoload :EntryPoint, 'shopify-cli/entry_point'
   autoload :Finalize, 'shopify-cli/finalize'
   autoload :Task, 'shopify-cli/task'
+  autoload :Tasks, 'shopify-cli/tasks'
   autoload :AppTypes, 'shopify-cli/app_types'
   autoload :AppTypeRegistry, 'shopify-cli/app_type_registry'
 
   module Tasks
     register :Clone, :clone, 'shopify-cli/tasks/clone'
     register :JsDeps, :js_deps, 'shopify-cli/tasks/js_deps'
+    register :Tunnel, :tunnel, 'shopify-cli/tasks/tunnel'
   end
 
   module Helpers

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -3,16 +3,30 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class CommandTest < MiniTest::Test
-      def setup
-        @command = ShopifyCli::Commands::Help.new
-      end
+      include TestHelpers::Context
 
       def test_non_existant
+        command = ShopifyCli::Commands::Help.new
         io = capture_io do
-          @command.call(%w(foobar), nil)
+          command.call(%w(foobar), nil)
         end
 
         assert_match(/Available commands/, io.join)
+      end
+
+      class FakeCommand < ShopifyCli::Command
+        prerequisite_task :tunnel
+
+        def call(_args, _name)
+          @ctx.puts('command!')
+        end
+      end
+
+      def test_prerequisite_task
+        @context.expects(:puts).with('success!')
+        @context.expects(:puts).with('command!')
+        command = FakeCommand.new(@context)
+        command.call([], nil)
       end
     end
   end


### PR DESCRIPTION
This implements the prerequisite task functionality as discussed in the [tech design](https://docs.google.com/document/d/19Qm0ios9ie2dIYMdlduU_XSS_WkKWl4zpFDJP7ViPgU/edit) which will allow us to compose Commands that have tasks that run before itself with minimal configuration, e.g:

```rb
class Command < ShopifyCLI::Command
  prerequisite_task: :install_node_js

  def call
    # do stuff
  end
end
```