### PR TITLE
add auto update mechanism

### DIFF
--- a/lib/shopify-cli/commands/update.rb
+++ b/lib/shopify-cli/commands/update.rb
@@ -8,47 +8,7 @@ module ShopifyCli
       end
 
       def call(_args, _name)
-        if File.exist?(File.expand_path('.git/HEAD.lock', ShopifyCli::ROOT))
-          err("failed!")
-          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
-          err("Try running {{green:dev update}}.")
-          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/HEAD.lock}} to continue.")
-          raise(ShopifyCli::AbortSilent)
-        end
-
-        if File.exist?(File.expand_path(".git/refs/heads/master.lock", ShopifyCli::ROOT))
-          err("failed!")
-          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
-          err("Try running {{green:dev update}}.")
-          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/refs/heads/master.lock}} to continue.")
-          raise(ShopifyCli::AbortSilent)
-        end
-
-        _, stat = CLI::Kit::System.capture2e('git', '-C', ShopifyCli::ROOT, 'fetch', 'origin', 'master')
-        unless stat.success?
-          raise(ShopifyCli::Abort, 'failed!')
-        end
-
-        commands = [
-          ['reset', '.'],
-          ['checkout', '.'],
-          ['checkout', '-f', '-B', 'master'],
-          ['reset', '--hard', 'FETCH_HEAD'],
-        ]
-        spin_group = CLI::UI::SpinGroup.new
-        spin_group.add('Updating shopify-cli') do |spinner|
-          commands.each do |args|
-            _, stat = CLI::Kit::System.capture2e('git', '-C', ShopifyCli::ROOT, *args)
-            raise(ShopifyCli::Abort, "command failed: #{args.join(' ')}") unless stat.success?
-          end
-          spinner.update_title('Updated shopify-cli')
-        end
-        spin_group.wait
-      end
-
-      def err(msg, newline: true)
-        method = newline ? :puts : :print
-        STDERR.send(method, CLI::UI.fmt("{{bold:{{red:#{msg}}}}}"))
+        ShopifyCli::Update.check_now(restart_command_after_update: false, ctx: @ctx)
       end
     end
   end

--- a/lib/shopify-cli/context/system.rb
+++ b/lib/shopify-cli/context/system.rb
@@ -14,6 +14,10 @@ module ShopifyCli
       def capture2(*args, **kwargs)
         CLI::Kit::System.capture2(*args, env: @env, **kwargs)
       end
+
+      def capture2e(*args, **kwargs)
+        CLI::Kit::System.capture2e(*args, env: @env, **kwargs)
+      end
     end
   end
 end

--- a/lib/shopify-cli/entry_point.rb
+++ b/lib/shopify-cli/entry_point.rb
@@ -3,14 +3,27 @@ require 'shopify_cli'
 module ShopifyCli
   module EntryPoint
     class << self
+      SKIP_UPDATE = %w(update help for-completion load-dev load-system open)
+
       def call(args)
         ctx = ShopifyCli::Context.new
         task_registry = ShopifyCli::Tasks::Registry
+
+        before_resolve(args)
+
         command, command_name, args = ShopifyCli::Resolver.call(args)
         executor = ShopifyCli::Executor.new(ctx, task_registry, log_file: ShopifyCli::LOG_FILE)
         executor.call(command, command_name, args)
       ensure
         ShopifyCli::Finalize.deliver!
+      end
+
+      def before_resolve(args)
+        ShopifyCli::Update.record_last_update_time
+
+        unless SKIP_UPDATE.include?(args.first)
+          ShopifyCli::Update.auto_update
+        end
       end
     end
   end

