### PR TITLE
remove use of Kernel.exec

### DIFF
--- a/lib/shopify-cli/commands/generate/billing.rb
+++ b/lib/shopify-cli/commands/generate/billing.rb
@@ -12,7 +12,7 @@ module ShopifyCli
             handler.option('recurring billing') { :billing_recurring }
             handler.option('one time billing') { :billing_one_time }
           end
-          ctx.exec(app_type.generate[type])
+          ctx.system(app_type.generate[type])
         end
 
         def self.help

--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -9,7 +9,7 @@ module ShopifyCli
           name = args.first
           project = ShopifyCli::Project.current
           app_type = ShopifyCli::AppTypeRegistry[project.config["app_type"].to_sym]
-          ctx.exec("#{app_type.generate[:page]} #{name}")
+          ctx.system("#{app_type.generate[:page]} #{name}")
         end
 
         def self.help

--- a/lib/shopify-cli/commands/serve.rb
+++ b/lib/shopify-cli/commands/serve.rb
@@ -8,7 +8,7 @@ module ShopifyCli
       def call(*)
         project = ShopifyCli::Project.current
         app_type = ShopifyCli::AppTypeRegistry[project.config["app_type"].to_sym]
-        @ctx.exec(app_type.serve_command(@ctx))
+        @ctx.system(app_type.serve_command(@ctx))
       end
 
       def self.help

--- a/lib/shopify-cli/context/system.rb
+++ b/lib/shopify-cli/context/system.rb
@@ -7,10 +7,6 @@ module ShopifyCli
         Kernel.spawn(*args, env: @env, **kwargs)
       end
 
-      def exec(*args, **kwargs)
-        Kernel.exec(*args, env: @env, **kwargs)
-      end
-
       def system(*args, **kwargs)
         CLI::Kit::System.system(*args, env: @env, **kwargs)
       end

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -62,7 +62,7 @@ module ShopifyCli
         )
         @context.app_metadata[:host] = 'https://example.com'
         cmd = ShopifyCli::Commands::Serve.new(@context)
-        @context.expects(:exec).with(
+        @context.expects(:system).with(
           "HOST=https://example.com PORT=8081 npm run dev"
         )
         cmd.call([], nil)

--- a/test/app_types/rails_test.rb
+++ b/test/app_types/rails_test.rb
@@ -50,7 +50,7 @@ module ShopifyCli
         )
         @context.app_metadata[:host] = 'https://example.com'
         cmd = ShopifyCli::Commands::Serve.new(@context)
-        @context.expects(:exec).with(
+        @context.expects(:system).with(
           "PORT=8081 bin/rails server"
         )
         cmd.call([], nil)

--- a/test/commands/generate/billing_test.rb
+++ b/test/commands/generate/billing_test.rb
@@ -14,14 +14,14 @@ module ShopifyCli
         def test_recurring_billing
           ShopifyCli::Project.write(@context, :node)
           CLI::UI::Prompt.expects(:ask).returns(:billing_recurring)
-          @context.expects(:exec).with('npm run-script generate-recurring-billing')
+          @context.expects(:system).with('npm run-script generate-recurring-billing')
           @command.call(['billing'], nil)
         end
 
         def test_one_time_billing
           ShopifyCli::Project.write(@context, :node)
           CLI::UI::Prompt.expects(:ask).returns(:billing_one_time)
-          @context.expects(:exec).with('npm run-script generate-one-time-billing')
+          @context.expects(:system).with('npm run-script generate-one-time-billing')
           @command.call(['billing'], nil)
         end
       end

--- a/test/commands/generate/page_test.rb
+++ b/test/commands/generate/page_test.rb
@@ -13,7 +13,7 @@ module ShopifyCli
 
         def test_run
           ShopifyCli::Project.write(@context, :node)
-          @context.expects(:exec).with('npm run-script generate-page name')
+          @context.expects(:system).with('npm run-script generate-page name')
           @command.call(['page', 'name'], nil)
         end
       end

--- a/test/commands/serve_test.rb
+++ b/test/commands/serve_test.rb
@@ -11,7 +11,7 @@ module ShopifyCli
       end
 
       def test_run
-        @context.expects(:exec).with('a command')
+        @context.expects(:system).with('a command')
         @command.call([], nil)
       end
     end


### PR DESCRIPTION
We were using exec because its simple but after some more thought we should stick to the system commands since they give us better control over input, output and environment variables.

![ruby subprocess](https://user-images.githubusercontent.com/73874/58902108-770a6400-86d0-11e9-9ad4-98bc018b2ed1.png)
