### PR TITLE
introduce extension runtimes

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -62,6 +62,12 @@ module Extension
   end
 
   module Features
+    module Runtimes
+      autoload :Admin, Project.project_filepath("features/runtimes/admin")
+      autoload :Base, Project.project_filepath("features/runtimes/base")
+      autoload :CheckoutPostPurchase, Project.project_filepath("features/runtimes/checkout_post_purchase")
+      autoload :CheckoutUiExtension, Project.project_filepath("features/runtimes/checkout_ui_extension")
+    end
     autoload :ArgoServe, Project.project_filepath("features/argo_serve")
     autoload :ArgoServeOptions, Project.project_filepath("features/argo_serve_options")
     autoload :ArgoSetup, Project.project_filepath("features/argo_setup")

--- a/lib/project_types/extension/features/argo_runtime.rb
+++ b/lib/project_types/extension/features/argo_runtime.rb
@@ -1,46 +1,14 @@
 module Extension
   module Features
     class ArgoRuntime
-      include SmartProperties
-
-      UI_EXTENSIONS_CHECKOUT_RUN = "@shopify/checkout-ui-extensions-run"
-      UI_EXTENSIONS_ADMIN_RUN = "@shopify/admin-ui-extensions-run"
-
-      ADMIN_RUN_FLAGS = [
-        :api_key,
-        :name,
-        :port,
-        :public_url,
-        :renderer_version,
-        :shop,
-        :uuid,
+      RUNTIMES = [
+        Runtimes::Admin.new,
+        Runtimes::CheckoutPostPurchase.new,
+        Runtimes::CheckoutUiExtension.new,
       ]
 
-      CHECKOUT_RUN_FLAGS = [
-        :port,
-        :public_url,
-      ]
-
-      property! :renderer, accepts: Models::NpmPackage
-      property! :cli, accepts: Models::NpmPackage
-
-      def supports?(flag)
-        case cli
-        when admin?
-          ADMIN_RUN_FLAGS.include?(flag.to_sym)
-        when checkout?
-          CHECKOUT_RUN_FLAGS.include?(flag.to_sym)
-        end
-      end
-
-      private
-
-      def admin?
-        ->(cli) { cli.name == UI_EXTENSIONS_ADMIN_RUN }
-      end
-
-      def checkout?
-        ->(cli) { cli.name == UI_EXTENSIONS_CHECKOUT_RUN }
+      def self.find(cli_package:, identifier:)
+        RUNTIMES.find { |runtime| runtime.active_runtime?(cli_package, identifier) }
       end
     end
   end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -7,7 +7,7 @@ module Extension
       NPM_SERVE_COMMAND = %w(run-script server)
 
       property! :specification_handler, accepts: Extension::Models::SpecificationHandlers::Default
-      property! :argo_runtime, accepts: Features::ArgoRuntime
+      property! :argo_runtime, accepts: -> (runtime) { runtime.class < Features::Runtimes::Base }
       property! :context, accepts: ShopifyCli::Context
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: nil

--- a/lib/project_types/extension/features/runtimes/admin.rb
+++ b/lib/project_types/extension/features/runtimes/admin.rb
@@ -1,0 +1,28 @@
+module Extension
+  module Features
+    module Runtimes
+      class Admin < Base
+        ADMIN_UI_EXTENSIONS_RUN = "@shopify/admin-ui-extensions-run"
+        PRODUCT_SUBSCRIPTION = "PRODUCT_SUBSCRIPTION"
+
+        AVAILABLE_FLAGS = [
+          :api_key,
+          :name,
+          :port,
+          :public_url,
+          :renderer_version,
+          :shop,
+          :uuid,
+        ]
+
+        def available_flags
+          AVAILABLE_FLAGS
+        end
+
+        def active_runtime?(cli_package, identifier)
+          cli_package.name == ADMIN_UI_EXTENSIONS_RUN && identifier == PRODUCT_SUBSCRIPTION
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/runtimes/base.rb
+++ b/lib/project_types/extension/features/runtimes/base.rb
@@ -1,0 +1,19 @@
+module Extension
+  module Features
+    module Runtimes
+      class Base
+        def available_flags
+          []
+        end
+
+        def supports?(flag)
+          available_flags.include?(flag)
+        end
+
+        def active_runtime?(cli_package, identifier)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/runtimes/checkout_post_purchase.rb
+++ b/lib/project_types/extension/features/runtimes/checkout_post_purchase.rb
@@ -1,0 +1,23 @@
+module Extension
+  module Features
+    module Runtimes
+      class CheckoutPostPurchase < Base
+        CHECKOUT_UI_EXTENSIONS_RUN = "@shopify/checkout-ui-extensions-run"
+        CHECKOUT_POST_PURCHASE = "CHECKOUT_POST_PURCHASE"
+
+        AVAILABLE_FLAGS = [
+          :port,
+          :public_url,
+        ]
+
+        def available_flags
+          AVAILABLE_FLAGS
+        end
+
+        def active_runtime?(cli_package, identifier)
+          cli_package.name == CHECKOUT_UI_EXTENSIONS_RUN && identifier == CHECKOUT_POST_PURCHASE
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
+++ b/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
@@ -1,0 +1,28 @@
+module Extension
+  module Features
+    module Runtimes
+      class CheckoutUiExtension < Base
+        CHECKOUT_UI_EXTENSIONS_RUN = "@shopify/checkout-ui-extensions-run"
+
+        IDENTIFIERS = [
+          "CHECKOUT_ARGO_EXTENSION",
+          "CHECKOUT_UI_EXTENSION",
+        ]
+
+        AVAILABLE_FLAGS = [
+          :port,
+          :public_url,
+          :shop,
+        ]
+
+        def available_flags
+          AVAILABLE_FLAGS
+        end
+
+        def active_runtime?(cli_package, identifier)
+          cli_package.name == CHECKOUT_UI_EXTENSIONS_RUN && IDENTIFIERS.include?(identifier)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -65,9 +65,9 @@ module Extension
         end
 
         def argo_runtime(context)
-          @argo_runtime ||= Features::ArgoRuntime.new(
-            renderer: renderer_package(context),
-            cli: cli_package(context),
+          @argo_runtime ||= Features::ArgoRuntime.find(
+            cli_package: cli_package(context),
+            identifier: identifier
           )
         end
 

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -46,6 +46,7 @@ module Extension
           checkout: {
             git_template: "https://github.com/Shopify/checkout-ui-extensions-template",
             renderer_package_name: "@shopify/checkout-ui-extensions",
+            required_fields: [:shop],
             cli_package_name: "@shopify/checkout-ui-extensions-run",
           },
         }

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -7,105 +7,36 @@ module Extension
     class ArgoRuntimeTest < MiniTest::Test
       include ExtensionTestHelpers::TempProjectSetup
 
-      def test_supports_port
-        runtimes = {
-          checkout_runtime => supports_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_port|
-          assert_equal accepts_port, runtime.supports?(:port)
-        end
-      end
-
-      def test_supports_public_url
-        runtimes = {
-          checkout_runtime => supports_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_tunnel|
-          assert_equal accepts_tunnel, runtime.supports?(:public_url)
-        end
-      end
-
-      def test_supports_uuid
-        runtimes = {
-          checkout_runtime => does_not_support_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_uuid|
-          assert_equal accepts_uuid, runtime.supports?(:uuid)
-        end
-      end
-
-      def test_supports_renderer_version
-        runtimes = {
-          checkout_runtime => does_not_support_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_renderer_version|
-          assert_equal accepts_renderer_version, runtime.supports?(:renderer_version)
-        end
-      end
-
-      def test_supports_api_key
-        runtimes = {
-          checkout_runtime => does_not_support_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_api_key|
-          assert_equal accepts_api_key, runtime.supports?(:api_key)
-        end
-      end
-
-      def test_supports_shop
-        runtimes = {
-          checkout_runtime => does_not_support_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_shop|
-          assert_equal accepts_shop, runtime.supports?(:shop)
-        end
-      end
-
-      def test_supports_name
-        runtimes = {
-          checkout_runtime => does_not_support_feature,
-          admin_runtime => supports_feature,
-        }
-
-        runtimes.each do |runtime, accepts_name|
-          assert_equal accepts_name, runtime.supports?(:name)
-        end
-      end
-
-      private
-
-      def checkout_runtime
-        ArgoRuntime.new(
-          cli: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
-          renderer: Models::NpmPackage.new(name: "@shopify/post-purchase-ui-extensions", version: "0.9.0")
+      def test_admin_runtime_is_returned_for_admin_extensions
+        runtime = ArgoRuntime.find(
+          cli_package: Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.13.0"),
+          identifier: "PRODUCT_SUBSCRIPTION"
         )
+        assert_equal(Runtimes::Admin, runtime.class)
       end
 
-      def admin_runtime
-        ArgoRuntime.new(
-          cli: Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.13.0"),
-          renderer: Models::NpmPackage.new(name: "@shopify/admin-ui-extensions", version: "0.12.0")
+      def test_checkout_ui_extension_runtime_is_returned_for_checkout_ui_extensions
+        runtime = ArgoRuntime.find(
+          cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
+          identifier: "CHECKOUT_UI_EXTENSION"
         )
+        assert_equal(Runtimes::CheckoutUiExtension, runtime.class)
       end
 
-      def supports_feature
-        true
+      def test_checkout_ui_extension_runtime_is_returned_for_legacy_checkout_argo_extensions
+        runtime = ArgoRuntime.find(
+          cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
+          identifier: "CHECKOUT_ARGO_EXTENSION"
+        )
+        assert_equal(Runtimes::CheckoutUiExtension, runtime.class)
       end
 
-      def does_not_support_feature
-        false
+      def test_checkout_post_purchase_runtime_is_returned_for_checkout_post_purchase_extensions
+        runtime = ArgoRuntime.find(
+          cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
+          identifier: "CHECKOUT_POST_PURCHASE"
+        )
+        assert_equal(Runtimes::CheckoutPostPurchase, runtime.class)
       end
     end
   end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -9,6 +9,7 @@ module Extension
 
       def setup
         ShopifyCli::ProjectType.load_type(:extension)
+        stub_package_manager
         super
       end
 
@@ -45,15 +46,11 @@ module Extension
       private
 
       def argo_runtime
-        Features::ArgoRuntime.new(cli: cli, renderer: renderer)
+        Features::ArgoRuntime.find(cli_package: cli, identifier: "PRODUCT_SUBSCRIPTION")
       end
 
       def cli
-        Models::NpmPackage.new(name: "@shopify/argo-admin-cli", version: "0.11.0")
-      end
-
-      def renderer
-        Models::NpmPackage.new(name: "@shopify/argo-admin", version: "0.0.1")
+        Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.11.0")
       end
 
       def specification_handler
@@ -62,6 +59,21 @@ module Extension
 
       def fake_js_system(success: true)
         proc { success }
+      end
+
+      def stub_package_manager
+        fake_list_result = <<~YARN
+          yarn list v1.22.5
+          ├─ @fake-package@0.3.9
+          └─ @shopify/admin-ui-extensions@0.3.8
+          ✨  Done in 0.40s.
+        YARN
+
+        ShopifyCli::JsSystem
+          .new(ctx: @context)
+          .tap { |js_system| js_system.stubs(call: [fake_list_result, nil, stub(success?: true)]) }
+          .yield_self { |js_system| Tasks::FindNpmPackages.new(js_system: js_system) }
+          .tap { |find_npm_packages_stub| Tasks::FindNpmPackages.expects(:new).returns(find_npm_packages_stub) }
       end
     end
   end

--- a/test/project_types/extension/features/runtimes/admin_test.rb
+++ b/test/project_types/extension/features/runtimes/admin_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    module Runtimes
+      class AdminTest < MiniTest::Test
+        include ExtensionTestHelpers::TempProjectSetup
+
+        def test_available_flags_are_supported_for_admin
+          flags = [
+            :api_key,
+            :name,
+            :port,
+            :public_url,
+            :renderer_version,
+            :shop,
+            :uuid,
+          ]
+
+          flags.each do |flag|
+            assert_equal runtime.supports?(flag), supported
+          end
+        end
+
+        def test_unsupported_flag_is_not_supported_for_admin
+          assert_equal runtime.supports?(:fake_flag), not_supported
+        end
+
+        def test_active_runtime_returns_true_for_valid_identifier_and_package_name
+          active_runtime = runtime.active_runtime?(cli_package, "PRODUCT_SUBSCRIPTION")
+          assert_equal active_runtime, active
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier
+          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_package
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "PRODUCT_SUBSCRIPTION")
+          assert_equal active_runtime, inactive
+        end
+
+        private
+
+        def supported
+          true
+        end
+
+        def active
+          true
+        end
+
+        def not_supported
+          false
+        end
+
+        def inactive
+          false
+        end
+
+        def runtime
+          @runtime ||= Runtimes::Admin.new
+        end
+
+        def cli_package
+          Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.11.0")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/runtimes/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/features/runtimes/checkout_post_purchase_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    module Runtimes
+      class CheckoutPostPurchaseTest < MiniTest::Test
+        include ExtensionTestHelpers::TempProjectSetup
+
+        def test_available_flags_are_supported_for_post_purchase
+          flags = [
+            :port,
+            :public_url,
+          ]
+
+          flags.each do |flag|
+            assert_equal runtime.supports?(flag), supported
+          end
+        end
+
+        def test_unsupported_flag_is_not_supported_for_post_purchase
+          assert_equal runtime.supports?(:fake_flag), not_supported
+        end
+
+        def test_active_runtime_returns_true_for_valid_identifier_and_package_name
+          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_POST_PURCHASE")
+          assert_equal active_runtime, active
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier
+          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_package
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "CHECKOUT_POST_PURCHASE")
+          assert_equal active_runtime, inactive
+        end
+
+        private
+
+        def supported
+          true
+        end
+
+        def active
+          true
+        end
+
+        def not_supported
+          false
+        end
+
+        def inactive
+          false
+        end
+
+        def runtime
+          @runtime ||= Runtimes::CheckoutPostPurchase.new
+        end
+
+        def cli_package
+          Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Features
+    module Runtimes
+      class CheckoutUiExtensionTest < MiniTest::Test
+        include ExtensionTestHelpers::TempProjectSetup
+
+        def test_available_flags_are_supported_for_checkout_ui_extension
+          flags = [
+            :port,
+            :public_url,
+            :shop,
+          ]
+
+          flags.each do |flag|
+            assert_equal runtime.supports?(flag), supported
+          end
+        end
+
+        def test_unsupported_flag_is_not_supported_for_checkout_ui_extension
+          assert_equal runtime.supports?(:fake_flag), not_supported
+        end
+
+        def test_active_runtime_returns_true_for_valid_identifier_and_package_name
+          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_UI_EXTENSION")
+          assert_equal active_runtime, active
+        end
+
+        def test_active_runtime_returns_true_for_legacy_identifier_and_package_name
+          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_ARGO_EXTENSION")
+          assert_equal active_runtime, active
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_identifier
+          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          assert_equal active_runtime, inactive
+        end
+
+        def test_active_runtime_returns_false_for_invalid_package
+          invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
+          active_runtime = runtime.active_runtime?(invalid_package, "CHECKOUT_UI_EXTENSION")
+          assert_equal active_runtime, inactive
+        end
+
+        private
+
+        def supported
+          true
+        end
+
+        def active
+          true
+        end
+
+        def not_supported
+          false
+        end
+
+        def inactive
+          false
+        end
+
+        def runtime
+          @runtime ||= Runtimes::CheckoutUiExtension.new
+        end
+
+        def cli_package
+          Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/ui-extensions-private/issues/1618

We need to pass the `--store` flag to the `checkout-extensions-ui-run` node process, but only for Checkout UI extensions, not for Post Purchase extensions.

### WHAT is this pull request doing?

In order to achieve the desired functionality, we have introduced various extension-specific runtimes:
* Admin
* CheckoutUiExtension
* CheckoutPostPurchase

as each one of these has very specific needs.

This PR introduces the extension-specific runtimes, and also adds the `shop` flag to extensions of type `CHECKOUT_UI_EXTENSION`.

### 🎩 Tophatting

* `cd` into a `PRODUCT_SUBSCRIPTION` extension
* run `shopify extension serve`
* observe serve behavior is unchanged

<img width="1889" alt="Screen Shot 2021-07-07 at 2 41 23 PM" src="https://user-images.githubusercontent.com/989784/124819863-67eee380-df32-11eb-894c-202ac42bf0dd.png">

* `cd` into a `CHECKOUT_UI_EXTENSION` or `CHECKOUT_ARGO_EXTENSION` project
* run `shopify extension serve`
* observe behavior is unchanged from before, verify `--store` flag is also being passed to the underlying node process

<img width="1437" alt="Screen Shot 2021-07-07 at 2 16 48 PM" src="https://user-images.githubusercontent.com/989784/124820063-a389ad80-df32-11eb-94d7-cc4fbe45d605.png">

* `cd` into a `CHECKOUT_POST_PURCHASE` project
* run `shopify extension serve`
* observe behavior is unchanged, verify `--store` is NOT being passed down to the underlying node process

<img width="1697" alt="Screen Shot 2021-07-07 at 2 17 25 PM" src="https://user-images.githubusercontent.com/989784/124820239-d59b0f80-df32-11eb-9dab-bb978b433166.png">

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
