### PR TITLE
add clearer error messaging for verify store

### DIFF
--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -282,7 +282,7 @@ module ShopifyCli
             },
           },
           ensure_dev_store: {
-            could_not_verify_store: "Couldn't verify your store %s",
+            could_not_verify_store: "Couldn't verify your store %s - try using the `shopify connect` command",
             convert_to_dev_store: <<~MESSAGE,
               Do you want to convert %s to a development store?
               Doing this will allow you to install your app, but the store will become {{bold:transfer-disabled}}.


### PR DESCRIPTION
Helps with [#1149](https://github.com/Shopify/shopify-app-cli/issues/1149)

When i created an app there wasn't a store to connect to and for some reason the CLI was having a hard time connecting after i did create a store. Running `shopify connect` helped me connect and solve the error. The current error messaging is kind of vague and not very helpful adding this will save people time in the future.

Also %s was empty since there was no store to connect to.