### PR TITLE
require store for checkout extensions

### DIFF
--- a/lib/project_types/extension/features/argo_runtime.rb
+++ b/lib/project_types/extension/features/argo_runtime.rb
@@ -19,6 +19,7 @@ module Extension
       CHECKOUT_RUN_FLAGS = [
         :port,
         :public_url,
+        :shop,
       ]
 
       property! :renderer, accepts: Models::NpmPackage

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -46,6 +46,7 @@ module Extension
           checkout: {
             git_template: "https://github.com/Shopify/checkout-ui-extensions-template",
             renderer_package_name: "@shopify/checkout-ui-extensions",
+            required_fields: [:shop],
             cli_package_name: "@shopify/checkout-ui-extensions-run",
           },
         }

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -64,7 +64,7 @@ module Extension
 
       def test_supports_shop
         runtimes = {
-          checkout_runtime => does_not_support_feature,
+          checkout_runtime => supports_feature,
           admin_runtime => supports_feature,
         }
 

--- a/test/project_types/extension/tasks/configure_features_test.rb
+++ b/test/project_types/extension/tasks/configure_features_test.rb
@@ -66,6 +66,13 @@ module Extension
         assert_equal "@shopify/checkout-ui-extensions", result.value.dig(0, :features, :argo, :renderer_package_name)
       end
 
+      def test_correct_required_fields_are_configured_for_checkout_extensions
+        set_of_attributes = build_set_of_specification_attributes(surface: "checkout")
+        result = ConfigureFeatures.call(set_of_attributes)
+        checkout_required_fields = [:shop]
+        assert_equal checkout_required_fields, result.value.dig(0, :features, :argo, :required_fields)
+      end
+
       private
 
       def build_set_of_specification_attributes(surface: "admin")


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/ui-extensions-private/issues/1618

### WHAT is this pull request doing?

* Require `shop` field for checkout extensions
* `EnsureDevStore` is called on `extension serve` for checkout extensions
* `--store` flag is populated correctly and massed down to the node process

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
