### PR TITLE
Fix CLI::UI::Formatter::FormatError running shopify theme pull

### DIFF
--- a/vendor/deps/cli-ui/lib/cli/ui/formatter.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/formatter.rb
@@ -19,6 +19,7 @@ module CLI
         'blue' => '94', # 9x = high-intensity fg color x
         'magenta' => '35',
         'cyan' => '36',
+        'grey' => '38',
         'bold' => '1',
         'italic' => '3',
         'underline' => '4',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes exception running e.g. `shopify theme pull`

/usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:116:in `rescue in block in apply_format': invalid format specifier: grey (CLI::UI::Formatter::FormatError)


### WHAT is this pull request doing?

add "grey" to formatter.rb as color.rb is expecting that key.

### Update checklist
This is my first commit/pull request to shopify-cli as I found a bug locally using the tool (thanks for maintaining the tool, much appreciated!), please guide me if I am missing some important facts in this review request, thanks!