### PR TITLE
[WIP] Replace toolchain-as bootstrap call with sparse checkout

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -28,16 +28,19 @@ shipping_filter:
 tax_filter:
   beta: true
   assemblyscript:
+    repo: "https://github.com/Shopify/extension-points.git"
     package: "@shopify/extension-point-as-tax-filter"
     sdk-version: "^9.0.0"
     toolchain-version: "^5.0.0"
 payment_methods:
   domain: 'checkout'
   assemblyscript:
+    repo: "https://github.com/Shopify/extension-points.git"
     package: "@shopify/scripts-checkout-apis"
     toolchain-version: "^5.0.0"
 shipping_methods:
   domain: 'checkout'
   assemblyscript:
+    repo: "https://github.com/Shopify/extension-points.git"
     package: "@shopify/scripts-checkout-apis"
     toolchain-version: "^5.0.0"

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -18,8 +18,22 @@ module Script
                 language: language,
                 no_config_ui: no_config_ui
               )
+
+              # the default value of this should be master
+              branch = "master"
+              # and be overwritten with a CLI argument - for now we'll just overwrite it here during dev
+              branch = "add-package-json"
+
               project_creator = Infrastructure::Languages::ProjectCreator
-                .for(ctx, language, extension_point, script_name, project.id)
+                .for(
+                  ctx, 
+                  language, 
+                  extension_point, 
+                  script_name, 
+                  project.id, 
+                  branch
+                  )
+
               install_dependencies(ctx, language, script_name, project_creator)
               bootstrap(ctx, project_creator)
               project
@@ -36,7 +50,7 @@ module Script
 
           def bootstrap(ctx, project_creator)
             UI::StrictSpinner.spin(ctx.message("script.create.creating")) do |spinner|
-              project_creator.bootstrap
+              # project_creator.bootstrap
               spinner.update_title(ctx.message("script.create.created"))
             end
           end

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -42,6 +42,8 @@ module Script
         class MetadataNotFoundError < ScriptProjectError; end
 
         class MetadataValidationError < ScriptProjectError; end
+
+        class ServiceFailureError < ScriptProjectError; end
       end
     end
   end

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -53,12 +53,13 @@ module Script
         end
 
         class ExtensionPointSDK
-          attr_reader :version, :beta, :package
+          attr_reader :version, :beta, :package, :repo
 
           def initialize(config)
             @beta = config["beta"] || false
             @package = config["package"]
             @version = config["package-version"]
+            @repo = config["repo"]
           end
 
           def beta?

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -16,7 +16,7 @@ module Script
           MIN_NODE_VERSION = "14.5.0" # kept because task_runner uses this
           ASC_ARGS = "-- --lib node_modules --optimize --use Date="
 
-          ORIGIN_BRANCH = "master"
+          ORIGIN_BRANCH = "add-package-json"
 
           def setup_dependencies
             # sparse checkout actions
@@ -25,13 +25,17 @@ module Script
             setup_sparse_checkout
             pull
             clean
+            set_script_name
 
             # TODO: files that should be in the repo, but arent yet
             write_npmrc
-            write_package_json
           end
 
           def bootstrap
+          end
+
+          def origin_branch
+            ORIGIN_BRANCH
           end
 
           def sparse_checkout_set_path
@@ -70,6 +74,14 @@ module Script
             FileUtils.copy_entry(source, path_to_project)
             ctx.rm_rf("packages")
             ctx.rm_rf(".git")
+          end
+
+          def set_script_name
+            config_file = "package.json"
+            upstream_name = "#{extension_point.type.gsub("_", "-")}-default"
+            contents = File.read(config_file)
+            new_contents = contents.sub(upstream_name, script_name)
+            File.write(config_file, new_contents)
           end
 
           def command_runner

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -113,12 +113,13 @@ module Script
           end
 
           def build_command
+            type = extension_point.dasherize_type
             domain = extension_point.domain
 
             if domain.nil?
               "#{BUILD} #{ASC_ARGS}"
             else
-              "#{BUILD} --domain #{domain} --ep #{extension_point.dasherize_type} #{ASC_ARGS}"
+              "#{BUILD} --domain #{domain} --ep #{type} #{ASC_ARGS}"
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -16,7 +16,7 @@ module Script
           MIN_NODE_VERSION = "14.5.0" # kept because task_runner uses this
           ASC_ARGS = "-- --lib node_modules --optimize --use Date="
 
