### PR TITLE
Use ruby2_keywords for delegation

### DIFF
--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -15,12 +15,13 @@ ENV["PATH"] = ENV["PATH"].split(":").select { |p| p.start_with?("/", "~") }.join
 vendor_path = File.expand_path("../../vendor/lib", __FILE__)
 $LOAD_PATH.unshift(vendor_path) unless $LOAD_PATH.include?(vendor_path)
 
-deps = %w(cli-ui cli-kit smart_properties webrick)
+deps = %w(cli-ui cli-kit smart_properties ruby2_keywords webrick)
 deps.each do |dep|
   vendor_path = File.expand_path("../../vendor/deps/#{dep}/lib", __FILE__)
   $LOAD_PATH.unshift(vendor_path) unless $LOAD_PATH.include?(vendor_path)
 end
 
+require "ruby2_keywords"
 require "cli/ui"
 require "cli/kit"
 require "smart_properties"

--- a/lib/shopify_cli/core/executor.rb
+++ b/lib/shopify_cli/core/executor.rb
@@ -3,10 +3,10 @@ require "shopify_cli"
 module ShopifyCLI
   module Core
     class Executor < CLI::Kit::Executor
-      def initialize(ctx, task_registry, *args, **kwargs)
-        @ctx = ctx || ShopifyCLI::Context.new
-        @task_registry = task_registry || ShopifyCLI::Tasks::TaskRegistry.new
-        super(*args, **kwargs)
+      ruby2_keywords def initialize(ctx, task_registry, *args)
+        @ctx = ctx || ShopifyCli::Context.new
+        @task_registry = task_registry || ShopifyCli::Tasks::TaskRegistry.new
+        super(*args)
       end
 
       def call(command, command_name, args)

--- a/lib/shopify_cli/result.rb
+++ b/lib/shopify_cli/result.rb
@@ -363,70 +363,72 @@ module ShopifyCLI
       Result::Failure.new(error)
     end
 
-    ##
-    # takes either a value or a block and chooses the appropriate result
-    # container based on the type of the value or the type of the block's return
-    # value. If the type is an exception, it is wrapped in a
-    # `ShopifyCLI::Result::Failure` and otherwise in a
-    # `ShopifyCLI::Result::Success`. If a block was provided instead of value, a
-    # `Proc` is returned and the result wrapping doesn't occur until the block
-    # is invoked.
-    #
-    # #### Parameters
-    #
-    # * `*args` should be an `Array` with zero or one element
-    # * `&block` should be a `Proc` that takes zero or one argument
-    #
-    # #### Returns
-    #
-    # Returns either a `Result::Success`, `Result::Failure` or a `Proc` that
-    # produces one of the former when invoked.
-    #
-    # #### Examples
-    #
-    #   Result.wrap(1) # => ShopifyCLI::Result::Success
-    #   Result.wrap(RuntimeError.new) # => ShopifyCLI::Result::Failure
-    #
-    #   Result.wrap { 1 } # => Proc
-    #   Result.wrap { 1 }.call # => ShopifyCLI::Result::Success
-    #   Result.wrap { raise }.call # => ShopifyCLI::Result::Failure
-    #
-    #   Result.wrap { |s| s.upcase }.call("hello").tap do |result|
-    #     result # => Result::Success
-    #     result.value # => "HELLO"
-    #   end
-    #
-    def self.wrap(*values, &block)
-      raise ArgumentError, "expected either a value or a block" unless (values.length == 1) ^ block
+    class << self
+      ##
+      # takes either a value or a block and chooses the appropriate result
+      # container based on the type of the value or the type of the block's return
+      # value. If the type is an exception, it is wrapped in a
+      # `ShopifyCli::Result::Failure` and otherwise in a
+      # `ShopifyCli::Result::Success`. If a block was provided instead of value, a
+      # `Proc` is returned and the result wrapping doesn't occur until the block
+      # is invoked.
+      #
+      # #### Parameters
+      #
+      # * `*args` should be an `Array` with zero or one element
+      # * `&block` should be a `Proc` that takes zero or one argument
+      #
+      # #### Returns
+      #
+      # Returns either a `Result::Success`, `Result::Failure` or a `Proc` that
+      # produces one of the former when invoked.
+      #
+      # #### Examples
+      #
+      #   Result.wrap(1) # => ShopifyCli::Result::Success
+      #   Result.wrap(RuntimeError.new) # => ShopifyCli::Result::Failure
+      #
+      #   Result.wrap { 1 } # => Proc
+      #   Result.wrap { 1 }.call # => ShopifyCli::Result::Success
+      #   Result.wrap { raise }.call # => ShopifyCli::Result::Failure
+      #
+      #   Result.wrap { |s| s.upcase }.call("hello").tap do |result|
+      #     result # => Result::Success
+      #     result.value # => "HELLO"
+      #   end
+      #
+      ruby2_keywords def wrap(*values, &block)
+        raise ArgumentError, "expected either a value or a block" unless (values.length == 1) ^ block
 
