### PR TITLE
fix: improved check for argo_admin_beta when running argo_serve

### DIFF
--- a/lib/project_types/extension/features/argo_runtime.rb
+++ b/lib/project_types/extension/features/argo_runtime.rb
@@ -12,6 +12,7 @@ module Extension
 
       property! :renderer, accepts: Models::NpmPackage
       property! :cli, accepts: Models::NpmPackage
+      property :beta_access, accepts: Array, default: -> { [] }
 
       def accepts_port?
         case cli
@@ -44,6 +45,26 @@ module Extension
         case cli
         when admin?
           cli >= ARGO_ADMIN_CLI_0_9_3
+        else
+          false
+        end
+      end
+
+      def accepts_shop?
+        return false unless beta_access.include?(:argo_admin_beta)
+        case cli
+        when admin?
+          cli >= ARGO_ADMIN_CLI_0_11_0
+        else
+          false
+        end
+      end
+
+      def accepts_api_key?
+        return false unless beta_access.include?(:argo_admin_beta)
+        case cli
+        when admin?
+          cli >= ARGO_ADMIN_CLI_0_11_0
         else
           false
         end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -8,6 +8,7 @@ module Extension
       property! :context, accepts: ShopifyCli::Context
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: ""
+      property :beta_access, accepts: Array, default: -> { [] }
 
       def call
         validate_env!
@@ -55,16 +56,12 @@ module Extension
         serve_options.npm_serve_command
       end
 
-      def argo_admin_beta?
-        ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:argo_admin_beta)
-      end
-
       def validate_env!
         ExtensionProject.reload
 
         return if required_fields.none?
 
-        return unless argo_admin_beta?
+        return unless beta_access.include?(:argo_admin_beta)
 
         ShopifyCli::Tasks::EnsureEnv.call(context, required: required_fields)
         ShopifyCli::Tasks::EnsureDevStore.call(context) if required_fields.include?(:shop)

--- a/lib/project_types/extension/features/argo_serve_options.rb
+++ b/lib/project_types/extension/features/argo_serve_options.rb
@@ -21,19 +21,16 @@ module Extension
         NPM_SERVE_COMMAND  + ["--"] + options
       end
 
-      def argo_admin_beta?
-        ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:argo_admin_beta)
-      end
-
       private
 
       def options
         project = ExtensionProject.current
+        api_key = project.env.api_key
 
         @serve_options ||= [].tap do |options|
           options << "--port=#{port}" if argo_runtime.accepts_port?
-          options << "--shop=#{project.env.shop}" if required_fields.include?(:shop) && argo_admin_beta?
-          options << "--apiKey=#{project.env.api_key}" if required_fields.include?(:api_key) && argo_admin_beta?
+          options << "--shop=#{project.env.shop}" if required_fields.include?(:shop) && argo_runtime.accepts_shop?
+          options << "--apiKey=#{api_key}" if required_fields.include?(:api_key) && argo_runtime.accepts_api_key?
           options << "--argoVersion=#{renderer_package.version}" if argo_runtime.accepts_argo_version?
           options << "--uuid=#{project.registration_uuid}" if argo_runtime.accepts_uuid?
           options << "--publicUrl=#{public_url}" if argo_runtime.accepts_tunnel_url?

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -51,8 +51,14 @@ module Extension
         end
 
         def serve(context:, port:, tunnel_url:)
-          Features::ArgoServe.new(specification_handler: self, argo_runtime: argo_runtime(context),
-          context: context, port: port, tunnel_url: tunnel_url).call
+          Features::ArgoServe.new(
+            specification_handler: self,
+            argo_runtime: argo_runtime(context),
+            context: context,
+            port: port,
+            tunnel_url: tunnel_url,
+            beta_access: beta_access
+          ).call
         end
 
         def renderer_package(context)
@@ -62,8 +68,17 @@ module Extension
         def argo_runtime(context)
           @argo_runtime ||= Features::ArgoRuntime.new(
             renderer: renderer_package(context),
-            cli: cli_package(context)
+            cli: cli_package(context),
+            beta_access: beta_access
           )
+        end
+
+        def beta_access
+          argo_admin_beta? ? [:argo_admin_beta] : []
+        end
+
+        def argo_admin_beta?
+          ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:argo_admin_beta)
         end
 
         def cli_package(context)

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -63,6 +63,36 @@ module Extension
         end
       end
 
+      def test_accepts_api_key
+        runtimes = {
+          checkout_runtime_0_3_8 => does_not_support_feature,
+          checkout_runtime_0_4_0 => does_not_support_feature,
+          admin_runtime_0_11_0 => does_not_support_feature,
+          admin_runtime_0_11_0_with_beta_access => supports_feature,
+          admin_runtime_0_9_3 => does_not_support_feature,
+          admin_runtime_0_9_2 => does_not_support_feature,
+        }
+
+        runtimes.each do |runtime, accepts_argo_version|
+          assert_equal accepts_argo_version, runtime.accepts_api_key?
+        end
+      end
+
+      def test_accepts_shop
+        runtimes = {
+          checkout_runtime_0_3_8 => does_not_support_feature,
+          checkout_runtime_0_4_0 => does_not_support_feature,
+          admin_runtime_0_11_0 => does_not_support_feature,
+          admin_runtime_0_11_0_with_beta_access => supports_feature,
+          admin_runtime_0_9_3 => does_not_support_feature,
+          admin_runtime_0_9_2 => does_not_support_feature,
+        }
+
+        runtimes.each do |runtime, accepts_argo_version|
+          assert_equal accepts_argo_version, runtime.accepts_shop?
+        end
+      end
+
       private
 
       def checkout_runtime_0_3_8