--- a/lib/shopify-cli/update.rb
+++ b/lib/shopify-cli/update.rb
@@ -1,0 +1,109 @@
+require 'shopify_cli'
+
+module ShopifyCli
+  module Update
+    FETCH_HEAD = File.expand_path('.git/FETCH_HEAD', ShopifyCli::ROOT)
+
+    class << self
+      def auto_update
+        return if ShopifyCli::Util.testing?
+        prompt_for_updates
+        return unless ShopifyCli::Config.get_bool('autoupdate', 'enabled')
+
+        # don't update more than once per hour.
+        file = begin
+                 File.mtime(FETCH_HEAD)
+               rescue Errno::ENOENT
+                 Time.at(0)
+               end
+        age = Time.now - file
+        return unless age > 3600
+
+        check_now(restart_command_after_update: true)
+      end
+
+      def check_now(restart_command_after_update: raise, ctx: ShopifyCli::Context.new)
+        if ShopifyCli::Util.development?
+          if restart_command_after_update
+            return # just skip
+          else
+            err("Development version of {{green:shopify}} in use. Run {{green:shopify load-system}} first.")
+            raise(ShopifyCli::AbortSilent)
+          end
+        end
+
+        if File.exist?(File.expand_path('.git/HEAD.lock', ShopifyCli::ROOT))
+          err("failed!")
+          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
+          err("Try running {{green:shopify update}}.")
+          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/HEAD.lock}} to continue.")
+          raise(ShopifyCli::AbortSilent)
+        end
+
+        if File.exist?(File.expand_path(".git/refs/heads/master.lock", ShopifyCli::ROOT))
+          err("failed!")
+          err("It looks like another git operation is in progress on {{blue:#{ShopifyCli::ROOT}}}.")
+          err("Try running {{green:shopify update}}.")
+          err("If that fails, you must run {{green: rm #{ShopifyCli::ROOT}/.git/refs/heads/master.lock}} to continue.")
+          raise(ShopifyCli::AbortSilent)
+        end
+
+        _, stat = ctx.capture2e('git', '-C', ShopifyCli::ROOT, 'fetch', 'origin', 'master')
+        unless stat.success?
+          raise(ShopifyCli::Abort, 'failed!')
+        end
+
+        commands = [
+          ['reset', '.'],
+          ['checkout', '.'],
+          ['checkout', '-f', '-B', 'master'],
+          ['reset', '--hard', 'FETCH_HEAD'],
+        ]
+        Kernel.print('Updating shopify-cli...')
+        commands.each do |args|
+          _, stat = ctx.capture2e('git', '-C', ShopifyCli::ROOT, *args)
+          raise(ShopifyCli::Abort, "command failed: #{args.join(' ')}") unless stat.success?
+        end
+
+        ctx.puts("done!")
+
+        if restart_command_after_update
+          ENV.replace($original_env)
+          opts = begin
+                   { 9 => IO.new(9) }
+                 rescue Errno::EBADF
+                   {}
+                 end
+
+          exec($PROGRAM_NAME, *ARGV, opts)
+        end
+      end
+
+      def prompt_for_updates
+        return if ShopifyCli::Config.get_section('autoupdate').key?('enabled')
+        opt = CLI::UI::Prompt.confirm('Would you like to enable auto updates for Shopify App CLI?')
+        ShopifyCli::Config.set('autoupdate', 'enabled', opt)
+        auto_update
+      end
+
+      def record_last_update_time
+        @last_update_time = last_update_time
+      end
+
+      def updated_since_last_recorded?
+        @last_update_time != last_update_time
+      end
+
+      def last_update_time
+        File.mtime(FETCH_HEAD)
+      rescue Errno::ENOENT
+        Time.now
+      end
+
+      def err(msg, newline: true)
+        method = newline ? :puts : :print
+        STDERR.send(method, CLI::UI.fmt("{{bold:{{red:#{msg}}}}}"))
+      end
+    end
+  end
+end

--- a/lib/shopify-cli/util.rb
+++ b/lib/shopify-cli/util.rb
@@ -1,0 +1,22 @@
+module ShopifyCli
+  module Util
+    class << self
+      def system?
+        ShopifyCli::INSTALL_DIR == ShopifyCli::ROOT
+      end
+
+      # Standard way of checking if we're using the development version of shopify (i.e., load-dev)
+      def development?
+        !system? && !testing?
+      end
+
+      def testing?
+        ci? || ENV['TEST']
+      end
+
+      def ci?
+        ENV['CI']
+      end
+    end
+  end
+end

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -109,4 +109,6 @@ module ShopifyCli
   autoload :Project, 'shopify-cli/project'
   autoload :Task, 'shopify-cli/task'
   autoload :Tasks, 'shopify-cli/tasks'
+  autoload :Update, 'shopify-cli/update'
+  autoload :Util, 'shopify-cli/util'
 end

--- a/test/shopify-cli/commands/update_test.rb
+++ b/test/shopify-cli/commands/update_test.rb
@@ -3,51 +3,15 @@ require 'test_helper'
 module ShopifyCli
   module Commands
     class UpdateTest < MiniTest::Test
-      include TestHelpers::Constants
+      include TestHelpers::Context
 
