### PR TITLE
only rescue Timeout::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [1305](https://github.com/Shopify/shopify-cli/pull/1305): Fix `Uninitialized constant Net::WriteTimeout` error
 
 Version 2.0.1
 -------------

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -81,7 +81,7 @@ module ShopifyCli
         else
           raise APIRequestUnexpectedError.new("#{response.code}\n#{response.body}", response: response)
         end
-      rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout, Errno::ETIMEDOUT, Timeout::Error
+      rescue Errno::ETIMEDOUT, Timeout::Error
         raise APIRequestTimeoutError.new("Timeout")
       end.retry_after(APIRequestRetriableError, retries: 3) do |e|
         sleep(1) if e.is_a?(APIRequestThrottledError)


### PR DESCRIPTION
### WHY are these changes introduced?

When running commands that make API calls, intermittent `uninitialized constant Net::WriteTimeout` errors occur. (Ruby version: `ruby 2.6.3p62`).

### WHAT is this pull request doing?

`Timeout::Error` is a parent of `Net::WriteTimeout` and `Net::ReadTimeout`, so just catching `Timeout::Error` instead of all its children fixes the issue for me.

If there's a better approach, I'm open to it! :) 

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
