### PR TITLE
Extended help command

### DIFF
--- a/lib/shopify-cli/commands.rb
+++ b/lib/shopify-cli/commands.rb
@@ -7,8 +7,8 @@ module ShopifyCli
       contextual_resolver: nil,
     )
 
-    def self.register(const, cmd, path)
-      autoload(const, path)
+    def self.register(const, cmd, path = nil)
+      autoload(const, path) if path
       Registry.add(->() { const_get(const) }, cmd)
     end
 

--- a/lib/shopify-cli/commands/generate.rb
+++ b/lib/shopify-cli/commands/generate.rb
@@ -24,6 +24,26 @@ module ShopifyCli
           Usage: {{command:#{ShopifyCli::TOOL_NAME} generate <page> or billing}}
         HELP
       end
+
+      def self.extended_help
+        <<~HELP
+          Subcommands:
+
+          * page: Generates code for a page or section of pages in your app. Usage:
+
+              {{command:#{ShopifyCli::TOOL_NAME} generate page [name]}}
+
+          * billing: Generates code for calling the Shopify Billing API and
+            accepting usage charges for your app. Usage:
+
+              {{command:#{ShopifyCli::TOOL_NAME} generate billing}}
+
+          * webhook: Generates code for registering and responding to a webhook
+            from Shopify. Usage:
+
+              {{command:#{ShopifyCli::TOOL_NAME} generate webhook [type]}}
+        HELP
+      end
     end
   end
 end

--- a/lib/shopify-cli/commands/help.rb
+++ b/lib/shopify-cli/commands/help.rb
@@ -3,8 +3,24 @@ require 'shopify_cli'
 module ShopifyCli
   module Commands
     class Help < ShopifyCli::Command
-      def call(*)
-        puts CLI::UI.fmt("{{bold:Available commands}}")
+      def call(args, _name)
+        command = args.shift
+        if command
+          if Registry.exist?(command)
+            cmd, _name = Registry.lookup_command(command)
+            @ctx.puts(CLI::UI.fmt(cmd.help))
+            if cmd.respond_to?(:extended_help)
+              @ctx.puts('')
+              @ctx.puts(CLI::UI.fmt(cmd.extended_help))
+            end
+            return
+          else
+            @ctx.puts("Command #{command} not found.")
+          end
+        end
+
+        @ctx.puts('{{bold:Available commands}}')
+        @ctx.puts('Use {{command:shopify help [command]}} to display detailed information about a specific command.')
         puts ""
 
         ShopifyCli::Commands::Registry.resolved_commands.each do |name, klass|

--- a/test/commands/help_test.rb
+++ b/test/commands/help_test.rb
@@ -2,9 +2,22 @@ require 'test_helper'
 
 module ShopifyCli
   module Commands
+    class FakeCommand < ShopifyCli::Command
+      class << self
+        def help
+          "basic help"
+        end
+
+        def extended_help
+          "extended help"
+        end
+      end
+    end
+
     class HelpTest < MiniTest::Test
       def setup
         @command = ShopifyCli::Commands::Help.new
+        ShopifyCli::Commands.register(:FakeCommand, 'fake')
       end
 
       def test_default_behavior_lists_tasks
@@ -15,6 +28,14 @@ module ShopifyCli
 
         assert_match('Available commands', output)
         assert_match(/Usage: .*shopify/, output)
+      end
+
+      def test_extended_help_for_individual_command
+        io = capture_io do
+          @command.call(%w(fake), nil)
+        end
+        output = io.join
+        assert_match(/basic help.*extended help/, output)
       end
     end
   end

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -2,7 +2,9 @@ module Minitest
   class Test
     def capture_io(&block)
       cap = CLI::UI::StdoutRouter::Capture.new(with_frame_inset: true, &block)
+      @context.output_captured = true if @context
       cap.run
+      @context.output_captured = false if @context
       [cap.stdout, cap.stderr]
     end
 

--- a/test/test_helpers/fake_context.rb
+++ b/test/test_helpers/fake_context.rb
@@ -1,6 +1,9 @@
 module TestHelpers
   class FakeContext < ShopifyCli::Context
+    attr_accessor :output_captured
+
     def puts(*args)
+      super(*args) if output_captured
     end
   end
 end


### PR DESCRIPTION
This allows an `extended_help` classmethod to be added to command classes for longer help output to be displayed when issuing help with that command, e.g. `shopify help generate` vs `shopify help`, which will just display a summary of all commands. Here's what it looks like:

![image](https://user-images.githubusercontent.com/73874/58816944-903fe180-85f8-11e9-84e8-38522e1a3ff1.png)
