### PR TITLE
add get_product task and ProductConverter

### DIFF
--- a/lib/graphql/get_variant_id.graphql
+++ b/lib/graphql/get_variant_id.graphql
@@ -1,0 +1,16 @@
+query {
+  products(first: 1) {
+    edges {
+      node {
+        id
+        variants(first: 1) {
+          edges {
+            node {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -40,12 +40,14 @@ module Extension
     autoload :ChooseNextAvailablePort, Project.project_filepath("tasks/choose_next_available_port")
     autoload :FindNpmPackages, Project.project_filepath("tasks/find_npm_packages")
     autoload :GetExtensions, Project.project_filepath("tasks/get_extensions")
+    autoload :GetProduct, Project.project_filepath("tasks/get_product")
 
     module Converters
       autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")
       autoload :VersionConverter, Project.project_filepath("tasks/converters/version_converter")
       autoload :ValidationErrorConverter, Project.project_filepath("tasks/converters/validation_error_converter")
       autoload :AppConverter, Project.project_filepath("tasks/converters/app_converter")
+      autoload :ProductConverter, Project.project_filepath("tasks/converters/product_converter")
     end
   end
 
@@ -93,6 +95,7 @@ module Extension
     autoload :Specifications, Project.project_filepath("models/specifications")
     autoload :LazySpecificationHandler, Project.project_filepath("models/lazy_specification_handler")
     autoload :NpmPackage, Project.project_filepath("models/npm_package")
+    autoload :Product, Project.project_filepath("models/product")
   end
 
   autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -166,6 +166,7 @@ module Extension
       tasks: {
         errors: {
           parse_error: "Unable to parse response from Partners Dashboard.",
+          store_error: "There was an error getting store data. Try again later.",
         },
       },
       errors: {

--- a/lib/project_types/extension/models/product.rb
+++ b/lib/project_types/extension/models/product.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class Product
+      include SmartProperties
+
+      property :variant_id, accepts: Integer, converts: :to_i
+      property :quantity, accepts: Integer, default: 1
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/product_converter.rb
+++ b/lib/project_types/extension/tasks/converters/product_converter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module Extension
+  module Tasks
+    module Converters
+      module ProductConverter
+        VARIANT_PATH = ["data", "products", "edges", 0, "node", "variants", "edges", 0, "node", "id"]
+
+        def self.from_hash(hash)
+          return nil if hash.nil?
+          variant = hash.dig(*VARIANT_PATH)
+          return unless variant
+          Models::Product.new(
+            variant_id: ShopifyCli::API.gid_to_id(variant)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/get_product.rb
+++ b/lib/project_types/extension/tasks/get_product.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module Extension
+  module Tasks
+    class GetProduct < ShopifyCli::Task
+      API_VERSION = "2021-07"
+      GRAPHQL_FILE = "get_variant_id"
+
+      def call(context, shop)
+        response = ShopifyCli::AdminAPI.query(
+          context,
+          GRAPHQL_FILE,
+          shop: shop,
+          api_version: API_VERSION
+        )
+        context.abort(context.message("tasks.errors.store_error")) if response.nil?
+        Converters::ProductConverter.from_hash(response)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/product_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/product_converter_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    module Converters
+      class ProductConverterTest < MiniTest::Test
+        include ExtensionTestHelpers::TempProjectSetup
+
+        def test_product_converter_from_hash_parses_product_correctly
+          variant_id = 987654321
+          response = JSON.parse(mock_api_response(variant_id))
+          product = Converters::ProductConverter.from_hash(response)
+          assert_equal(variant_id, product.variant_id)
+          assert_kind_of(Models::Product, product)
+        end
+
+        def test_product_converter_returns_nil_for_empty_hash
+          assert_nil Converters::ProductConverter.from_hash(nil)
+        end
+
+        def test_product_converter_returns_nil_if_no_variant_exists
+          assert_nil Converters::ProductConverter.from_hash({})
+        end
+
+        private
+
+        def mock_api_response(variant_id)
+          {
+            "data": {
+              "products": {
+                "edges": [
+                  {
+                    "node": {
+                      "id": "gid://shopify/Product/123456789",
+                      "variants": {
+                        "edges": [
+                          {
+                            "node": {
+                              "id": "gid://shopify/ProductVariant/#{variant_id}",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          }.to_json
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/get_product_test.rb
+++ b/test/project_types/extension/tasks/get_product_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    class GetProductTest < MiniTest::Test
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def test_get_product_returns_a_product
+        response = JSON.parse(mock_api_response)
+        ShopifyCli::AdminAPI.stubs(:query).returns(response)
+
+        result = Tasks::GetProduct.call(@context, "shop.myshopify.com")
+        assert_kind_of(Models::Product, result)
+      end
+
+      def test_get_product_returns_nil_for_no_products
+        ShopifyCli::AdminAPI.stubs(:query).returns({})
+
+        result = Tasks::GetProduct.call(@context, "shop.myshopify.com")
+        assert_nil result
+      end
+
+      def test_get_product_raises_error_for_nil_response
+        ShopifyCli::AdminAPI.stubs(:query).returns(nil)
+
+        error = assert_raises CLI::Kit::Abort do
+          Tasks::GetProduct.call(@context, "shop.myshopify.com")
+        end
+        assert_includes error.message, "There was an error getting store data"
+      end
+
+      private
+
+      def mock_api_response
+        {
+          "data": {
+            "products": {
+              "edges": [
+                {
+                  "node": {
+                    "id": "gid://shopify/Product/123456789",
+                    "variants": {
+                      "edges": [
+                        {
+                          "node": {
+                            "id": "gid://shopify/ProductVariant/987654321",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/ui-extensions-private/issues/1619

### WHAT is this pull request doing?

* Add task get_product to fetch products for a given shop from the Admin API
* Add Product model (`Product.new(variant_id, quantity)`)
* Add ProductConverter

### Expected response

```
{
  "data" => {
    "products" => {
      "edges" => [
        {
          "node" => {
            "id" => "gid://shopify/Product/SOME_PRODUCT_ID",
            "variants" => {
              "edges" => [
                {
                  "node" => {
                    "id" => "gid://shopify/ProductVariant/SOME_VARIANT_ID",
                  },
                },
              ],
            },
          },
        },
      ],
    },
  },
}
```

### Tophatting

1. Ensure you are authenticated to the CLI with a store. `shopify login --store=YOUR_SHOP_DOMAIN_HERE`
2. If you don't have any products in your dev shop, run `shopify populate products`. If this call fails, you are not authenticated to the CLI correctly, and you will not be able to run the call. See _Known Issues_ for possible fixes.
3. I used `binding.pry` to open a terminal with the necessary context, but there may be other ways to open a terminal with the correct context.
4. Run `Tasks::GetProduct.call(context, YOUR_SHOP_DOMAIN_HERE)`

You should get an object that looks like this:

`<Extension::Models::Product:0x00007f7efd1932b8 @quantity=1, @variant_id=40500631994567>`

### Known issues

The call to the Admin API can fail if you're not logged in correctly. This is a known issue currently with the CLI (which happens on `shopify populate products` and other commands).

You can run `shopify populate products` as a test run to see if you are logged in correctly. If you get an error when you run `shopify populate products`, you will not be able to run `Tasks::GetProduct.call` either.

The error returned is: `Command not allowed with current login [...]`.

To fix this error: https://github.com/Shopify/shopify-cli/issues/1361#issuecomment-879426041

If that doesn't work, try: https://github.com/Shopify/shopify-cli/issues/1349#issuecomment-879032260

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