@@ -90,6 +120,14 @@ module Extension
         ArgoRuntime.new(
           cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0"),
           renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3")
+        )
+      end
+
+      def admin_runtime_0_11_0_with_beta_access
+        ArgoRuntime.new(
+          cli: Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0"),
+          renderer: Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.9.3"),
+          beta_access: [:argo_admin_beta]
         )
       end
 

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -18,10 +18,11 @@ module Extension
         argo_runtime = Features::ArgoRuntime.new(cli: cli, renderer: renderer)
         specification_handler = ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
 
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
-
-        argo_serve = Features::ArgoServe.new(context: @context, argo_runtime: argo_runtime,
-          specification_handler: specification_handler)
+        argo_serve = Features::ArgoServe.new(
+          context: @context,
+          argo_runtime: argo_runtime,
+          specification_handler: specification_handler
+        )
 
         Tasks::FindNpmPackages.expects(:exactly_one_of).returns(ShopifyCli::Result.success(renderer))
         argo_serve.expects(:validate_env!).once
@@ -33,30 +34,17 @@ module Extension
         cli = Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
         renderer = Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.0.1")
         argo_runtime = Features::ArgoRuntime.new(cli: cli, renderer: renderer)
+        specification_handler = ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
 
-        specification = Extension::Models::Specification.new(
-          {
-            identifier: "test",
-            features: {
-              argo: {
-                surface: "admin",
-                git_template: "https://github.com/Shopify/argo-admin.git",
-                renderer_package_name: "@shopify/argo-admin",
-                required_fields: [:shop, :api_key],
-                required_shop_beta_flags: [:argo_admin_beta],
-              },
-            },
-          }
-        )
-        specification_handler = Extension::Models::SpecificationHandlers::Default.new(specification)
-
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Feature.stubs(:enabled?).with(:argo_admin_beta).returns(true)
         ShopifyCli::Tasks::EnsureEnv.stubs(:call)
         ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
 
-        argo_serve = Features::ArgoServe.new(context: @context, argo_runtime: argo_runtime,
-          specification_handler: specification_handler)
+        argo_serve = Features::ArgoServe.new(
+          context: @context,
+          argo_runtime: argo_runtime,
+          specification_handler: specification_handler,
+          beta_access: [:argo_admin_beta]
+        )
 
         Tasks::FindNpmPackages.expects(:exactly_one_of).returns(ShopifyCli::Result.success(renderer))
 

--- a/test/project_types/extension/tasks/argo_serve_options_test.rb
+++ b/test/project_types/extension/tasks/argo_serve_options_test.rb
@@ -21,10 +21,11 @@ renderer_package: argo_admin)
 
       def test_serve_options_include_api_key_when_required
         required_fields = [:api_key]
-        argo_runtime = setup_argo_runtime(renderer_package: argo_admin, version: "0.1.2-doesnt-matter")
-
-        ShopifyCli::Shopifolk.expects(:check).returns(true)
-        ShopifyCli::Feature.expects(:enabled?).with(:argo_admin_beta).returns(true)
+        argo_runtime = setup_argo_runtime(
+          renderer_package: argo_admin,
+          version: "0.11.0",
+          beta_access: [:argo_admin_beta]
+        )
 
         options = Features::ArgoServeOptions.new(argo_runtime: argo_runtime, context: @context,
           renderer_package: argo_admin, required_fields: required_fields)
@@ -35,10 +36,11 @@ renderer_package: argo_admin)
 
       def test_serve_options_include_shop_when_required
         required_fields = [:shop]
-        argo_runtime = setup_argo_runtime(renderer_package: argo_admin, version: "0.1.2-doesnt-matter")
-
-        ShopifyCli::Shopifolk.expects(:check).returns(true)
-        ShopifyCli::Feature.expects(:enabled?).with(:argo_admin_beta).returns(true)
+        argo_runtime = setup_argo_runtime(
+          renderer_package: argo_admin,
+          version: "0.11.0",
+          beta_access: [:argo_admin_beta]
+        )
 
         options = Features::ArgoServeOptions.new(argo_runtime: argo_runtime, context: @context,
           renderer_package: argo_admin, required_fields: required_fields)
@@ -92,10 +94,10 @@ renderer_package: argo_admin)
         )
       end
 
-      def setup_argo_runtime(renderer_package:, version:, cli_package_name: "@shopify/argo-admin-cli")
+      def setup_argo_runtime(renderer_package:, version:, cli_package_name: "@shopify/argo-admin-cli", beta_access: [])
         cli = Models::NpmPackage.new(name: cli_package_name, version: version)
 
-        Features::ArgoRuntime.new(renderer: renderer_package, cli: cli)
+        Features::ArgoRuntime.new(renderer: renderer_package, cli: cli, beta_access: beta_access)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/argo-admin-template/issues/101

### WHAT is this pull request doing?

* Adds check for `argo_admin_beta` to `ArgoServeOptions`
* Checks for `argo_admin_beta` in `ArgoServe`, if beta is not required, we return, else, we add the required fields to the env

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrmenting this when releasing).
