### PR TITLE
update directory for JsDeps.call

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -38,7 +38,7 @@ module ShopifyCli
       def build
         ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', name)
         ShopifyCli::Finalize.request_cd(name)
-        ShopifyCli::Tasks::JsDeps.call(dir)
+        ShopifyCli::Tasks::JsDeps.call(ctx.root)
 
         api_key = CLI::UI.ask('What is your Shopify API Key')
         api_secret = CLI::UI.ask('What is your Shopify API Secret')


### PR DESCRIPTION
when doing `shopify create` on master i’m consistently running into a malformed path situation. this fixes it for me, but @katiedavis can’t reproduce, so i’m kinda uncertain about this.

edit: not captured in the screenshot, but i was in `~/src/github.com/Shopify/` when i ran the command

![Screen Shot 2019-05-30 at 3 29 52 PM](https://user-images.githubusercontent.com/786799/58659124-28378580-82f0-11e9-9747-15ce2bb8ccef.png)