-          ORIGIN_BRANCH = 'master'
+          ORIGIN_BRANCH = "master"
 
           def setup_dependencies
             # sparse checkout actions
@@ -55,16 +55,16 @@ module Script
             repo = extension_point.sdks.assemblyscript.repo
             command_runner.call("git remote add -f origin #{repo}")
           end
-  
+
           def setup_sparse_checkout
             command_runner.call("git config core.sparsecheckout true")
             command_runner.call("git sparse-checkout set #{sparse_checkout_set_path}")
           end
-          
+
           def pull
             command_runner.call("git pull origin #{ORIGIN_BRANCH}")
           end
-  
+
           def clean
             source = File.join(path_to_project, sparse_checkout_set_path)
             FileUtils.copy_entry(source, path_to_project)
@@ -113,13 +113,12 @@ module Script
           end
 
           def build_command
-            type = extension_point.dasherize_type
             domain = extension_point.domain
 
             if domain.nil?
               "#{BUILD} #{ASC_ARGS}"
             else
-              "#{BUILD} --domain #{domain} --ep #{type} #{ASC_ARGS}"
+              "#{BUILD} --domain #{domain} --ep #{extension_point.dasherize_type} #{ASC_ARGS}"
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -4,88 +4,12 @@ module Script
   module Layers
     module Infrastructure
       module Languages
-        class AssemblyScriptProjectCreator
-          include SmartProperties
-          property! :ctx, accepts: ShopifyCli::Context
-          property! :extension_point, accepts: Domain::ExtensionPoint
-          property! :script_name, accepts: String
-          property! :path_to_project, accepts: String
-
-          BUILD = "shopify-scripts-toolchain-as build --src src/shopify_main.ts " \
-          "--binary build/script.wasm --metadata build/metadata.json"
+        class AssemblyScriptProjectCreator < ProjectCreator
           MIN_NODE_VERSION = "14.5.0" # kept because task_runner uses this
-          ASC_ARGS = "-- --lib node_modules --optimize --use Date="
-
-          ORIGIN_BRANCH = "add-package-json"
 
           def setup_dependencies
-            # sparse checkout actions
-            git_init
-            setup_remote
-            setup_sparse_checkout
-            pull
-            clean
-            set_script_name
-
-            # TODO: files that should be in the repo, but arent yet
+            super
             write_npmrc
-          end
-
-          def bootstrap
-          end
-
-          def origin_branch
-            ORIGIN_BRANCH
-          end
-
-          def sparse_checkout_set_path
-            type = extension_point.dasherize_type
-            domain = extension_point.domain
-
-            if domain.nil?
-              "packages/default/extension-point-as-#{type}/assembly/sample"
-            else
-              "packages/#{domain}/samples/#{type}"
-            end
-          end
-
-          private
-
-          def git_init
-            command_runner.call("git init")
-          end
-
-          def setup_remote
-            repo = extension_point.sdks.assemblyscript.repo
-            command_runner.call("git remote add -f origin #{repo}")
-          end
-
-          def setup_sparse_checkout
-            command_runner.call("git config core.sparsecheckout true")
-            command_runner.call("git sparse-checkout set #{sparse_checkout_set_path}")
-          end
-
-          def pull
-            command_runner.call("git pull origin #{ORIGIN_BRANCH}")
-          end
-
-          def clean
-            source = File.join(path_to_project, sparse_checkout_set_path)
-            FileUtils.copy_entry(source, path_to_project)
-            ctx.rm_rf("packages")
-            ctx.rm_rf(".git")
-          end
-
-          def set_script_name
-            config_file = "package.json"
-            upstream_name = "#{extension_point.type.gsub("_", "-")}-default"
-            contents = File.read(config_file)
-            new_contents = contents.sub(upstream_name, script_name)
-            File.write(config_file, new_contents)
-          end
-
-          def command_runner
-            @command_runner ||= CommandRunner.new(ctx: ctx)
           end
 
           def write_npmrc
@@ -93,47 +17,6 @@ module Script
             command_runner.call("npm --userconfig ./.npmrc config set engine-strict true")
           end
 
