### PR TITLE
add latest_api_version helper

### DIFF
--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -18,6 +18,7 @@ module ShopifyCli
 
         def test_populate_calls_api_with_mutation
           Helpers::Haikunator.stubs(:haikunate).returns('fake product')
+          @resource.api.stubs(:latest_api_version).returns('2019-04')
           @resource.stubs(:price).returns('1.00')
           body = @resource.api.mutation_body(@mutation)
           stub_request(:post, "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")

--- a/test/shopify-cli/helpers/api_test.rb
+++ b/test/shopify-cli/helpers/api_test.rb
@@ -8,6 +8,7 @@ module ShopifyCli
       def setup
         super
         @api = API.new(ctx: @context, token: 'faketoken')
+        @api.stubs(:latest_api_version).returns('2019-04')
         @context.stubs(:project).returns(
           Project.at(File.join(FIXTURE_DIR, 'app_types/node'))
         )


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #120
@katiedavis is this what you had in mind?

### WHAT is this pull request doing?

Adds a helper in ShopifyCLi::Helpers::API that queries the unstable GraphQL API to get a list of versions, and returns the handle of the one marked `Latest`.

Edit: Oh, I also copied `query_body` from the GraphQL helpers into the API class. Do we actually need both sets of helpers, or can we combine these?