### PR TITLE
fix clone command for new repo name

### DIFF
--- a/lib/shopify-cli/app_types/node.rb
+++ b/lib/shopify-cli/app_types/node.rb
@@ -37,7 +37,7 @@ module ShopifyCli
       end
 
       def build
-        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/webgen-embeddedapp.git', name)
+        ShopifyCli::Tasks::Clone.call('git@github.com:shopify/shopify-app-node.git', name)
         ShopifyCli::Finalize.request_cd(name)
         ShopifyCli::Tasks::JsDeps.call(ctx.root)
 

--- a/test/app_types/node_test.rb
+++ b/test/app_types/node_test.rb
@@ -12,7 +12,7 @@ module ShopifyCli
 
       def test_build_creates_app
         ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/webgen-embeddedapp.git',
+          'git@github.com:shopify/shopify-app-node.git',
           'test-app',
         )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)
@@ -41,7 +41,7 @@ module ShopifyCli
 
       def test_build_does_not_error_on_missing_git_dir
         ShopifyCli::Tasks::Clone.stubs(:call).with(
-          'git@github.com:shopify/webgen-embeddedapp.git',
+          'git@github.com:shopify/shopify-app-node.git',
           'test-app',
         )
         ShopifyCli::Tasks::JsDeps.stubs(:call).with(@context.root)


### PR DESCRIPTION
Updates the call to clone our node app to it's new name `shopify-app-node`