### PR TITLE
Add docs link to product subscription post-create

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -35,7 +35,7 @@ module Extension
         loading_apps: 'Loading your apps...',
         ask_app: 'Which app would you like to register this extension with?',
         no_apps: '{{x}} You don’t have any apps.',
-        learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, ' \
+        learn_about_apps: '{{*}} Learn more about building apps at {{underline:https://shopify.dev/concepts/apps}}, ' \
           'or try creating a new app using {{command:shopify create}}.',
         invalid_api_key: 'The API key %s does not match any of your apps.',
         confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
@@ -69,7 +69,7 @@ module Extension
         extended_help: <<~HELP,
           {{bold:Subcommands:}}
 
-            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. 
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account.
             Visit https://dashboard.ngrok.com/signup to sign up.
               Usage: {{command:%1$s tunnel auth <token>}}
 
@@ -122,6 +122,14 @@ module Extension
         name: 'Product Subscription',
         tagline: '(limit 1 per app)',
         overrides: {
+          create: {
+            learn_more: <<~MESSAGE,
+              {{*}} Once you're ready to version and publish your extension,
+              run {{command:shopify register}} to register this extension with one of your apps.
+              {{*}} Learn more about building your extension at
+              {{underline:https://shopify.dev/tutorials/getting-started-product-subscription-extension}}.
+            MESSAGE
+          },
           register: {
             confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
           },


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/app-extension-libs/issues/272

### WHAT is this pull request doing?

Adds an override to the `learn_more` message for the Product Subscription extension type.

However, it isn’t working? I tried running the CLI from `./bin/shopify` and didn’t see the override.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR~~