-          def extension_point_version
-            return extension_point.sdks.assemblyscript.version if extension_point.sdks.assemblyscript.versioned?
-
-            out = command_runner.call("npm show #{extension_point.sdks.assemblyscript.package} version --json")
-            "^#{JSON.parse(out)}"
-          end
-
-          def write_package_json
-            package_json = <<~HERE
-              {
-                "name": "#{script_name}",
-                "version": "1.0.0",
-                "devDependencies": {
-                  "@shopify/scripts-sdk-as": "#{extension_point.sdks.assemblyscript.sdk_version}",
-                  "@shopify/scripts-toolchain-as": "#{extension_point.sdks.assemblyscript.toolchain_version}",
-                  "#{extension_point.sdks.assemblyscript.package}": "#{extension_point_version}",
-                  "@as-pect/cli": "^6.0.0",
-                  "assemblyscript": "^0.18.13"
-                },
-                "scripts": {
-                  "test": "asp --summary --verbose",
-                  "build": "#{build_command}"
-                },
-                "engines": {
-                  "node": ">=#{MIN_NODE_VERSION}"
-                }
-              }
-            HERE
-            ctx.write("package.json", package_json)
-          end
-
-          def build_command
-            type = extension_point.dasherize_type
-            domain = extension_point.domain
-
-            if domain.nil?
-              "#{BUILD} #{ASC_ARGS}"
-            else
-              "#{BUILD} --domain #{domain} --ep #{type} #{ASC_ARGS}"
-            end
-          end
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -11,22 +11,72 @@ module Script
           property! :script_name, accepts: String
           property! :path_to_project, accepts: String
 
-          BOOTSTRAP = "npx --no-install shopify-scripts-toolchain-as bootstrap --from %{extension_point} --dest %{base}"
           BUILD = "shopify-scripts-toolchain-as build --src src/shopify_main.ts " \
           "--binary build/script.wasm --metadata build/metadata.json"
-          MIN_NODE_VERSION = "14.5.0"
+          MIN_NODE_VERSION = "14.5.0" # kept because task_runner uses this
           ASC_ARGS = "-- --lib node_modules --optimize --use Date="
 
+          EP_REPO = "https://github.com/Shopify/extension-points.git"
+          ORIGIN_BRANCH = 'master'
+
           def setup_dependencies
+            # sparse checkout actions
+            git_init
+            setup_remote
+            setup_sparse_checkout
+            pull
+            clean
+
+            # TODO: files that should be in the repo, but arent yet
             write_npmrc
             write_package_json
           end
 
           def bootstrap
-            command_runner.call(bootstap_command)
           end
 
           private
+
+          def git_init
+            out, status = ctx.capture2e("git init")
+            raise Domain::Errors::ServiceFailureError, out unless status.success?
+          end
+
+          def setup_remote
+            out, status = ctx.capture2e("git remote add -f origin #{EP_REPO}")
+            raise Domain::Errors::ServiceFailureError, out unless status.success?
+          end
+  
+          def setup_sparse_checkout
+            out, status = ctx.capture2e("git config core.sparsecheckout true")
+            raise Domain::Errors::ServiceFailureError, out unless status.success?
+
+            out, status = ctx.capture2e("git sparse-checkout set #{sparse_checkout_set_path}")
+            raise Domain::Errors::ServiceFailureError, out unless status.success?
+          end
+
+          def sparse_checkout_set_path
+            type = extension_point.dasherize_type
+            domain = extension_point.domain
+
+            if domain.nil?
+              "packages/default/extension-point-as-#{type}/assembly/sample"
+            else
+              "packages/#{domain}/samples/#{type}"
+            end
+          end
+  
+          def pull
+            out, status = ctx.capture2e("git pull origin #{ORIGIN_BRANCH}")
+            raise Domain::Errors::ServiceFailureError, out unless status.success?
+          end
+  
+          def clean
+            source = File.join(path_to_project, sparse_checkout_set_path)
+            FileUtils.copy_entry(source, path_to_project)
+            ctx.rm_rf("packages")
+            ctx.rm_rf(".git")
+          end
 
           def command_runner
             @command_runner ||= CommandRunner.new(ctx: ctx)
@@ -66,18 +116,6 @@ module Script
               }
             HERE
             ctx.write("package.json", package_json)
