### PR TITLE
update subcommands without options to return after showing help

### DIFF
--- a/lib/shopify-cli/commands/create/project.rb
+++ b/lib/shopify-cli/commands/create/project.rb
@@ -5,9 +5,12 @@ module ShopifyCli
     class Create
       class Project < ShopifyCli::Command
         def call(ctx, args)
-          ctx.puts(self.class.help) if args.empty?
-          ShopifyCli::Tasks::Tunnel.call(ctx)
+          if args.empty?
+            ctx.puts(self.class.help)
+            return
+          end
           name = args.first
+          ShopifyCli::Tasks::Tunnel.call(ctx)
           api_key = CLI::UI.ask('What is your Shopify API Key')
           api_secret = CLI::UI.ask('What is your Shopify API Secret')
           ctx.app_metadata = {

--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -5,7 +5,10 @@ module ShopifyCli
     class Generate
       class Page < ShopifyCli::Task
         def call(ctx, args)
-          ctx.puts(self.class.help) if args.empty?
+          if args.empty?
+            ctx.puts(self.class.help)
+            return
+          end
           name = args.first
           project = ShopifyCli::Project.current
           app_type = ShopifyCli::AppTypeRegistry[project.config["app_type"].to_sym]

--- a/lib/shopify-cli/commands/generate/webhook.rb
+++ b/lib/shopify-cli/commands/generate/webhook.rb
@@ -7,7 +7,6 @@ module ShopifyCli
         include ShopifyCli::Helpers::SchemaParser
 
         def call(ctx, args)
-          # TODO: Add check for file after authenticate shopify is complete
           selected_type = args.first
           schema = ShopifyCli::Tasks::GetSchema.call(ctx)
           enum = get_types_by_name(schema, 'WebhookSubscriptionTopic')


### PR DESCRIPTION
It turns out we weren't returning after showing the text for commands that didn't have an options list if you didn't provide an argument.

If there's a more Ruby way of doing the conditionals let me know. 