### PR TITLE
send HOST and PORT to node serve command

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -19,8 +19,12 @@ module ShopifyCli
         'node embedded app'
       end
 
-      def self.serve_command
-        'npm run dev'
+      def self.serve_command(ctx)
+        %W(
+          HOST=#{ctx.app_metadata[:host]}
+          PORT=#{ShopifyCli::Tasks::Tunnel::PORT}
+          npm run dev
+        ).join(' ')
       end
 
       def self.generate

--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -8,7 +8,7 @@ module ShopifyCli
         'rails embedded app'
       end
 
-      def self.serve_command
+      def self.serve_command(_ctx)
         'bin/rails server'
       end
 

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -8,7 +8,7 @@ module ShopifyCli
       def call(*)
         project = ShopifyCli::Project.current
         app_type = ShopifyCli::AppTypeRegistry[project.config["app_type"].to_sym]
-        @ctx.exec(app_type.serve_command)
+        @ctx.exec(app_type.serve_command(@ctx))
       end
 
       def self.help

--- a/lib/shopify-cli/project.rb
+++ b/lib/shopify-cli/project.rb
@@ -3,6 +3,8 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Project
+    include SmartProperties
+
     class << self
       def current
         at(Dir.pwd)
@@ -13,7 +15,7 @@ module ShopifyCli
         unless proj_dir
           raise(ShopifyCli::Abort, "You are not in a shopify project")
         end
-        @at ||= Hash.new { |h, k| h[k] = new(k) }
+        @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
         @at[proj_dir]
       end
 
@@ -48,11 +50,7 @@ module ShopifyCli
       end
     end
 
-    attr_reader :directory
-
-    def initialize(directory)
-      @directory = directory
-    end
+    property :directory
 
     def config
       @config ||= begin

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -34,6 +34,23 @@ module ShopifyCli
           output
         )
       end
+
+      def test_server_command
+        ShopifyCli::Project.expects(:current).returns(
+          TestHelpers::FakeProject.new(
+            directory: @context.root,
+            config: {
+              'app_type' => 'node',
+            }
+          )
+        )
+        @context.app_metadata[:host] = 'https://example.com'
+        cmd = ShopifyCli::Commands::Serve.new(@context)
+        @context.expects(:exec).with(
+          "HOST=https://example.com PORT=8081 npm run dev"
+        )
+        cmd.call([], nil)
+      end
     end
   end
 end

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -5,5 +5,6 @@ module TestHelpers
   autoload :FakeTask, 'test_helpers/fake_task'
   autoload :FakeContext, 'test_helpers/fake_context'
   autoload :FakeFS, 'test_helpers/fake_fs'
+  autoload :FakeProject, 'test_helpers/fake_project'
   autoload :AppType, 'test_helpers/app_type'
 end

--- a/test/test_helpers/app_type.rb
+++ b/test/test_helpers/app_type.rb
@@ -5,7 +5,7 @@ module TestHelpers
     class FakeAppType < ShopifyCli::AppTypes::AppType
       def self.description; end
 
-      def self.serve_command
+      def self.serve_command(_ctx)
         "a command"
       end
 

--- a/test/test_helpers/fake_project.rb
+++ b/test/test_helpers/fake_project.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module TestHelpers
+  class FakeProject < ShopifyCli::Project
+    include SmartProperties
+    property :directory
+    property :config
+  end
+end


### PR DESCRIPTION
Depends on #57 

Sends the HOST and PORT as env vars to the Node AppType's serve commands and adds a test for this.