### PR TITLE
more elegant solution for prerequisite tasks

### DIFF
--- a/lib/shopify-cli/command.rb
+++ b/lib/shopify-cli/command.rb
@@ -17,9 +17,6 @@ module ShopifyCli
 
     def initialize(ctx = nil)
       @ctx = ctx || ShopifyCli::Context.new
-      self.class.prerequisite_tasks.each do |_, task|
-        task.call(ctx)
-      end
     end
   end
 end

--- a/lib/shopify-cli/command_registry.rb
+++ b/lib/shopify-cli/command_registry.rb
@@ -1,0 +1,22 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  class CommandRegistry < CLI::Kit::CommandRegistry
+    def initialize(default:, contextual_resolver: nil, task_registry: nil, ctx: nil)
+      @ctx = ctx || ShopifyCli::Context.new
+      @task_registry = task_registry || ShopifyCli::Tasks::Registry.new
+      super(default: default, contextual_resolver: contextual_resolver)
+    end
+
+    private
+
+    def resolve_command(name)
+      resolve_prerequisite(name)
+      super
+    end
+
+    def resolve_prerequisite(name)
+      @task_registry[name].call(@ctx)
+    end
+  end
+end

--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -2,12 +2,10 @@ require 'shopify_cli'
 
 module ShopifyCli
   module Commands
-    class CommandRegistry < CLI::Kit::CommandRegistry
-    end
-
-    Registry = CommandRegistry.new(
+    Registry = ShopifyCli::CommandRegistry.new(
       default: 'help',
-      contextual_resolver: nil
+      contextual_resolver: nil,
+      task_registry: ShopifyCli::Tasks::Registry
     )
 
     def self.register(const, cmd, path)
@@ -20,6 +18,7 @@ module ShopifyCli
     register :LoadDev, 'load-dev', 'shopify-cli/commands/load_dev'
     register :LoadSystem, 'load-system', 'shopify-cli/commands/load_system'
     register :Server, 'server', 'shopify-cli/commands/server'
+    register :Tunnel, 'tunnel', 'shopify-cli/commands/tunnel'
     register :Update, 'update', 'shopify-cli/commands/update'
   end
 end

--- a/lib/shopify-cli/commands/tunnel.rb
+++ b/lib/shopify-cli/commands/tunnel.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Tunnel < ShopifyCli::Command
+      # subcommands :start, :stop
+
+      def call(_args, _name)
+        puts CLI::UI.fmt(self.class.help)
+      end
+
+      def self.help
+        <<~HELP
+          Start and manage an http tunnel.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} tunnel start|stop}}
+        HELP
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -30,6 +30,9 @@ require 'cli/kit'
 
 # Defines register commands for init scripts
 require 'shopify-cli/register'
+require 'shopify-cli/tasks'
+require 'shopify-cli/context'
+require 'shopify-cli/command_registry'
 require 'shopify-cli/commands'
 
 # Enable stdout routing. At this point all calls to STDOUT (and STDERR) will go through this class.

--- a/test/commands/command_test.rb
+++ b/test/commands/command_test.rb
@@ -6,27 +6,12 @@ module ShopifyCli
       include TestHelpers::Context
 
       def test_non_existant
-        command = ShopifyCli::Commands::Help.new
+        command = ShopifyCli::Commands::Help.new(@context)
         io = capture_io do
           command.call(%w(foobar), nil)
         end
 
         assert_match(/Available commands/, io.join)
-      end
-
-      class FakeCommand < ShopifyCli::Command
-        prerequisite_task :tunnel
-
-        def call(_args, _name)
-          @ctx.puts('command!')
-        end
-      end
-
-      def test_prerequisite_task
-        @context.expects(:puts).with('success!')
-        @context.expects(:puts).with('command!')
-        command = FakeCommand.new(@context)
-        command.call([], nil)
       end
     end
   end

--- a/test/shopify-cli/command_registry_test.rb
+++ b/test/shopify-cli/command_registry_test.rb
@@ -1,0 +1,29 @@
+module ShopifyCli
+  class CommandRegistryTest < MiniTest::Test
+    include TestHelpers::Context
+    include TestHelpers::FakeTask
+
+    class FakeCommand < ShopifyCli::Command
+      prerequisite_task :fake_task
+      attr_accessor :ctx
+
+      def call(_args, _name)
+        @ctx.puts('command!')
+      end
+    end
+
+    def test_prerequisite_task
+      reg = ShopifyCli::CommandRegistry.new(
+        default: nil,
+        task_registry: @registry,
+        ctx: @context
+      )
+      reg.add(FakeCommand, :fake)
+      @context.expects(:puts).with('success!')
+      @context.expects(:puts).with('command!')
+      klass, _ = reg.lookup_command(:fake)
+      cmd = klass.new(@context)
+      cmd.call([], nil)
+    end
+  end
+end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module TestHelpers
-  autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :Constants, 'test_helpers/constants'
   autoload :Context, 'test_helpers/context'
+  autoload :FakeTask, 'test_helpers/fake_task'
   autoload :FakeContext, 'test_helpers/fake_context'
+  autoload :FakeFS, 'test_helpers/fake_fs'
 end

--- a/test/test_helpers/fake_task.rb
+++ b/test/test_helpers/fake_task.rb
@@ -1,0 +1,20 @@
+module TestHelpers
+  module FakeTask
+    class FakeTask < ShopifyCli::Task
+      def call(ctx)
+        ctx.puts('success!')
+      end
+    end
+
+    def setup
+      @registry = ShopifyCli::Tasks::TaskRegistry.new
+      @registry.add(FakeTask, :fake)
+      super
+    end
+
+    def teardown
+      @registry = nil
+      super
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the `prerequisite_task` logic out of the parent `Command` class to the `Registry`, which is the mechanism that keeps track of all the commands in the system. This way the execution of prerequisites isn't tied to the execution of a single command but during the process of a user issuing a command. It's subtle, but it will make testing way easier.

TL;DR now we can `.call` a command during test without having to worry about prereq tasks running