### PR TITLE
adds explanatory comment for lines added to .bash_profile

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -235,7 +235,11 @@ install_bash_shell_shim() {
   fi
 
   if ! grep -q "shopify.sh" "${bp}" 2>/dev/null; then
-    echo "if [[ -f "${install_dir}/shopify.sh" ]]; then source "${install_dir}/shopify.sh"; fi" >> "${bp}"
+    {
+      echo ''
+      echo '# load shopify-cli, but only if present and the shell is interactive'
+      echo "if [[ -f "${install_dir}/shopify.sh" ]]; then source "${install_dir}/shopify.sh"; fi"
+    } >> "${bp}"
   fi
 
   if ! grep -q "shopify.sh" "${HOME}/.bashrc" 2>/dev/null; then


### PR DESCRIPTION
Currently the install script appends lines to both ~/.bashrc and ~/.bash_profile, but only .bashrc adds a comment explaining what the line does. This duplicates the append behaviour and comment messaging for greater transparency.