### PR TITLE
Manually populate monorail data for theme commmands

### DIFF
--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -90,7 +90,7 @@ module ShopifyCli
           {
             schema_id: INVOCATIONS_SCHEMA,
             payload: {
-              project_type: Project.current_project_type.to_s,
+              project_type: commands[0] == "theme" ? "theme" : Project.current_project_type.to_s,
               command: commands.join(" "),
               args: args.join(" "),
               time_start: start_time,
@@ -109,6 +109,8 @@ module ShopifyCli
                 project = Project.current(force_reload: true)
                 payload[:api_key] = project.env&.api_key
                 payload[:partner_id] = project.config["organization_id"]
+              else
+                payload[:partner_id] = ShopifyCli::DB.get(:organization_id)
               end
               payload[:metadata] = JSON.dump(metadata) unless metadata.empty?
             end,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Since theme projects do not use `.shopify-cli.yml` file, some monorail data is missing. This PR adds `project_type` and `partner_id` in.

What the monorail payload looks like now for theme commands:
![image](https://user-images.githubusercontent.com/30154753/124796065-bd20fa00-df1e-11eb-8661-ec9166384d5f.png)
 

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