-      if values.length == 1
-        values.pop.yield_self do |value|
-          case value
-          when Result::Success, Result::Failure
-            value
-          when NilClass, Exception
-            Result.failure(value)
-          else
-            Result.success(value)
+        if values.length == 1
+          values.pop.yield_self do |value|
+            case value
+            when Result::Success, Result::Failure
+              value
+            when NilClass, Exception
+              Result.failure(value)
+            else
+              Result.success(value)
+            end
           end
-        end
-      else
-        ->(*args) do
-          begin
-            wrap(block.call(*args))
-          rescue Exception => error # rubocop:disable Lint/RescueException
-            wrap(error)
-          end
+        else
+          ->(*args) do
+            begin
+              wrap(block.call(*args))
+            rescue Exception => error # rubocop:disable Lint/RescueException
+              wrap(error)
+            end
+          end.ruby2_keywords
         end
       end
-    end
 
-    ##
-    # Wraps the given block and invokes it with the passed arguments.
-    #
-    def self.call(*args, &block)
-      raise ArgumentError, "expected a block" unless block
-      wrap(&block).call(*args)
+      ##
+      # Wraps the given block and invokes it with the passed arguments.
+      #
+      ruby2_keywords def call(*args, &block)
+        raise ArgumentError, "expected a block" unless block
+        wrap(&block).call(*args)
+      end
     end
   end
 end

--- a/lib/shopify_cli/task.rb
+++ b/lib/shopify_cli/task.rb
@@ -2,9 +2,11 @@ require "shopify_cli"
 
 module ShopifyCLI
   class Task
-    def self.call(*args, **kwargs)
-      task = new
-      task.call(*args, **kwargs)
+    class << self
+      ruby2_keywords def call(*args)
+        task = new
+        task.call(*args)
+      end
     end
 
     private

