### PR TITLE
Fix `theme pull` no pulling files that have no remote checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 * [#1324](https://github.com/Shopify/shopify-cli/pull/1324): Fix issue [#1308](https://github.com/Shopify/shopify-cli/issues/1308) where a non-English language on Partner Account breaks how CLI determines latest API version.
 * [#1322](https://github.com/Shopify/shopify-cli/pull/1322): Fix error when running `shopify theme language-server --help`
 * [#1321](https://github.com/Shopify/shopify-cli/pull/1321): Fix error when pulling images with `theme pull`
+* [#1319](https://github.com/Shopify/shopify-cli/pull/1319): Fix `theme pull` not pulling some files
 
 Version 2.0.1
 -------------

--- a/lib/shopify-cli/theme/dev_server/local_assets.rb
+++ b/lib/shopify-cli/theme/dev_server/local_assets.rb
@@ -72,7 +72,7 @@ module ShopifyCli
         def replace_asset_urls(body)
           replaced_body = body.join.gsub(ASSET_REGEX) do |match|
             path = Pathname.new(Regexp.last_match[1])
-            if @theme.asset_paths.include?(path)
+            if @theme.static_asset_paths.include?(path)
               "/#{path}"
             else
               match

--- a/lib/shopify-cli/theme/syncer.rb
+++ b/lib/shopify-cli/theme/syncer.rb
@@ -149,7 +149,7 @@ module ShopifyCli
         # Process lower-priority files in the background
 
         # Assets are served locally, so can be uploaded in the background
-        enqueue_updates(@theme.asset_files)
+        enqueue_updates(@theme.static_asset_files)
 
         unless delay_low_priority_files
           wait!(&block)
@@ -281,7 +281,7 @@ module ShopifyCli
 
       def update_checksums(api_response)
         api_response.values.flatten.each do |asset|
-          if asset["key"] && asset["checksum"]
+          if asset["key"]
             @checksums[asset["key"]] = asset["checksum"]
           end
         end

--- a/lib/shopify-cli/theme/theme.rb
+++ b/lib/shopify-cli/theme/theme.rb
@@ -20,11 +20,11 @@ module ShopifyCli
       end
 
       def theme_files
-        glob(["**/*.liquid", "**/*.json", "assets/*"])
+        glob(["**/*.liquid", "**/*.json", "assets/*"]).uniq
       end
 
-      def asset_files
-        glob("assets/*")
+      def static_asset_files
+        glob("assets/*").reject(&:liquid?)
       end
 
       def liquid_files
@@ -43,8 +43,8 @@ module ShopifyCli
         theme_files.include?(self[file])
       end
 
-      def asset_paths
-        asset_files.map(&:relative_path)
+      def static_asset_paths
+        static_asset_files.map(&:relative_path)
       end
 
       def [](file)

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -12,8 +12,8 @@ module ShopifyCli
         @theme = Theme.new(@ctx, root: root, id: "123")
       end
 
-      def test_assets
-        assert_includes(@theme.asset_paths, Pathname.new("assets/theme.css"))
+      def test_static_assets
+        assert_includes(@theme.static_asset_paths, Pathname.new("assets/theme.css"))
       end
 
       def test_theme_files


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Theme files that have no checksums returned by the API were not pulled.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Remove the check that required a checksum to be present.

Also fix duplicated theme files being pull or pushed.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
