### PR TITLE
[Proposal] Freeform Apps

### DIFF
--- a/lib/project_types/dev/cli.rb
+++ b/lib/project_types/dev/cli.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Dev
+  class Project < ShopifyCli::ProjectType
+    declare("Freeform App")
+    register_command('Dev::Commands::Populate', "populate")
+    register_command('Dev::Commands::Serve', "serve")
+    register_command('Dev::Commands::Tunnel', "tunnel")
+
+    require Project.project_filepath('messages/messages')
+    register_messages(Dev::Messages::MESSAGES)
+  end
+
+  # define/autoload project specific Commands
+  module Commands
+    autoload :Populate, Project.project_filepath('commands/populate')
+    autoload :Serve, Project.project_filepath('commands/serve')
+    autoload :Tunnel, Project.project_filepath('commands/tunnel')
+  end
+
+  # define/autoload project specific Tasks
+  module Tasks
+  end
+
+  # define/autoload project specific Forms
+  module Forms
+  end
+end

--- a/lib/project_types/dev/commands/populate.rb
+++ b/lib/project_types/dev/commands/populate.rb
@@ -1,0 +1,23 @@
+require 'shopify_cli'
+
+module Dev
+  module Commands
+    class Populate < ShopifyCli::Command
+      subcommand :Customer, 'customers', Project.project_filepath('commands/populate/customer')
+      subcommand :DraftOrder, 'draftorders', Project.project_filepath('commands/populate/draft_order')
+      subcommand :Product, 'products', Project.project_filepath('commands/populate/product')
+
+      def call(_args, _name)
+        @ctx.puts(self.class.help)
+      end
+
+      def self.help
+        ShopifyCli::Context.message('dev.populate.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('dev.populate.extended_help', ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/commands/populate/customer.rb
+++ b/lib/project_types/dev/commands/populate/customer.rb
@@ -1,0 +1,31 @@
+require 'shopify_cli'
+
+module Dev
+  module Commands
+    class Populate
+      class Customer < ShopifyCli::AdminAPI::PopulateResourceCommand
+        @input_type = :CustomerInput
+
+        def defaults
+          first_name, last_name = ShopifyCli::Helpers::Haikunator.name
+          {
+            firstName: first_name,
+            lastName: last_name,
+          }
+        end
+
+        def message(data)
+          ret = data['customerCreate']['customer']
+          id = ShopifyCli::API.gid_to_id(ret['id'])
+          @ctx.message(
+            'dev.populate.customer.added',
+            ret['displayName'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/commands/populate/draft_order.rb
+++ b/lib/project_types/dev/commands/populate/draft_order.rb
@@ -1,0 +1,28 @@
+require 'shopify_cli'
+
+module Dev
+  module Commands
+    class Populate
+      class DraftOrder < ShopifyCli::AdminAPI::PopulateResourceCommand
+        @input_type = :DraftOrderInput
+
+        def defaults
+          {
+            lineItems: [{
+              originalUnitPrice: price,
+              quantity: 1,
+              weight: { value: 10, unit: 'GRAMS' },
+              title: ShopifyCli::Helpers::Haikunator.title,
+            }],
+          }
+        end
+
+        def message(data)
+          ret = data['draftOrderCreate']['draftOrder']
+          id = ShopifyCli::API.gid_to_id(ret['id'])
+          @ctx.message('dev.populate.draft_order.added', ShopifyCli::Project.current.env.shop, admin_url, id)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/commands/populate/product.rb
+++ b/lib/project_types/dev/commands/populate/product.rb
@@ -1,0 +1,30 @@
+require 'shopify_cli'
+
+module Dev
+  module Commands
+    class Populate
+      class Product < ShopifyCli::AdminAPI::PopulateResourceCommand
+        @input_type = :ProductInput
+
+        def defaults
+          {
+            title: ShopifyCli::Helpers::Haikunator.title,
+            variants: [{ price: price }],
+          }
+        end
+
+        def message(data)
+          ret = data['productCreate']['product']
+          id = ShopifyCli::API.gid_to_id(ret['id'])
+          @ctx.message(
+            'dev.populate.product.added',
+            ret['title'],
+            ShopifyCli::Project.current.env.shop,
+            admin_url,
+            id
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/commands/serve.rb
+++ b/lib/project_types/dev/commands/serve.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Dev
+  module Commands
+    class Serve < ShopifyCli::Command
+      prerequisite_task :ensure_env
+
+      options do |parser, flags|
+        parser.on('--host=HOST') { |h| flags[:host] = h.gsub('"', '') }
+      end
+
+      def call(*)
+        project = ShopifyCli::Project.current
+        url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
+        @ctx.abort(@ctx.message('dev.serve.error.host_must_be_https')) if url.match(/^https/i).nil?
+        project.env.update(@ctx, :host, url)
+        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+          @ctx,
+          url: url,
+          callback_url: "/auth/callback",
+        )
+        serve_cmd = project.config['serve_cmd']
+        @ctx.abort('didnt find a serve_cmd in your .shopify-cli.yml') if serve_cmd.nil?
+        CLI::UI::Frame.open(@ctx.message('dev.serve.running_server')) do
+          @ctx.system(project.config['serve_cmd'], env: project.env.to_h.tap do |env|
+            env['PORT'] = ShopifyCli::Tunnel::PORT.to_s
+          end)
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message('dev.serve.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('dev.serve.extended_help')
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/commands/tunnel.rb
+++ b/lib/project_types/dev/commands/tunnel.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'shopify_cli'
+
+module Dev
+  module Commands
+    class Tunnel < ShopifyCli::Command
+      def call(args, _name)
+        subcommand = args.shift
+        case subcommand
+        when 'auth'
+          token = args.shift
+          if token.nil?
+            @ctx.puts(@ctx.message('dev.tunnel.error.token_argument_missing'))
+            @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
+          else
+            ShopifyCli::Tunnel.auth(@ctx, token)
+          end
+        when 'start'
+          ShopifyCli::Tunnel.start(@ctx)
+        when 'stop'
+          ShopifyCli::Tunnel.stop(@ctx)
+        else
+          @ctx.puts(self.class.help)
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message('dev.tunnel.help', ShopifyCli::TOOL_NAME)
+      end
+
+      def self.extended_help
+        ShopifyCli::Context.message('dev.tunnel.extended_help', ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/dev/messages/messages.rb
+++ b/lib/project_types/dev/messages/messages.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+module Dev
+  module Messages
+    MESSAGES = {
+      dev: {
+        error: {
+          generic: "Error",
+        },
+
+        create: {
+          help: <<~HELP,
+          {{command:%s create node}}: Creates an embedded nodejs app.
+            Usage: {{command:%s create node}}
+            Options:
+              {{command:--name=NAME}} App name. Any string.
+              {{command:--app_url=APPURL}} App URL. Must be a valid URL.
+              {{command:--organization_id=ID}} Partner organization ID. Must be an existing organization.
+              {{command:--shop_domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
+          HELP
+          error: {
+            node_required: "node is required to create an app project. Download at https://nodejs.org/en/download.",
+            node_version_failure: "Failed to get the current node version. Please make sure it is installed as " \
+              "per the instructions at https://nodejs.org/en.",
+            npm_required: "npm is required to create an app project. Download at https://www.npmjs.com/get-npm.",
+            npm_version_failure: "Failed to get the current npm version. Please make sure it is installed as per " \
+              "the instructions at https://www.npmjs.com/get-npm.",
+          },
+          info: {
+            created: "{{v}} {{green:%s}} was created in your Partner Dashboard {{underline:%s}}",
+            serve: "{{*}} Change directories to your new project folder {{green:%s}} and run {{command:%s serve}} " \
+              "to start a local server",
+            install: "{{*}} Then, visit {{underline:%s/test}} to install {{green:%s}} on your Dev Store",
+          },
+          node_version: "node %s",
+          npm_version: "npm %s",
+        },
+
+        deploy: {
+          help: <<~HELP,
+          Deploy the current Node project to a hosting service. Heroku ({{underline:https://www.heroku.com}}) is currently the only option, but more will be added in the future.
+            Usage: {{command:%s deploy [ heroku ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+            {{cyan:heroku}}: Deploys the current Node project to Heroku.
+              Usage: {{command:%s deploy heroku}}
+          HELP
+          heroku: {
+            help: <<~HELP,
+            Deploy the current Node project to Heroku
+              Usage: {{command:%s deploy heroku}}
+            HELP
+            downloading: "Downloading Heroku CLI…",
+            downloaded: "Downloaded Heroku CLI",
+            installing: "Installing Heroku CLI…",
+            installing_windows: "Running Heroku CLI install wizard…",
+            installed: "Installed Heroku CLI",
+            authenticating: "Authenticating with Heroku…",
+            authenticated: "{{v}} Authenticated with Heroku",
+            authenticated_with_account: "{{v}} Authenticated with Heroku as `%s`",
+            deploying: "Deploying to Heroku…",
+            deployed: "{{v}} Deployed to Heroku",
+            git: {
+              checking: "Checking git repo…",
+              initialized: "Git repo initialized",
+              what_branch: "What branch would you like to deploy?",
+              branch_selected: "{{v}} Git branch `%s` selected for deploy",
+            },
+            app: {
+              no_apps_found: "No existing Heroku app found. What would you like to do?",
+              name: "What is your Heroku app’s name?",
+              select: "Specify an existing Heroku app",
+              selecting: "Selecting Heroku app `%s`…",
+              selected: "{{v}} Heroku app `%s` selected",
+              create: "Create a new Heroku app",
+              creating: "Creating new Heroku app…",
+              created: "{{v}} New Heroku app created",
+            },
+          },
+        },
+
+        generate: {
+          help: <<~HELP,
+          Generate code in your Node project. Supports generating new billing API calls, new pages, or new webhooks.
+            Usage: {{command:%s generate [ billing | page | webhook ]}}
+          HELP
+          extended_help: <<~EXAMPLES,
+          {{bold:Examples:}}
+            {{cyan:%s generate webhook PRODUCTS_CREATE}}
+              Generate and register a new webhook that will be called every time a new product is created on your store.
+          EXAMPLES
+
+          error: {
+            name_exists: "%s already exists!",
+            generic: "Error generating %s",
+          },
+
+          billing: {
+            help: <<~HELP,
+            Enable charging for your app. This command generates the necessary code to call Shopify’s billing API.
+              Usage: {{command:%s generate billing [ one-time-billing | recurring-billing ]}}
+            HELP
+            type_select: "How would you like to charge for your app?",
+            generating: "Generating %s code ...",
+            generated: "{{green:%s}} generated in server/server.js",
+          },
+
+          page: {
+            help: <<~HELP,
+            Generate a new page in your app with the specified name. New files are generated inside the project’s “/pages” directory.
+              Usage: {{command:%s generate page <pagename>}}
+            HELP
+            error: {
+              invalid_page_type: "Invalid page type.",
+            },
+            type_select: "Which template would you like to use?",
+            generating: "Generating %s page...",
+            generated: "{{green: %s}} generated in pages/%s",
+          },
+
+          webhook: {
+            help: <<~HELP,
+            Generate and register a new webhook that listens for the specified Shopify store event.
+              Usage: {{command:%s generate webhook <type>}}
+            HELP
+            type_select: "What type of webhook would you like to create?",
+            generating: "Generating webhook: %s",
+            generated: "{{green:%s}} generated in server/server.js",
+          },
+        },
+
+        open: {
+          help: <<~HELP,
+          Open your local development app in the default browser.
+            Usage: {{command:%s open}}
+          HELP
+        },
+
+        populate: {
+          help: <<~HELP,
+          Populate your Shopify development store with example customers, orders, or products.
+            Usage: {{command:%s populate [ customers | draftorders | products ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:customers [options]}}: Add dummy customers to the specified development store.
+              Usage: {{command:%1$s populate customers}}
+
+            {{cyan:draftorders [options]}}: Add dummy orders to the specified development store.
+              Usage: {{command:%1$s populate draftorders}}
+
+            {{cyan:products [options]}}: Add dummy products to the specified development store.
+              Usage: {{command:%1$s populate products}}
+
+          {{bold:Options:}}
+
+            {{cyan:--count [integer]}}: The number of dummy items to populate. Defaults to 5.
+            {{cyan:--silent}}: Silence the populate output.
+            {{cyan:--help}}: Display more options specific to each subcommand.
+
+          {{bold:Examples:}}
+
+            {{command:%1$s populate products}}
+              Populate your development store with 5 additional products.
+
+            {{command:%1$s populate customers --count 30}}
+              Populate your development store with 30 additional customers.
+
+            {{command:%1$s populate draftorders}}
+              Populate your development store with 5 additional orders.
+
+            {{command:%1$s populate products --help}}
+              Display the list of options available to customize the {{command:%1$s populate products}} command.
+          HELP
+
+          customer: {
+            added: "%s added to {{green:%s}} at {{underline:%scustomers/%d}}",
+          },
+
+          draft_order: {
+            added: "DraftOrder added to {{green:%s}} at {{underline:%sdraft_orders/%d}}",
+          },
+
+          product: {
+            added: "%s added to {{green:%s}} at {{underline:%sproducts/%d}}",
+          },
+        },
+
+        serve: {
+          help: <<~HELP,
+          Start a local development node server for your project, as well as a public ngrok tunnel to your localhost.
+            Usage: {{command:%s serve}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Options:}}
+            {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
+          HELP
+
+          error: {
+            host_must_be_https: "HOST must be a HTTPS url.",
+          },
+
+          open_info: "{{*}} Press {{yellow: Control-T}} to open this project in {{green:%s}} ",
+          running_server: "Running server...",
+        },
+
+        tunnel: {
+          help: <<~HELP,
+          Start or stop an http tunnel to your local development app using ngrok.
+            Usage: {{command:%s tunnel [ auth | start | stop ]}}
+          HELP
+          extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:%1$s tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:%1$s tunnel start}}
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:%1$s tunnel stop}}
+
+          HELP
+
+          error: {
+            token_argument_missing: "{{x}} {{red:auth requires a token argument}}\n\n",
+          },
+        },
+
+        forms: {
+          create: {
+            error: {
+              invalid_app_type: "Invalid app type %s",
+            },
+            app_name: "App name",
+            app_type: {
+              select: "What type of app are you building?",
+              select_public: "Public: An app built for a wide merchant audience.",
+              select_custom: "Custom: An app custom built for a single client.",
+              selected: "App type {{green:%s}}",
+            },
+          },
+        },
+      },
+    }.freeze
+  end
+end

--- a/lib/shopify-cli/project_type.rb
+++ b/lib/shopify-cli/project_type.rb
@@ -45,8 +45,12 @@ module ShopifyCli
         File.join(ShopifyCli::PROJECT_TYPES_DIR, project_type.to_s, path)
       end
 
-      def creator(name, command_const)
+      def declare(name)
         @project_name = name
+      end
+
+      def creator(name, command_const)
+        declare(name)
         @project_creator_command_class = command_const
         ShopifyCli::Commands::Create.subcommand(command_const, @project_type)
       end


### PR DESCRIPTION
I have been thinking for a long time on how to support *all* shopify apps to allow use to optimize their workflow. We are doing a few major things that all devs could use, not just node and ruby. If we could allow for a way for other apps to leverage these things and get out of their way for other things, we may be able to help a lot more people.

- Tunnel
- Update URLs
- Populate 
- Managing Env (ApiKey, Secret, Shop, Org) 

![screen](https://user-images.githubusercontent.com/463193/91328244-a5240a00-e794-11ea-85f5-aec1a77c8c50.gif)

### Thoughts From here
- Connect could have an option to create an APIkey instead of fetch one.
- I need a way for project types to extend connect so that we can run something *after* connect to collection the serve_cmd config.
- If we go in this direction, we might think about making the `.shopify-cli.yml` no longer a dotfile.

Fixes #244