### PR TITLE
add not yet implemented message

### DIFF
--- a/lib/shopify-cli/app_types/rails.rb
+++ b/lib/shopify-cli/app_types/rails.rb
@@ -22,10 +22,10 @@ module ShopifyCli
 
         def generate
           {
-            page: 'not-yet',
-            billing_recurring: 'not-yet',
-            billing_one_time: 'not-yet',
-            webhook: 'not-yet',
+            page: NotImplementedError,
+            billing_recurring: NotImplementedError,
+            billing_one_time: NotImplementedError,
+            webhook: NotImplementedError,
           }
         end
 

--- a/lib/shopify-cli/commands/generate.rb
+++ b/lib/shopify-cli/commands/generate.rb
@@ -55,7 +55,7 @@ module ShopifyCli
       end
 
       def self.run_generate(script, name, ctx)
-        if script.include?('not-yet')
+        if script.include?('NotImplementedError')
           raise(ShopifyCli::Abort, 'This feature is not yet available for Rails apps')
         end
         stat = ctx.system(script)

--- a/lib/shopify-cli/commands/generate/billing.rb
+++ b/lib/shopify-cli/commands/generate/billing.rb
@@ -18,6 +18,7 @@ module ShopifyCli
         def self.help
           <<~HELP
             Enable charging for your app. This command generates the necessary code to call Shopify’s billing API.
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate billing}}
           HELP
         end
       end

--- a/lib/shopify-cli/commands/generate/page.rb
+++ b/lib/shopify-cli/commands/generate/page.rb
@@ -18,7 +18,7 @@ module ShopifyCli
         def self.help
           <<~HELP
             Generate a new page in your app with the specified name. New files are generated inside the project’s “/pages” directory.
-              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate <pagename>}}
+              Usage: {{command:#{ShopifyCli::TOOL_NAME} generate page <pagename>}}
           HELP
         end
       end


### PR DESCRIPTION
This is a very ungraceful way to handle telling users we don't have the generate command ready for Rails apps. If you have a better suggestion let me know! 