### PR TITLE
Change how latest api version is determined, fixes 1308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
-* [1305](https://github.com/Shopify/shopify-cli/pull/1305): Fix `Uninitialized constant Net::WriteTimeout` error
+* [#1305](https://github.com/Shopify/shopify-cli/pull/1305): Fix `Uninitialized constant Net::WriteTimeout` error
+* [#1324](https://github.com/Shopify/shopify-cli/pull/1324): Fix issue [#1308](https://github.com/Shopify/shopify-cli/issues/1308) where a non-English language on Partner Account breaks how CLI determines latest API version.
 
 Version 2.0.1
 -------------

--- a/lib/graphql/api_versions.graphql
+++ b/lib/graphql/api_versions.graphql
@@ -1,6 +1,6 @@
 query {
   publicApiVersions {
     handle
-    displayName
+    supported
   }
 }

--- a/lib/shopify-cli/admin_api.rb
+++ b/lib/shopify-cli/admin_api.rb
@@ -134,8 +134,12 @@ module ShopifyCli
         )
         CLI::Kit::Util.begin do
           versions = client.query("api_versions")["data"]["publicApiVersions"]
-          latest = versions.find { |version| version["displayName"].include?("Latest") }
-          latest["handle"]
+          # return the most recent supported version
+          versions
+            .select { |version| version["supported"] }
+            .map { |version| version["handle"] }
+            .sort
+            .reverse[0]
         end.retry_after(API::APIRequestUnauthorizedError, retries: 1) do
           ShopifyCli::IdentityAuth.new(ctx: ctx).reauthenticate
         end

--- a/lib/shopify-cli/api.rb
+++ b/lib/shopify-cli/api.rb
@@ -108,7 +108,7 @@ module ShopifyCli
       {
         "User-Agent" => "Shopify CLI; v=#{ShopifyCli::VERSION}",
         "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCli::VERSION} sha=#{ShopifyCli.sha}",
-        "Sec-CH-UA-PLATFORM" => ctx.os,
+        "Sec-CH-UA-PLATFORM" => ctx.os.to_s,
       }.tap do |headers|
         headers["X-Shopify-Cli-Employee"] = "1" if Shopifolk.acting_as_shopify_organization?
       end.merge(auth_headers(token))

--- a/test/fixtures/api/versions.json
+++ b/test/fixtures/api/versions.json
@@ -3,15 +3,18 @@
     "publicApiVersions": [
       {
         "handle": "2019-04",
-        "displayName": "2019-04 (Latest)"
+        "displayName": "2019-04 (Latest)",
+        "supported": true
       },
       {
         "handle": "2019-07",
-        "displayName": "2019-07 (Release candidate)"
+        "displayName": "2019-07 (Release candidate)",
+        "supported": false
       },
       {
         "handle": "unstable",
-        "displayName": "unstable"
+        "displayName": "unstable",
+        "supported": false
       }
     ]
   }

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -34,7 +34,7 @@ module ShopifyCli
       headers = {
         "User-Agent" => "Shopify CLI; v=#{ShopifyCli::VERSION}",
         "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCli::VERSION} sha=#{ShopifyCli.sha}",
-        "Sec-CH-UA-PLATFORM" => @context.os,
+        "Sec-CH-UA-PLATFORM" => @context.os.to_s,
         "Auth" => "faketoken",
       }
       uri = URI.parse("https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json")


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1308

### WHAT is this pull request doing?

Previously, the latest API version was determined by looking for the displayName that had "Latest" in it - this only works when Partner account preferred language is English.
Now it's determined by reverse sorting the list of handles (ignoring "unstable") and picking the second on the list (the first will be the proposed version).

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).