-      def setup
-        super
-        @dir = Dir.mktmpdir
-        @command = ShopifyCli::Commands::Update.new
-        redefine_constant(ShopifyCli, :ROOT, @dir)
-        FileUtils.mkdir("#{ShopifyCli::ROOT}/.git")
-      end
-
-      def test_raises_if_git_process_running
-        File.write("#{ShopifyCli::ROOT}/.git/HEAD.lock", 'test')
-        io = capture_io do
-          assert_raises ShopifyCli::AbortSilent do
-            @command.call([], nil)
-          end
-        end
-        assert_match("It looks like another git operation is in progress", io.join)
-      end
-
-      def test_raises_if_git_branch_process_running
-        FileUtils.mkdir_p("#{ShopifyCli::ROOT}/.git/refs/heads")
-        File.write("#{ShopifyCli::ROOT}/.git/refs/heads/master.lock", 'test')
-        io = capture_io do
-          assert_raises ShopifyCli::AbortSilent do
-            @command.call([], nil)
-          end
-        end
-        assert_match("It looks like another git operation is in progress", io.join)
-      end
-
-      class Stat
-        def success?
-          true
-        end
-      end
-
-      def test_pulls_from_git
-        CLI::Kit::System.expects(:capture2e)
-          .returns([nil, Stat.new])
-          .times(5)
-
-        capture_io do
-          @command.call([], nil)
-        end
+      def test_calls_update
+        ShopifyCli::Update.expects(:check_now).with(
+          restart_command_after_update: false,
+          ctx: @context,
+        )
+        cmd = ShopifyCli::Commands::Update.new(@context)
+        cmd.call([], nil)
       end
     end
   end

