### PR TITLE
add fake call to populate

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -20,5 +20,6 @@ module ShopifyCli
     register :Serve, 'serve', 'shopify-cli/commands/serve'
     register :Tunnel, 'tunnel', 'shopify-cli/commands/tunnel'
     register :Update, 'update', 'shopify-cli/commands/update'
+    register :Populate, 'populate', 'shopify-cli/commands/populate'
   end
 end

--- a/lib/shopify-cli/commands/populate.rb
+++ b/lib/shopify-cli/commands/populate.rb
@@ -1,0 +1,24 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Commands
+    class Populate < ShopifyCli::Command
+      def call
+        puts CLI::UI.fmt(self.class.mock)
+      end
+
+      def self.mock
+        <<~MOCK
+          Store populated with 50 products, customers and order records.
+        MOCK
+      end
+
+      def self.help
+        <<~HELP
+          Populate dev store with products, customers and order records.
+          Usage: {{command:#{ShopifyCli::TOOL_NAME} populate <storename>}}
+        HELP
+      end
+    end
+  end
+end


### PR DESCRIPTION
This prints out a success message to mock population of test stores and adds information about command when you run `Shopify`. 