-          end
-
-          def bootstap_command
-            type = extension_point.dasherize_type
-            base_command = format(BOOTSTRAP, extension_point: type, base: path_to_project)
-            domain = extension_point.domain
-
-            if domain.nil?
-              base_command
-            else
-              "#{base_command} --domain #{domain}"
-            end
           end
 
           def build_command

--- a/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
@@ -5,20 +5,82 @@ module Script
     module Infrastructure
       module Languages
         class ProjectCreator
-          PROJECT_CREATORS = {
-            "assemblyscript" => AssemblyScriptProjectCreator,
-            "rust" => RustProjectCreator,
-          }
+          include SmartProperties
+          property! :ctx, accepts: ShopifyCli::Context
+          property! :extension_point, accepts: Domain::ExtensionPoint
+          property! :script_name, accepts: String
+          property! :path_to_project, accepts: String
+          property! :branch, accepts: String
 
-          def self.for(ctx, language, extension_point, script_name, path_to_project)
-            raise Errors::ProjectCreatorNotFoundError unless PROJECT_CREATORS[language]
-            PROJECT_CREATORS[language].new(
+          def self.for(ctx, language, extension_point, script_name, path_to_project, branch)
+
+            project_creators = {
+              "assemblyscript" => AssemblyScriptProjectCreator,
+              "rust" => RustProjectCreator,
+            }
+
+            raise Errors::ProjectCreatorNotFoundError unless project_creators[language]
+            project_creators[language].new(
               ctx: ctx,
               extension_point: extension_point,
               script_name: script_name,
-              path_to_project: path_to_project
+              path_to_project: path_to_project,
+              branch: branch
             )
           end
+
+          # the sparse checkout process is common to all script types
+          def setup_dependencies
+            
+            setup_sparse_checkout
+
+            @config_files = {
+              "assemblyscript" => "package.json",
+              "rust" => "cargo.toml",
+            }
+
+            clean
+            set_script_name(@config_files["assemblyscript"])
+            
+          end
+
+          def setup_sparse_checkout
+            repo = extension_point.sdks.assemblyscript.repo
+            path = sparse_checkout_set_path
+            ShopifyCli::Git.sparse_checkout(repo, path, branch, ctx)
+          end
+
+          # this should be passed to the ProjectCreator, we shouldn't have to do it manually ourselves
+          def sparse_checkout_set_path
+            type = extension_point.dasherize_type
+            domain = extension_point.domain
+
+            if domain.nil?
+              "packages/default/extension-point-as-#{type}/assembly/sample"
+            else
+              "packages/#{domain}/samples/#{type}"
+            end
+          end
+
+          def set_script_name(config_file)
+
+            upstream_name = "#{extension_point.type.gsub("_", "-")}-default"
+            contents = File.read(config_file)
+            new_contents = contents.sub(upstream_name, script_name)
+            File.write(config_file, new_contents)
+          end
+
+          def clean
+            source = File.join(path_to_project, sparse_checkout_set_path)
+            FileUtils.copy_entry(source, path_to_project)
+            ctx.rm_rf("packages") #TODO - needs to be language agnostic
+            ctx.rm_rf(".git")
+          end
+
+          def command_runner
+            @command_runner ||= CommandRunner.new(ctx: ctx)
+          end
+          
         end
       end
     end

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -109,16 +109,32 @@ module ShopifyCli
 
         # init
         output, status = ctx.capture2e("git init")
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.repo_not_initiated"))
+        end
 
         # setup_remote
         output, status = ctx.capture2e("git remote add -f origin #{repo}")
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.remote_not_added"))
+        end
         
         # setup_sparse_checkout
         output, status = ctx.capture2e("git config core.sparsecheckout true")
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.sparse_checkout_not_enabled"))
+        end
+
         output, status = ctx.capture2e("git sparse-checkout set #{set}")
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.sparse_checkout_not_set"))
+        end
 
         # pull
         output, status = ctx.capture2e("git pull origin #{branch}")
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.pull_failed"))
+        end
 
       end
 

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -105,6 +105,23 @@ module ShopifyCli
         end
       end
 
+      def sparse_checkout(repo, set, branch, ctx)
+
+        # init
+        output, status = ctx.capture2e("git init")
+
+        # setup_remote
+        output, status = ctx.capture2e("git remote add -f origin #{repo}")
+        
+        # setup_sparse_checkout
+        output, status = ctx.capture2e("git config core.sparsecheckout true")
+        output, status = ctx.capture2e("git sparse-checkout set #{set}")
+
+        # pull
+        output, status = ctx.capture2e("git pull origin #{branch}")
+
+      end
+
       private
 
       def exec(*args, dir: Dir.pwd, default: nil, ctx: Context.new)

--- a/lib/shopify-cli/messages/messages.rb
+++ b/lib/shopify-cli/messages/messages.rb
@@ -85,6 +85,10 @@ module ShopifyCli
             repo_not_initiated:
               "Git repo is not initiated. Please run {{command:git init}} and make at least one commit.",
             no_commits_made: "No git commits have been made. Please make at least one commit.",
+            remote_not_added: "Remote could not be added.",
+            sparse_checkout_not_enabled: "Sparse checkout could not be enabled.",
+            sparse_checkout_not_set:"Sparse checkout set command failed.",
+            pull_failed: "Pull failed.",
           },
 
           cloning: "Cloning %s into %s...",

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
@@ -83,7 +83,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
 
       # moving files up to project root
