### PR TITLE
require at least node version 16.1 for argo extensions

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -95,6 +95,8 @@ module Extension
           missing_file_error: "Could not find built extension file.",
           script_prepare_error: "An error occurred while attempting to prepare your script.",
           initialization_error: "{{x}} There was an error while initializing the project.",
+          error_listing_dependencies: "An error occurred while preparing your script. "\
+            "You may need to run `npm prune` to fix your dependencies, or update Node to at least v16.1.0.",
           dependencies: {
             node: {
               node_not_installed: "Node must be installed to create this extension.",

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -138,6 +138,14 @@ module Extension
         end
       end
 
+      def test_config_aborts_with_error_if_npm_list_fails
+        with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
+          Tasks::FindNpmPackages.expects(:exactly_one_of).raises(RuntimeError)
+          error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+          assert_includes error.message, @context.message("features.argo.error_listing_dependencies")
+        end
+      end
+
       def test_runs_yarn_install_and_yarn_run_script_if_the_package_manager_is_yarn
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
           ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes:
https://github.com/Shopify/argo-private/issues/1586
https://github.com/Shopify/argo-private/issues/1546

`shopify push` fails on some extensions with a version of node less than v16.1.0, due to an issue with how earlier versions of node install packages (see issue for more info).

### WHAT is this pull request doing?

* Checks current version of node installed, if the version installed is less than the version required (v16.1.0), the user will see an error prompting them to update their node version
* Added a rescue for the RuntimeError users were experiencing as a result of `npm list` erroring out, which will return an error prompting the user to run `npm prune` or update their version of Node.

### Tophat 🎩 

A new product subscription extension:

* Using nvm, install a Node version prior to v16.1.0
* Run `nvm use` and set your Node version to the version you set in the previous step
* Create a **new** product subscription extension with `shopify create extension`

You will see an error message asking you to upgrade your version of Node:

<img width="1139" alt="Screen Shot 2021-06-15 at 5 06 28 PM" src="https://user-images.githubusercontent.com/989784/122129692-156f4b00-cdfc-11eb-912b-b47556f8dd6e.png">

An existing product subscription extension:

* `cd` into the extension
* Using nvm, set your Node version to something lower than v16.1.0
* Run `shopify register` and `shopify push`

You will see the new error message asking you to run `npm prune` or update your version of Node:

<img width="1586" alt="Screen Shot 2021-06-15 at 3 46 18 PM" src="https://user-images.githubusercontent.com/989784/122127460-d095e500-cdf8-11eb-94f6-656c855e37a1.png">

* Now set your Node version with nvm to something higher than or equal to `v16.1.0`
* Run `shopify push`
* Notice the extension now pushes successfully

<img width="1560" alt="Screen Shot 2021-06-15 at 5 00 43 PM" src="https://user-images.githubusercontent.com/989784/122129112-3edba700-cdfb-11eb-8dcd-d7f9898c7037.png">

A new checkout extension:

* Run `shopify create extension` and create a new checkout extension

The extension should be created successfully even if you're on an older version of Node:

<img width="1373" alt="Screen Shot 2021-06-15 at 2 52 47 PM" src="https://user-images.githubusercontent.com/989784/122129272-75b1bd00-cdfb-11eb-829c-609401acacdd.png">

`shopify serve`, `shopify register` and `shopify push` will also work as expected.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
