### PR TITLE
Remove .git directory after Node create

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -47,6 +47,10 @@ module ShopifyCli
           scopes: 'read_products',
         )
         env_file.write(ctx, '.env')
+
+        ctx.rm_r(File.join(ctx.root, '.git'))
+        ctx.rm_r(File.join(ctx.root, '.github'))
+
         puts CLI::UI.fmt(post_clone)
       end
 

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -3,7 +3,11 @@ require 'shopify_cli'
 
 module ShopifyCli
   class Context
+    autoload :FileSystem, 'shopify-cli/context/file_system'
+
     include SmartProperties
+    include FileSystem
+
     property :root, default: lambda { Dir.pwd }, converts: :to_s
 
     def initialize(*)
@@ -18,10 +22,6 @@ module ShopifyCli
 
     def print_task(text)
       puts CLI::UI.fmt("{{yellow:*}} #{text}")
-    end
-
-    def write(fname, content)
-      File.write(File.join(@root, fname), content)
     end
 
     def puts(*args)

--- a/lib/shopify-cli/context/file_system.rb
+++ b/lib/shopify-cli/context/file_system.rb
@@ -1,0 +1,15 @@
+require 'fileutils'
+
+module ShopifyCli
+  class Context
+    module FileSystem
+      def write(fname, content)
+        File.write(File.join(root, fname), content)
+      end
+
+      def rm_r(*args)
+        FileUtils.rm_r(*args)
+      end
+    end
+  end
+end

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -24,6 +24,8 @@ module ShopifyCli
             SCOPES=read_products
           KEYS
         )
+        @context.expects(:rm_r).with(File.join(@context.root, '.git'))
+        @context.expects(:rm_r).with(File.join(@context.root, '.github'))
         io = capture_io do
           @app.build
         end


### PR DESCRIPTION
Depends on #57 

Removes the `.git/` directory after creating a node app, this way no one accidentally pushes anything to our repo. Also moves file system-related things in Context to a sub module where there will probably be more things in the future.