### PR TITLE
clean up how Context and AppType interact

### DIFF
--- a/lib/shopify-cli/app_type_registry.rb
+++ b/lib/shopify-cli/app_type_registry.rb
@@ -7,8 +7,8 @@ module ShopifyCli
         app_types[identifier] = klass
       end
 
-      def build(identifier, handle, ctx)
-        app_types[identifier].call(handle, ctx)
+      def build(identifier, name, ctx)
+        app_types[identifier].new(name: name, ctx: ctx).build
       end
 
       def each(&enumerator)

--- a/lib/shopify-cli/app_types.rb
+++ b/lib/shopify-cli/app_types.rb
@@ -3,6 +3,11 @@ require 'shopify_cli'
 module ShopifyCli
   module AppTypes
     class AppType < ShopifyCli::Task
+      include SmartProperties
+
+      property :name
+      property :ctx, accepts: ShopifyCli::Context
+
       class << self
         def description
           raise NotImplementedError
@@ -17,11 +22,13 @@ module ShopifyCli
         end
       end
 
-      def call(*args)
-        @name = args.shift
-        @ctx = args.shift
-        @dir = File.join(Dir.pwd, @name)
-        build
+      def initialize(*)
+        super
+        ctx.root = dir
+      end
+
+      def dir
+        File.join(ctx.root, name)
       end
 
       def build

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -31,12 +31,10 @@ module ShopifyCli
         }
       end
 
-      protected
-
       def build
-        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', @name)
-        ShopifyCli::Finalize.request_cd(@name)
-        ShopifyCli::Tasks::JsDeps.call(@dir)
+        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', name)
+        ShopifyCli::Finalize.request_cd(name)
+        ShopifyCli::Tasks::JsDeps.call(dir)
 
         api_key = CLI::UI.ask('What is your Shopify API Key')
         api_secret = CLI::UI.ask('What is your Shopify API Secret')
@@ -45,10 +43,10 @@ module ShopifyCli
           app_type: self,
           api_key: api_key,
           secret: api_secret,
-          host: @ctx.app_metadata[:host],
+          host: ctx.app_metadata[:host],
           scopes: 'read_products',
         )
-        env_file.write(@ctx, '.env')
+        env_file.write(ctx, '.env')
         puts CLI::UI.fmt(post_clone)
       end
 

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -22,9 +22,9 @@ module ShopifyCli
         unless rails_installed?
           ShopifyCli::Helpers::GemHelper.install!(ctx, 'rails')
         end
-        ctx.system('rails', 'new', @name)
+        ctx.system('rails', 'new', name)
         ctx.system('echo', '"gem \'shopify_app\'"', '>>', 'Gemfile')
-        ctx.system('bundle', 'install', chdir: @dir)
+        ctx.system('bundle', 'install', chdir: dir)
         api_key = CLI::UI.ask('What is your Shopify API Key')
         api_secret = CLI::UI.ask('What is your Shopify API Secret')
         ctx.system(
@@ -32,7 +32,7 @@ module ShopifyCli
           'generate',
           'shopify_app', "--api_key #{api_key}", "--secret #{api_secret}"
         )
-        ShopifyCli::Finalize.request_cd(@name)
+        ShopifyCli::Finalize.request_cd(name)
         puts CLI::UI.fmt(post_clone)
       end
 

--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -17,9 +17,6 @@ module ShopifyCli
 
         return puts "not yet implemented" unless app_type
 
-        # we need the concept of "project" probably to hold path state
-        @ctx.root = File.join(Dir.pwd, @name)
-
         AppTypeRegistry.build(app_type, @name, @ctx)
 
         ShopifyCli::Project.write(@ctx, app_type)

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -3,9 +3,11 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Context
-    attr_accessor :root
+    include SmartProperties
+    property :root, default: lambda { Dir.pwd }, converts: :to_s
 
-    def initialize
+    def initialize(*)
+      super
       @env = ($original_env || ENV).clone
     end
 

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -7,16 +7,12 @@ module ShopifyCli
 
       def setup
         super
-        @app = ShopifyCli::AppTypes::Node.new
+        @app = ShopifyCli::AppTypes::Node.new(name: 'test-app', ctx: @context)
       end
 
       def test_embedded_app_creation
-        ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/webgen-embeddedapp.git',
-          'test-app'
-        )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(
-          File.join(Dir.pwd, 'test-app')
+          File.join(@context.root, 'test-app')
         )
         CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
         @context.app_metadata[:host] = 'host'
@@ -29,7 +25,7 @@ module ShopifyCli
           KEYS
         )
         io = capture_io do
-          @app.call('test-app', @context)
+          @app.build
         end
         output = io.join
 

--- a/test/commands/create_test.rb
+++ b/test/commands/create_test.rb
@@ -30,7 +30,7 @@ module ShopifyCli
       def test_implemented_option
         FileUtils.mkdir_p('test-app')
         CLI::UI::Prompt.expects(:ask).returns(:node)
-        ShopifyCli::AppTypes::Node.any_instance.stubs(:call).with('test-app', @context)
+        ShopifyCli::AppTypes::Node.any_instance.stubs(:build)
         @command.call(['test-app'], nil)
       end
     end

--- a/test/test_helpers/context.rb
+++ b/test/test_helpers/context.rb
@@ -2,8 +2,7 @@
 module TestHelpers
   module Context
     def setup
-      @context = TestHelpers::FakeContext.new
-      @context.root = Dir.mktmpdir
+      @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
       FileUtils.touch(File.join(@context.root, '.shopify-cli.yml'))
       super
       FileUtils.cd(@context.root)


### PR DESCRIPTION
In trying to add some tests for something things in here I've realized how tenuous the relationship between Context and AppType is during the create command. The meat of this is adding `root` as a property on Context so we can ensure it's set. We're also better off having real properties on `AppType` rather than relying on positional arguments.