--- a/test/shopify-cli/update_test.rb
+++ b/test/shopify-cli/update_test.rb
@@ -1,0 +1,186 @@
+require 'test_helper'
+require 'shellwords'
+
+module ShopifyCli
+  class UpdateTest < MiniTest::Test
+    include TestHelpers::Constants
+    include TestHelpers::Context
+
+    class Stat
+      def initialize(success: true)
+        @success = success
+      end
+
+      def success?
+        @success
+      end
+    end
+
+    def setup
+      super
+
+      $original_env = ENV.clone
+
+      redefine_constant(ShopifyCli, :ROOT, @context.root)
+      FileUtils.mkdir("#{ShopifyCli::ROOT}/.git")
+      redefine_constant(ShopifyCli::Update, :FETCH_HEAD, File.expand_path('.git/FETCH_HEAD', @context.root))
+      ShopifyCli::Config.set('autoupdate', 'enabled', true)
+    end
+
+    def teardown
+      super
+      ShopifyCli::Update.instance_variable_set(:@last_update_time, nil)
+    end
+
+    def test_check_now_aborts_when_head_lock_exists
+      ShopifyCli::Util.expects(:development?).returns(false)
+      FileUtils.touch(File.expand_path('.git/HEAD.lock', ShopifyCli::ROOT))
+      ShopifyCli::Update.expects(:exec).never
+
+      io = capture_io do
+        assert_raises ShopifyCli::AbortSilent do
+          ShopifyCli::Update.check_now(restart_command_after_update: true, ctx: @context)
+        end
+      end
+      assert_match("It looks like another git operation is in progress", io.join)
+    end
+
+    def test_check_now_aborts_when_branch_head_lock_exists
+      ShopifyCli::Util.expects(:development?).returns(false)
+      lockfile = File.expand_path(".git/refs/heads/master.lock", ShopifyCli::ROOT)
+      FileUtils.mkdir_p(File.dirname(lockfile))
+      FileUtils.touch(lockfile)
+
+      ShopifyCli::Update.expects(:exec).never
+
+      io = capture_io do
+        assert_raises ShopifyCli::AbortSilent do
+          ShopifyCli::Update.check_now(restart_command_after_update: true, ctx: @context)
+        end
+      end
+      assert_match("It looks like another git operation is in progress", io.join)
+    end
+
+    def test_updated_since_last_recorded_without_recording
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now)
+
+      assert(ShopifyCli::Update.updated_since_last_recorded?, message: "should have been updated")
+    end
+
+    def test_updated_since_last_recorded_with_same_mtime
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now)
+      ShopifyCli::Update.record_last_update_time
+
+      refute(ShopifyCli::Update.updated_since_last_recorded?, message: "should not have been updated")
+    end
+
+    def test_updated_since_last_recorded_with_different_mtime
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now - 10000)
+      ShopifyCli::Update.record_last_update_time
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now)
+
+      assert(ShopifyCli::Update.updated_since_last_recorded?, message: "should have been updated")
+    end
+
+    def test_auto_update_doesnt_check_if_fetch_head_not_stale
+      ShopifyCli::Util.expects(:testing?).returns(false)
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now - 10)
+      ShopifyCli::Update.expects(:check_now).never
+
+      ShopifyCli::Update.auto_update
+    end
+
+    def test_auto_update_checks_if_fetch_head_stale
+      ShopifyCli::Util.expects(:testing?).returns(false)
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now - 3601)
+      ShopifyCli::Update.expects(:check_now).once
+
+      ShopifyCli::Update.auto_update
+    end
+
+    def test_auto_update_does_not_check_if_config_disabled
+      ShopifyCli::Util.expects(:testing?).returns(false)
+      ShopifyCli::Config.expects(:get_bool).with('autoupdate', 'enabled').returns(false)
+      FileUtils.touch(ShopifyCli::Update::FETCH_HEAD, mtime: Time.now - 3601)
+      ShopifyCli::Update.expects(:check_now).never
+
+      ShopifyCli::Update.auto_update
+    end
+
+    def test_prompt_for_updates_sets_config
+      ShopifyCli::Config.expects(:get_section).with('autoupdate').returns({})
+      CLI::UI::Prompt.expects(:confirm).returns(true)
+      ShopifyCli::Update.expects(:auto_update)
+
+      ShopifyCli::Update.prompt_for_updates
+    end
+
+    def test_check_now_completes_but_does_not_restart
+      fake_context_for_success
+      ShopifyCli::Update.expects(:exec).never
+
+      capture_io do
+        ShopifyCli::Update.check_now(restart_command_after_update: false, ctx: @context)
+      end
+    end
+
+    def test_check_now_completes_and_restarts
+      fake_context_for_success
+      ShopifyCli::Update.expects(:exec).with($PROGRAM_NAME, *ARGV, is_a(Hash))
+
+      capture_io do
+        ShopifyCli::Update.check_now(restart_command_after_update: true, ctx: @context)
+      end
+    end
+
+    def test_check_now_aborts_when_master_fetch_fails
+      fake_context_for_failed_fetch
+      ShopifyCli::Update.expects(:exec).never
+
+      assert_raises ShopifyCli::Abort do
+        ShopifyCli::Update.check_now(restart_command_after_update: true, ctx: @context)
+      end
+    end
+
+    def test_check_now_aborts_when_reset_fails
+      fake_context_for_failed_reset
+      ShopifyCli::Update.expects(:exec).never
+
+      capture_io do
+        assert_raises ShopifyCli::Abort do
+          ShopifyCli::Update.check_now(restart_command_after_update: true, ctx: @context)
+        end
+      end
+    end
+
+    private
+
+    def fake_context_for_success
+      ShopifyCli::Util.expects(:development?).returns(false)
+      fake_git(["fetch", "origin", 'master'])
+      fake_git(["reset", "."])
+      fake_git(["checkout", "."])
+      fake_git(["checkout", "-f", "-B", 'master'])
+      fake_git(["reset", "--hard", "FETCH_HEAD"])
+    end
+
+    def fake_context_for_failed_fetch
+      ShopifyCli::Util.expects(:development?).returns(false)
+      fake_git(["fetch", "origin", 'master'], success: false)
+    end
+
+    def fake_context_for_failed_reset
+      ShopifyCli::Util.expects(:development?).returns(false)
+      fake_git(["fetch", "origin", 'master'])
+      fake_git(["reset", "."])
+      fake_git(["checkout", "."])
+      fake_git(["checkout", "-f", "-B", 'master'], success: false)
+    end
+
+    def fake_git(args, success: true)
+      command_string = ["git", "-C", ShopifyCli::ROOT, *args]
+      @context.expects(:capture2e).with(*command_string)
+        .returns([nil, Stat.new(success: success)])
+    end
+  end
+end

--- a/test/test_helpers/context.rb
+++ b/test/test_helpers/context.rb
@@ -2,8 +2,10 @@
 module TestHelpers
   module Context
     def setup
-      @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir, env: {
+      root = Dir.mktmpdir
+      @context = TestHelpers::FakeContext.new(root: root, env: {
         'HOME' => '~',
+        'XDG_CONFIG_HOME' => root,
       })
       FileUtils.touch(File.join(@context.root, '.shopify-cli.yml'))
       super


### PR DESCRIPTION
This adds an auto update feature to the CLI, which is opt-in. The first time a user runs a command (with a few exceptions for speed) they are prompted to opt-in to auto updates.

![image](https://user-images.githubusercontent.com/73874/59299816-9ae32200-8c5b-11e9-8d8f-0c49942a7739.png)

Their preference is stored in `~/.config/shopify/config` via the `CLI::Kit::Config` API.