### PR TITLE
don't error on missing git dir

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -52,8 +52,12 @@ module ShopifyCli
         )
         env_file.write(ctx, '.env')
 
-        ctx.rm_r(File.join(ctx.root, '.git'))
-        ctx.rm_r(File.join(ctx.root, '.github'))
+        begin
+          ctx.rm_r(File.join(ctx.root, '.git'))
+          ctx.rm_r(File.join(ctx.root, '.github'))
+        rescue Errno::ENOENT => e
+          ctx.debug(e)
+        end
 
         puts CLI::UI.fmt(post_clone)
       end

--- a/lib/shopify-cli/context.rb
+++ b/lib/shopify-cli/context.rb
@@ -30,10 +30,8 @@ module ShopifyCli
       Kernel.puts(CLI::UI.fmt(*args))
     end
 
-    def debug(msg)
-      if @env['DEBUG']
-        puts("{{yellow:DEBUG}} #{msg}")
-      end
+    def debug(string)
+      puts("{{red:DEBUG}} #{string}") if getenv('DEBUG')
     end
 
     def app_metadata

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -10,7 +10,11 @@ module ShopifyCli
         @app = ShopifyCli::AppTypes::Node.new(name: 'test-app', ctx: @context)
       end
 
-      def test_embedded_app_creation
+      def test_build_creates_app
+        ShopifyCli::Tasks::Clone.stubs(:call).with(
+          'git@github.com:shopify/webgen-embeddedapp.git',
+          'test-app',
+        )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
         CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
         @context.app_metadata[:host] = 'host'
@@ -33,6 +37,18 @@ module ShopifyCli
           CLI::UI.fmt('Run {{command:shopify serve}} to start the app server'),
           output
         )
+      end
+
+      def test_build_does_not_error_on_missing_git_dir
+        ShopifyCli::Tasks::Clone.stubs(:call).with(
+          'git@github.com:shopify/webgen-embeddedapp.git',
+          'test-app',
+        )
+        ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
+        CLI::UI.expects(:ask).twice.returns('apikey', 'apisecret')
+        @context.app_metadata[:host] = 'host'
+        @context.expects(:write)
+        @app.build
       end
 
       def test_server_command

--- a/test/shopify-cli/helpers/gem_test.rb
+++ b/test/shopify-cli/helpers/gem_test.rb
@@ -19,13 +19,13 @@ module ShopifyCli
       end
 
       def test_install_installs_with_gem_home_populated
-        @context.expects(:getenv).with('GEM_HOME').returns('~/.gem/ruby/2.5.5')
+        @context.setenv('GEM_HOME', '~/.gem/ruby/2.5.5')
         @context.expects(:system).with('gem install mygem')
         Gem.install(@context, 'mygem')
       end
 
       def test_install_does_not_install_if_installed
-        @context.expects(:getenv).with('GEM_HOME').returns("~/.gem/ruby/#{RUBY_VERSION}")
+        @context.setenv('GEM_HOME', "~/.gem/ruby/#{RUBY_VERSION}")
         Dir.expects(:glob).with("~/.gem/ruby/#{RUBY_VERSION}/gems/mygem-*").returns([
           "~/.gem/ruby/#{RUBY_VERSION}/gems/mygem-1.0.0",
         ]).at_least_once


### PR DESCRIPTION
Currently if for some reason if the `.git` `.github` do not exist post create (not sure why) the Node create task errors out. Let's just ignore this error for now.