### PR TITLE
Fix call to undefined method when running `theme serve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1298](https://github.com/Shopify/shopify-cli/pull/1298): Fix error in `theme serve` command
 
 Version 2.0.0
 -------------

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -10,7 +10,9 @@ module Theme
 
       def call(*)
         flags = options.flags.dup
-        ShopifyCli::Theme::DevServer.start(@ctx, ".", **flags)
+        ShopifyCli::Theme::DevServer.start(@ctx, ".", **flags) do |syncer|
+          UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
+        end
       end
 
       def self.help

--- a/lib/shopify-cli/theme/dev_server.rb
+++ b/lib/shopify-cli/theme/dev_server.rb
@@ -20,7 +20,7 @@ module ShopifyCli
       class << self
         attr_accessor :ctx
 
-        def start(ctx, root, port: 9292, silent: false)
+        def start(ctx, root, port: 9292)
           @ctx = ctx
           theme = DevelopmentTheme.new(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
@@ -43,10 +43,10 @@ module ShopifyCli
           CLI::UI::Frame.open(@ctx.message("theme.serve.serve")) do
             ctx.print_task("Syncing theme ##{theme.id} on #{theme.shop}")
             @syncer.start_threads
-            if silent
-              @syncer.upload_theme!(delay_low_priority_files: true)
+            if block_given?
+              yield @syncer
             else
-              @syncer.upload_theme_with_progress_bar!(delay_low_priority_files: true)
+              @syncer.upload_theme!(delay_low_priority_files: true)
             end
 
             return if stopped

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -176,7 +176,7 @@ module ShopifyCli
         def start_server
           @ctx = TestHelpers::FakeContext.new(root: "#{ShopifyCli::ROOT}/test/fixtures/theme")
           @server_thread = Thread.new do
-            DevServer.start(@ctx, "#{ShopifyCli::ROOT}/test/fixtures/theme", port: @@port, silent: true)
+            DevServer.start(@ctx, "#{ShopifyCli::ROOT}/test/fixtures/theme", port: @@port)
           rescue Exception => e
             puts "Failed to start DevServer:"
             puts e.message


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Issue reported by a partner:

```
Traceback (most recent call last):
[...]
         3: from /Users/harryfrancis/.rvm/gems/ruby-2.7.2/gems/shopify-cli-2.0.0/lib/project_types/theme/commands/serve.rb:13:in `call'
         2: from /Users/harryfrancis/.rvm/gems/ruby-2.7.2/gems/shopify-cli-2.0.0/lib/shopify-cli/theme/dev_server.rb:43:in `start'
         1: from /Users/harryfrancis/.rvm/gems/ruby-2.7.2/gems/shopify-cli-2.0.0/vendor/deps/cli-ui/lib/cli/ui/frame.rb:103:in `open'
/Users/harryfrancis/.rvm/gems/ruby-2.7.2/gems/shopify-cli-2.0.0/lib/shopify-cli/theme/dev_server.rb:49:in `block in start': undefined method `upload_theme_with_progress_bar!' for #<ShopifyCli::Theme::Syncer:0x00007fa3cd2f2b78> (NoMethodError)
```

### WHAT is this pull request doing?

Updating to the new API for using the upload progress bar.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
