### PR TITLE
Add `extension check` command for checking theme app extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 * [#1322](https://github.com/Shopify/shopify-cli/pull/1322): Fix error when running `shopify theme language-server --help`
 * [#1324](https://github.com/Shopify/shopify-cli/pull/1324): Fix issue [#1308](https://github.com/Shopify/shopify-cli/issues/1308) where a non-English language on Partner Account breaks how CLI determines latest API version.
 * [#1343](https://github.com/Shopify/shopify-cli/pull/1343): Fix inconsistent use of periods vs ellipsis in messages. This replaces periods with ellipsis.
+* [#1352](https://github.com/Shopify/shopify-cli/pull/1352): Add `shopify extension check` for checking theme app extensions
 
 Version 2.0.1
 -------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     shopify-cli (2.0.1)
       listen (~> 3.5)
-      theme-check (~> 1.0)
+      theme-check (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -76,7 +76,7 @@ GEM
     rubocop-shopify (2.0.1)
       rubocop (~> 1.11)
     ruby-progressbar (1.11.0)
-    theme-check (1.0.0)
+    theme-check (1.1.0)
       liquid (>= 5.0.1)
       nokogumbo
     timecop (0.9.2)

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -24,6 +24,7 @@ module Extension
     subcommand :Serve, "serve", Project.project_filepath("commands/serve")
     subcommand :Push, "push", Project.project_filepath("commands/push")
     subcommand :Tunnel, "tunnel", Project.project_filepath("commands/tunnel")
+    subcommand :Check, "check", Project.project_filepath("commands/check")
   end
   ShopifyCli::Commands.register("Extension::Command", "extension")
 

--- a/lib/project_types/extension/commands/check.rb
+++ b/lib/project_types/extension/commands/check.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "theme_check"
+
+module Extension
+  class Command
+    class Check < ExtensionCommand
+      class CheckOptions < ShopifyCli::Options
+        def initialize(ctx, theme_check)
+          super()
+          @theme_check = theme_check
+          @ctx = ctx
+        end
+
+        def parse(_options_block, args)
+          # Check if .theme-check.yml exists, or if another -C has been passed on the command line
+          unless args.include?("-C") || @ctx.file_exist?(".theme-check.yml")
+            args += ["-C", ":theme_app_extension"]
+          end
+          @theme_check.parse(args)
+        end
+      end
+
+      def initialize(*)
+        super
+        if project.specification_identifier == "THEME_APP_EXTENSION"
+          @theme_check = ThemeCheck::Cli.new
+          self.options = CheckOptions.new(@ctx, @theme_check)
+        end
+      end
+
+      def call(*)
+        if project.specification_identifier == "THEME_APP_EXTENSION"
+          @theme_check.run
+        else
+          @ctx.abort(@ctx.message("check.unsupported", project.specification_identifier))
+        end
+      end
+
+      def self.help
+        ShopifyCli::Context.message("check.help", ShopifyCli::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -139,6 +139,10 @@ module Extension
               Usage: {{command:%1$s extension tunnel status}}
         HELP
       },
+      check: {
+        help: "Check your extension for errors, suggestions, and best practices.",
+        unsupported: "{{red:%s projects are not supported for `extension check`}}",
+      },
       features: {
         argo: {
           missing_file_error: "Could not find built extension file.",

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -44,5 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest", "~> 5.0")
 
   spec.add_dependency("listen", "~> 3.5")
-  spec.add_dependency("theme-check", "~> 1.0")
+  spec.add_dependency("theme-check", "~> 1.1")
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Allows theme app extension developers to run theme-check against their extension code by running `shopify extension check` in their project directory.

Fixes https://github.com/Shopify/shopify/issues/294975

### WHAT is this pull request doing?

Bumps the version of theme-check we need to 1.1.0, which includes support for Theme App Extensions

The check command checks for a few things:
* Does a .theme-check.yml file exist?
* Has the user specified a -C parameter on the command line?

If neither of these is true, then we add `-C :theme_app_extension` to the options we pass to theme check, so that the default behaviour is to use the built-in theme app extension configuration.

Initially I wanted to have this behaviour specified within the theme_app_extension specification handler. I couldn't figure out how to do this easily, since the current model needs to query shopify for the current list of supported extensions before instantiating the handler objects. I didn't want every invocation of `shopify extension check` to require a network call to shopify, so I hardcoded `if project.specification_identifier == "THEME_APP_EXTENSION"` in a few places.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/54458/124809372-0cbaf200-df2e-11eb-8ffa-f92d7f86ade7.png">

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
