### PR TITLE
Added link to theme kit migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ Run:
 
 To start the server. The server includes hot reload for CSS & Sections.
 
+**Note:** Shopify CLI is the recommended and officially supported tool for developing Themes and creating CI/CD workflows.  Please refer to the [Theme Kit Migration Guide](https://github.com/Shopify/shopify-cli/blob/main/THEMEKIT_MIGRATION.md) for details.
+
 ### Contributing
 
-Shopify CLI is an [open source tool](https://github.com/Shopify/shopify-cli/blob/main/.github/LICENSE.md) and everyone is welcome to help the community by [contributing](https://github.com/Shopify/shopify-cli/blob/main/.github/CONTRIBUTING.md) to the project.
+Shopify CLI is an [open source tool](https://github.com/Shopify/shopify-cli/blob/main/LICENSE) and everyone is welcome to help the community by [contributing](https://github.com/Shopify/shopify-cli/blob/main/.github/CONTRIBUTING.md) to the project.
 
 ### Where to get help
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Run:
 
 To start the server. The server includes hot reload for CSS & Sections.
 
-**Note:** Shopify CLI is the recommended and officially supported tool for developing Themes and creating CI/CD workflows.  Please refer to the [Theme Kit Migration Guide](https://github.com/Shopify/shopify-cli/blob/main/THEMEKIT_MIGRATION.md) for details.
+**Note:** Shopify CLI is the recommended and officially supported tool for developing themes and creating CI/CD workflows. Please refer to the [Theme Kit Migration Guide](https://github.com/Shopify/shopify-cli/blob/main/THEMEKIT_MIGRATION.md) for details.
 
 ### Contributing
 


### PR DESCRIPTION
### WHY are these changes introduced?

Added link to [theme kit migration guide](THEMEKIT_MIGRATION.md) to `README.md`

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing) - n/a
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows) - n/a
- [ ] I've left the version number as is (we'll handle incrementing this when releasing) - n/a