### PR TITLE
Stub partners call when bypass flag is set

### DIFF
--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -56,9 +56,9 @@ module Script
               "appType" => "custom",
               "apiKey" => "stubbed-api-key",
               "apiSecretKeys" => [{ "secret" => "stubbed-api-secret" }],
-              "title" => "Fake App (Not connected to Partners)"
-            }
-          ]
+              "title" => "Fake App (Not connected to Partners)",
+            },
+          ],
         }
       end
 

--- a/test/project_types/script/tasks/ensure_env_test.rb
+++ b/test/project_types/script/tasks/ensure_env_test.rb
@@ -139,19 +139,18 @@ describe Script::Tasks::EnsureEnv do
           end
         end
 
-        describe "when the partners bypass flag is set" do
+        describe("when the partners bypass flag is set") do
           before do
             Script::Tasks::EnsureEnv.any_instance.stubs(:partner_proxy_bypass).returns(true)
           end
 
-          it "should not call partners to query for apps" do
+          it("should not call partners to query for apps") do
             ShopifyCli::PartnersAPI.expects(:query).never
             Script::Layers::Infrastructure::ScriptService.any_instance.expects(:get_app_scripts).returns([])
 
             subject
           end
         end
-
 
         describe("when asking app connection") do
           describe("when number of apps == 0") do


### PR DESCRIPTION
### WHY are these changes introduced?

When developing with Scripts locally, or when using a spin constellation, using Partners adds unnecessary friction.

For this reason we added a flag which bypasses the Partners proxy.

Even when this flag is on, we still authenticate with Partners to get a list of apps to use.

In the spin constellation environment, we don't have this option.

### WHAT is this pull request doing?

Before attempting to authenticate and call Partners, we check to see if the bypass flag is on. If it is, we put in fake app data.

When used in production, this will simply fail when attempting to contact production since the app information is nonsense.

When used in a spin environment, it will call script service directly and publish the script with the garbage API key. Along with another upcoming PR to return all App scripts regardless of api key in the Spin environment, this allows us to completely ignore Partners and Apps when working on Scripts.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
