### PR TITLE
Connect to spin instance when env variables are present

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -97,7 +97,6 @@ module Script
             tokens = { "APP_KEY" => api_key }.compact.to_json
             { "X-Shopify-Authenticated-Tokens" => tokens }
           end
-
         end
         private_constant(:ScriptServiceAPI)
 
@@ -110,13 +109,17 @@ module Script
         private_constant(:PartnersProxyAPI)
 
         def script_service_request(query_name:, variables: nil, **options)
-          resp = if ENV["BYPASS_PARTNERS_PROXY"]
+          resp = if bypass_partners_proxy
             ScriptServiceAPI.query(ctx, query_name, variables: variables, **options)
           else
             proxy_through_partners(query_name: query_name, variables: variables, **options)
           end
           raise_if_graphql_failed(resp)
           resp
+        end
+
+        def bypass_partners_proxy
+          !ENV["BYPASS_PARTNERS_PROXY"].nil?
         end
 
         def proxy_through_partners(query_name:, variables: nil, **options)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -69,23 +69,35 @@ module Script
         class ScriptServiceAPI < ShopifyCli::API
           property(:api_key, accepts: String)
 
+          LOCAL_INSTANCE_URL = "https://script-service.myshopify.io"
+
           def self.query(ctx, query_name, api_key: nil, variables: {})
             api_client(ctx, api_key).query(query_name, variables: variables)
           end
 
           def self.api_client(ctx, api_key)
+            instance_url = spin_instance_url || LOCAL_INSTANCE_URL
             new(
               ctx: ctx,
-              url: "https://script-service.myshopify.io/graphql",
+              url: "#{instance_url}/graphql",
               token: "",
               api_key: api_key
             )
+          end
+
+          def self.spin_instance_url
+            workspace = ENV["SPIN_WORKSPACE"]
+            namespace = ENV["SPIN_NAMESPACE"]
+            return if workspace.nil? || namespace.nil?
+
+            "https://script-service.#{workspace}.#{namespace}.us.spin.dev"
           end
 
           def auth_headers(*)
             tokens = { "APP_KEY" => api_key }.compact.to_json
             { "X-Shopify-Authenticated-Tokens" => tokens }
           end
+
         end
         private_constant(:ScriptServiceAPI)
 

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -14,8 +14,12 @@ module ShopifyCli
       end
 
       def request(uri, body, headers, req)
+        cert_store = OpenSSL::X509::Store.new
+        cert_store.set_default_paths
+
         http = ::Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
+        http.cert_store = cert_store
 
         req.body = body unless body.nil?
         req["Content-Type"] = "application/json"

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -1,4 +1,5 @@
 require "net/http"
+require "openssl"
 
 module ShopifyCli
   class HttpRequest

--- a/lib/shopify-cli/http_request.rb
+++ b/lib/shopify-cli/http_request.rb
@@ -21,6 +21,7 @@ module ShopifyCli
         http = ::Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
         http.cert_store = cert_store
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE if ENV["SSL_VERIFY_NONE"]
 
         req.body = body unless body.nil?
         req["Content-Type"] = "application/json"

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -26,6 +26,10 @@ describe Script::Layers::Infrastructure::ScriptService do
     HERE
   end
 
+  before do
+    script_service.stubs(:bypass_partners_proxy).returns(false)
+  end
+
   describe ".push" do
     let(:script_name) { "foo_bar" }
     let(:script_content) { "(module)" }


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/script-service/issues/3074

We're building out a spin environment to use for the scripts platform.

One part of this is the ability to target an instance of script service running on spin from your local cli instance.

### WHAT is this pull request doing?

Adding in some environment checks which allow you to call directly to script service running in a spin workspace.

Example usage:
```
BYPASS_PARTNERS_PROXY=1 SPIN_WORKSPACE=nv01 SPIN_NAMESPACE=duncan-uszkay shopify push
```

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Change is not public facing
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
