### PR TITLE
[Checkout Extensibility] Cleanup checkout_argo_extension extension type

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -76,7 +76,6 @@ module Extension
   module Models
     module SpecificationHandlers
       autoload :Default, Project.project_filepath("models/specification_handlers/default")
-      autoload :CheckoutArgoExtension, Project.project_filepath("models/specification_handlers/checkout_ui_extension")
     end
 
     autoload :App, Project.project_filepath("models/app")

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -13,8 +13,6 @@ module Extension
           }
         end
       end
-
-      CheckoutArgoExtension = CheckoutUiExtension
     end
   end
 end


### PR DESCRIPTION
~We have to migrate existing early access partners using `CHECKOUT_ARGO_EXTENSION` before merging this PR.~

### WHY are these changes introduced?

Fixes https://github.com/Shopify/argo-private/issues/1581

Now that the `checkout_argo_extension` type is not used anymore by partners and all early access partners have been migrated to the new `checkout_ui_extension` type, this PR is removing all references to the legacy type.

### WHAT is this pull request doing?

Cleaning up references to `checkout_argo_extension`.

### Update checklist
- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public facing since partners will not see this change given they were already migrated to the new type.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
