### PR TITLE
improve Schema error handling

### DIFF
--- a/lib/shopify-cli/helpers/graphql.rb
+++ b/lib/shopify-cli/helpers/graphql.rb
@@ -2,13 +2,6 @@ module ShopifyCli
   module Helpers
     module GraphQL
       autoload :Queries, 'shopify-cli/helpers/graphql/queries'
-
-      def query_body(query, variables: {})
-        JSON.dump(
-          query: query,
-          variables: variables,
-        )
-      end
     end
   end
 end

--- a/lib/shopify-cli/tasks/schema.rb
+++ b/lib/shopify-cli/tasks/schema.rb
@@ -3,31 +3,21 @@ require 'shopify_cli'
 module ShopifyCli
   module Tasks
     class Schema < ShopifyCli::Task
-      include ShopifyCli::Helpers::GraphQL
       include ShopifyCli::Helpers::GraphQL::Queries
 
       def call(ctx)
         @ctx = ctx
-        get
-        if @response.code == '401'
-          ShopifyCli::Tasks::AuthenticateShopify.call(ctx)
-          get
-        end
+        @api = Helpers::API.new(ctx: ctx, token: Helpers::AccessToken.read(ctx))
         @ctx.app_metadata = { schema: schema_file }
         schema_file
       end
 
       def get
-        uri = URI.parse("https://#{shop_name}/admin/api/2019-04/graphql.json")
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        request = Net::HTTP::Post.new(uri.request_uri)
-        request["X-Shopify-Access-Token"] = Helpers::AccessToken.read(@ctx)
-        request["Content-Type"] = "application/json"
-        request.body = query_body(introspection)
-        @response = http.request(request)
-        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'),
-          @response.body.force_encoding('UTF-8'))
+        _, resp = @api.post(@api.graphql_url, @api.query_body(introspection))
+        File.write(File.join(ShopifyCli::TEMP_DIR, 'shopify_schema.json'), resp)
+      rescue Helpers::API::APIRequestUnauthorizedError
+        ShopifyCli::Tasks::AuthenticateShopify.call(@ctx)
+        get
       end
 
       def shop_name

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -7,4 +7,5 @@ module TestHelpers
   autoload :FakeFS, 'test_helpers/fake_fs'
   autoload :FakeProject, 'test_helpers/fake_project'
   autoload :AppType, 'test_helpers/app_type'
+  autoload :Schema, 'test_helpers/schema'
 end

--- a/test/test_helpers/schema.rb
+++ b/test/test_helpers/schema.rb
@@ -1,0 +1,13 @@
+module TestHelpers
+  module Schema
+    def setup
+      super
+      ShopifyCli::Tasks::Schema.stubs(:call).returns(schema)
+      @context.app_metadata[:schema] = schema
+    end
+
+    def schema
+      @schema ||= JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
+    end
+  end
+end


### PR DESCRIPTION
Currently the Schema test makes a request for the schema even if it already has it in the filesystem. I fixed that and refactored it to use our `API` helper which is a bit cleaner. Also, there's a TestHelper for when you need to mock the schema in something else.
