### PR TITLE
fix dir/ctx.root confusion

### DIFF
--- a/lib/shopify-cli/app_types.rb
+++ b/lib/shopify-cli/app_types.rb
@@ -24,11 +24,7 @@ module ShopifyCli
 
       def initialize(*)
         super
-        ctx.root = dir
-      end
-
-      def dir
-        File.join(ctx.root, name)
+        ctx.root = File.join(ctx.root, name)
       end
 
       def build

--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -38,7 +38,7 @@ module ShopifyCli
       def build
         ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', name)
         ShopifyCli::Finalize.request_cd(name)
-        ShopifyCli::Tasks::JsDeps.call(dir)
+        ShopifyCli::Tasks::JsDeps.call(ctx.root)
 
         api_key = CLI::UI.ask('What is your Shopify API Key')
         api_secret = CLI::UI.ask('What is your Shopify API Secret')

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -11,9 +11,7 @@ module ShopifyCli
       end
 
       def test_embedded_app_creation
-        ShopifyCli::Tasks::JsDeps.stubs(:call).with(
-          File.join(@context.root, 'test-app')
-        )
+        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
         CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
         @context.app_metadata[:host] = 'host'
         @context.expects(:write).with('.env',


### PR DESCRIPTION
`ctx.root` and `dir` are the same thing from the perspective of an AppType, so let's just use the one.