### PR TITLE
[Extension] Added Timeout Error rescue when checking if port is available. 

### DIFF
--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -28,7 +28,7 @@ module Extension
           socket.close
           false
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
         true
       end
     end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1336 <!-- link to issue if one exists -->

'shopify extension serve' was returning error 'X No available ports found to run extension.'
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adding rescue for ETIMEDOUT error when Socket.tcp is called to indicate socket is available.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
