### PR TITLE
handle missing env error

### DIFF
--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -49,6 +49,7 @@ module Extension
     end
 
     def app
+      validate_env_present
       Models::App.new(api_key: env["api_key"], secret: env["secret"])
     end
 
@@ -107,7 +108,13 @@ module Extension
     end
 
     def property_present?(key)
+      validate_env_present
       !env[key].nil? && !env[key].strip.empty?
+    end
+
+    def validate_env_present
+      return if env
+      raise ShopifyCli::Abort, "Missing .env file. Run `shopify extension connect` to generate an .env file."
     end
 
     def integer?(value)

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -139,6 +139,15 @@ module Extension
       end
     end
 
+    def test_missing_env_file_raises_error_when_accessing_app_attributes
+      project = ExtensionProject.new
+      refute File.exist?(".env")
+
+      assert_raises CLI::Kit::Abort do
+        project.app
+      end
+    end
+
     private
 
     def valid_env_file_attributes_without(*keys)


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-cli/issues/1302

### WHAT is this pull request doing?

* Show an error to the end user letting them know they need to create an `.env` file by running `shopify extension connect` for commands that require env values.

### Reviewer's hat rack 🎩 

* Create a new extension with `shopify extension create`
* `cd` into the project
* remove the env file with `rm .env`
* try running any extension command
* you should see the error alerting you to run `shopify extension connect`

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