--- a/vendor/deps/ruby2_keywords/LICENSE
+++ b/vendor/deps/ruby2_keywords/LICENSE
@@ -1,0 +1,22 @@
+Copyright 2019-2020 Nobuyoshi Nakada, Yusuke Endoh
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/deps/ruby2_keywords/README.md
+++ b/vendor/deps/ruby2_keywords/README.md
@@ -1,0 +1,67 @@
+# ruby2_keywords
+
+Provides empty `Module#ruby2_keywords` method, for the forward
+source-level compatibility against ruby2.7 and ruby3.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'ruby2_keywords'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install ruby2_keywords
+
+## Usage
+
+For class/module instance methods:
+
+```ruby
+require 'ruby2_keywords'
+
+module YourModule
+  ruby2_keywords def delegating_method(*args)
+    other_method(*args)
+  end
+end
+```
+
+For global methods:
+
+```ruby
+require 'ruby2_keywords'
+
+ruby2_keywords def oldstyle_keywords(options = {})
+end
+```
+
+You can do the same for a method defined by `Module#define_method`:
+
+```ruby
+define_method :delegating_method do |*args, &block|
+  other_method(*args, &block)
+end
+ruby2_keywords :delegating_method
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome on [GitHub] or
+[Ruby Issue Tracking System].
+
+## License
+
+The gem is available as open source under the terms of the
+[Ruby License] or the [2-Clause BSD License].
+
+[GitHub]: https://github.com/ruby/ruby2_keywords/
+[Ruby Issue Tracking System]: https://bugs.ruby-lang.org
+[Ruby License]: https://www.ruby-lang.org/en/about/license.txt
+[2-Clause BSD License]: https://opensource.org/licenses/BSD-2-Clause

--- a/vendor/deps/ruby2_keywords/Rakefile
+++ b/vendor/deps/ruby2_keywords/Rakefile
@@ -1,0 +1,54 @@
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+helper = Bundler::GemHelper.instance
+
+Rake::TestTask.new(:test) do |t|
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+task :default => :test
+
+task "build" => "date_epoch"
+
+task "date_epoch" do
+  ENV["SOURCE_DATE_EPOCH"] = IO.popen(%W[git -C #{__dir__} log -1 --format=%ct], &:read).chomp
+end
+
+def helper.update_gemspec
+  path = "#{__dir__}/#{gemspec.name}.gemspec"
+  File.open(path, "r+b") do |f|
+    if (d = f.read).sub!(/^(version\s*=\s*)".*"/) {$1 + gemspec.version.to_s.dump}
+      f.rewind
+      f.truncate(0)
+      f.print(d)
+    end
+  end
+end
+
+def helper.commit_bump
+  sh(%W[git -C #{__dir__} commit -m bump\ up\ to\ #{gemspec.version}
+        #{gemspec.name}.gemspec])
+end
+
+def helper.version=(v)
+  gemspec.version = v
+  update_gemspec
+  commit_bump
+  tag_version
+end
+major, minor, teeny = helper.gemspec.version.segments
+
+task "bump:teeny" do
+  helper.version = Gem::Version.new("#{major}.#{minor}.#{teeny+1}")
+end
+
+task "bump:minor" do
+  raise "can't bump up minor"
+end
+
+task "bump:major" do
+  raise "can't bump up major"
+end
+
+task "bump" => "bump:teeny"

--- a/vendor/deps/ruby2_keywords/lib/ruby2_keywords.rb
+++ b/vendor/deps/ruby2_keywords/lib/ruby2_keywords.rb
@@ -1,0 +1,57 @@
+class Module
+  unless private_method_defined?(:ruby2_keywords)
+    private
+    # call-seq:
+    #    ruby2_keywords(method_name, ...)
+    #
+    # Does nothing.
+    def ruby2_keywords(name, *)
+      # nil
+    end
+  end
+end
+
+main = TOPLEVEL_BINDING.receiver
+unless main.respond_to?(:ruby2_keywords, true)
+  # call-seq:
+  #    ruby2_keywords(method_name, ...)
+  #
+  # Does nothing.
+  def main.ruby2_keywords(name, *)
+    # nil
+  end
+end
+
+class Proc
+  unless method_defined?(:ruby2_keywords)
+    # call-seq:
+    #    proc.ruby2_keywords -> proc
+    #
+    # Does nothing and just returns the receiver.
+    def ruby2_keywords
+      self
+    end
+  end
+end
+
+class << Hash
+  unless method_defined?(:ruby2_keywords_hash?)
+    # call-seq:
+    #    Hash.ruby2_keywords_hash?(hash) -> false
+    #
+    # Returns false.
+    def ruby2_keywords_hash?(hash)
+      false
+    end
+  end
+
+  unless method_defined?(:ruby2_keywords_hash)
+    # call-seq:
+    #    Hash.ruby2_keywords_hash(hash) -> new_hash
+    #
+    # Duplicates a given hash and returns the new hash.
+    def ruby2_keywords_hash(hash)
+      hash.dup
+    end
+  end
+end

--- a/vendor/deps/ruby2_keywords/ruby2_keywords.gemspec
+++ b/vendor/deps/ruby2_keywords/ruby2_keywords.gemspec
@@ -1,0 +1,18 @@
+version = "0.0.4"
+abort "Version must not reach 1" if version[/\d+/].to_i >= 1
+
+Gem::Specification.new do |s|
+  s.name = "ruby2_keywords"
+  s.version = version
+  s.summary = "Shim library for Module#ruby2_keywords"
+  s.homepage = "https://github.com/ruby/ruby2_keywords"
+  s.licenses = ["Ruby", "BSD-2-Clause"]
+  s.authors = ["Nobuyoshi Nakada"]
+  s.require_paths = ["lib"]
+  s.rdoc_options = ["--main", "README.md"]
+  s.files = [
+    "LICENSE",
+    "README.md",
+    "lib/ruby2_keywords.rb",
+  ]
+end

--- a/vendor/deps/ruby2_keywords/test/test_keyword.rb
+++ b/vendor/deps/ruby2_keywords/test/test_keyword.rb
@@ -1,0 +1,41 @@
+require 'test/unit'
+LOADING_RUBY2_KEYWORDS = (RUBY_VERSION.scan(/\d+/).map(&:to_i) <=> [2, 7]) < 0
+if LOADING_RUBY2_KEYWORDS
+  require 'ruby2_keywords'
+end
+
+class TestKeywordArguments < Test::Unit::TestCase
+  def test_loaded_features
+    list = $LOADED_FEATURES.grep(%r[/ruby2_keywords\.rb\z])
+    if LOADING_RUBY2_KEYWORDS
+      assert_not_empty(list)
+      assert_not_include($LOADED_FEATURES, "ruby2_keywords.rb")
+    else
+      assert_empty(list)
+      assert_include($LOADED_FEATURES, "ruby2_keywords.rb")
+    end
+  end
+
+  def test_module_ruby2_keywords
+    assert_send([Module, :private_method_defined?, :ruby2_keywords])
+    assert_operator(Module.instance_method(:ruby2_keywords).arity, :<, 0)
+  end
+
+  def test_toplevel_ruby2_keywords
+    main = TOPLEVEL_BINDING.receiver
+    assert_send([main, :respond_to?, :ruby2_keywords, true])
+    assert_operator(main.method(:ruby2_keywords).arity, :<, 0)
+  end
+
+  def test_proc_ruby2_keywords
+    assert_respond_to(Proc.new {}, :ruby2_keywords)
+  end
+
+  def test_hash_ruby2_keywords_hash?
+    assert_false(Hash.ruby2_keywords_hash?({}))
+  end
+
+  def test_hash_ruby2_keywords_hash
+    assert_equal({}, Hash.ruby2_keywords_hash({}.freeze))
+  end
+end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

Delegation in Ruby is extremely complicated when you're trying to support a broad range of versions, including future versions.

Using `ruby2_keywords` is the carefully thought-out best-practice way to do this.

* https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
* https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

It uses `ruby2_keywords`, via the vendored gem.

There's one very tricky case, which is commented.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [ ] ~~I've considered possible cross-platform impacts (Mac, Linux, Windows).~~