-      type = extension_point.type
       source = File.join(project_creator.path_to_project, project_creator.sparse_checkout_set_path)
       FileUtils.expects(:copy_entry).with(source, project_creator.path_to_project)
 

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
@@ -61,7 +61,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .returns(system_output(msg: "", success: true))
       context
         .expects(:capture2e)
-        .with("git pull origin master")
+        .with("git pull origin #{project_creator.origin_branch}")
         .once
         .returns(system_output(msg: "", success: true))
 
@@ -75,20 +75,13 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .then.with("npm --userconfig ./.npmrc config set engine-strict true")
         .returns(fake_capture2e_response)
 
-      # package.json generation
-      context
-        .expects(:capture2e)
-        .with("npm show @shopify/extension-point-as-fake version --json")
-        .once
-        .returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
-
       # moving files up to project root
       source = File.join(project_creator.path_to_project, project_creator.sparse_checkout_set_path)
       FileUtils.expects(:copy_entry).with(source, project_creator.path_to_project)
 
-      # confirm package.json - only once this file is checked into the repo
-      # File.expects(:read).with("package.json").returns("name = payment-filter-default")
-      # File.expects(:write).with("package.json", "name = #{script_name}")
+      # confirm package.json
+      File.expects(:read).with("package.json").returns("name: payment-methods-default")
+      File.expects(:write).with("package.json", "name: #{script_name}")
 
       # clean-up git files
       context.expects(:rm_rf).with(".git")
@@ -143,7 +136,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
       context.expects(:capture2e).times(4).returns(system_output(msg: "", success: true))
       context
         .expects(:capture2e)
-        .with("git pull origin master")
+        .with("git pull origin #{project_creator.origin_branch}")
         .once
         .returns(system_output(msg: "Fatal", success: false))
       assert_raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError) { subject }

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -105,6 +105,39 @@ module ShopifyCli
       end
     end
 
+    def test_sparse_checkout
+      repo = "git@github.com:shopify/test.git"
+      set = "packages/"
+      branch = "fake-branch"
+
+      @context.expects(:capture2e)
+        .with("git init")
+        .once
+        .returns(["", @status_mock[:true]])
+      @context
+        .expects(:capture2e)
+        .with("git remote add -f origin #{repo}")
+        .once
+        .returns(["", @status_mock[:true]])        
+      @context
+        .expects(:capture2e)
+        .with("git config core.sparsecheckout true")
+        .once
+        .returns(["", @status_mock[:true]])
+      @context
+        .expects(:capture2e)
+        .with("git sparse-checkout set #{set}")
+        .returns(["", @status_mock[:true]])
+      @context
+        .expects(:capture2e)
+        .with("git pull origin #{branch}")
+        .returns(["", @status_mock[:true]])
+
+      ShopifyCli::Git.sparse_checkout(repo, set, branch, @context)
+    end
+    
+    
+
     private
 
     def in_repo


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/2610.  
This is the swap over from using the toolchain's bootstrap command with sparse checkout.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- [X] Checks out the sample code directories from the EP repo based on the type of script
- [X] Updates the AssemblyScriptProjectCreator tests
- [x] Adds additional AssemblyScriptProjectCreator tests (package.json checkout)
- [ ] Waits for the related repo to be public

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
