### PR TITLE
changed graphql parameter field type to non-nullable

### DIFF
--- a/lib/project_types/script/graphql/app_script_update_or_create.graphql
+++ b/lib/project_types/script/graphql/app_script_update_or_create.graphql
@@ -9,9 +9,9 @@ mutation AppScriptUpdateOrCreate(
   $schemaMinorVersion: String,
   $useMsgpack: Boolean,
   $uuid: String,
-  $configurationUi: Boolean,
-  $scriptJsonVersion: String,
-  $configurationDefinition: String,
+  $configurationUi: Boolean!,
+  $scriptJsonVersion: String!,
+  $configurationDefinition: String!,
 ) {
   appScriptUpdateOrCreate(
     extensionPointName: $extensionPointName


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3380

`appScriptUpdateOrCreate` query fields `configurationDefinition`, `scriptJsonVersion` and `configurationUi` should not be nullable anymore. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
