### PR TITLE
fix calling Project from create command

### DIFF
--- a/lib/shopify-cli/commands/create.rb
+++ b/lib/shopify-cli/commands/create.rb
@@ -5,11 +5,11 @@ module ShopifyCli
     class Create < ShopifyCli::Command
       autoload :Project, 'shopify-cli/commands/create/project'
 
-      def call(args, _name)
+      def call(args, name)
         subcommand = args.shift
         case subcommand
         when 'project'
-          Project.new(@ctx).call(args)
+          Project.new(@ctx).call(args, name)
         else
           @ctx.puts(self.class.help)
         end

--- a/test/shopify-cli/commands/create_test.rb
+++ b/test/shopify-cli/commands/create_test.rb
@@ -17,8 +17,8 @@ module ShopifyCli
 
       def test_with_project_calls_project
         ShopifyCli::Commands::Create::Project.any_instance.expects(:call)
-          .with(['new-app'], nil)
-        @command.call(['project', 'new-app'], nil)
+          .with(['new-app'], 'create')
+        @command.call(['project', 'new-app'], 'create')
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes broken Project subcommand in create. Ideally these case statements will be replaced with something that resolves subcommands automatically.