### PR TITLE
SchemaParser cleanup

### DIFF
--- a/lib/shopify-cli/commands/generate/webhook.rb
+++ b/lib/shopify-cli/commands/generate/webhook.rb
@@ -4,12 +4,13 @@ module ShopifyCli
   module Commands
     class Generate
       class Webhook < ShopifyCli::Task
-        include ShopifyCli::Helpers::SchemaParser
         def call(ctx, args)
           selected_type = args.first
-          schema = ShopifyCli::Tasks::Schema.call(ctx)
-          enum = get_types_by_name(schema, 'WebhookSubscriptionTopic')
-          webhooks = get_names_from_enum(enum)
+          schema = ShopifyCli::Helpers::SchemaParser.new(
+            schema: ShopifyCli::Tasks::Schema.call(ctx)
+          )
+          enum = schema['WebhookSubscriptionTopic']
+          webhooks = schema.get_names_from_enum(enum)
 
           unless selected_type
             selected_type = CLI::UI::Prompt.ask('What type of webhook would you like to create?') do |handler|

--- a/lib/shopify-cli/helpers/schema_parser.rb
+++ b/lib/shopify-cli/helpers/schema_parser.rb
@@ -3,12 +3,18 @@ require 'shopify_cli'
 
 module ShopifyCli
   module Helpers
-    module SchemaParser
-      def get_types_by_name(schema, name)
-        all_types = schema["data"]["__schema"]["types"]
+    class SchemaParser
+      include SmartProperties
 
-        all_types.find do |object|
-          object["name"] == name
+      property :schema
+
+      def types
+        @types = schema["data"]["__schema"]["types"]
+      end
+
+      def [](name)
+        types.find do |object|
+          object['name'] == name.to_s
         end
       end
 

--- a/test/shopify-cli/helpers/schema_parser_test.rb
+++ b/test/shopify-cli/helpers/schema_parser_test.rb
@@ -4,18 +4,18 @@ module ShopifyCli
   module Helpers
     class SchemaParserTest < MiniTest::Test
       def setup
-        @test_obj = Object.new
-        @test_obj.extend(SchemaParser)
-        @schema = JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
+        @test_obj = SchemaParser.new(
+          schema: JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json")))
+        )
         @enum = {
-            "kind" => "ENUM",
-            "name" => "WebhookSubscriptionTopic",
-            "enumValues" => [{ "name" => "APP_UNINSTALLED" }],
-          }
+          "kind" => "ENUM",
+          "name" => "WebhookSubscriptionTopic",
+          "enumValues" => [{ "name" => "APP_UNINSTALLED" }],
+        }
       end
 
-      def test_get_types_by_name
-        assert_equal(@test_obj.get_types_by_name(@schema, 'WebhookSubscriptionTopic'), @enum)
+      def test_access
+        assert_equal(@test_obj['WebhookSubscriptionTopic'], @enum)
       end
 
       def test_get_names_from_enum


### PR DESCRIPTION
Small refactor to turn SchemaParser into a class so that you don't have to keep passing schema around to it.
