### PR TITLE
adds resouce_url to argo_serve options

### DIFF
--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -68,6 +68,7 @@ module Extension
 
       def options
         project = ExtensionProject.current
+        resource_url = project.resource_url
 
         @serve_options ||= [].tap do |options|
           options << "--port=#{port}" if argo_runtime.supports?(:port)
@@ -77,6 +78,7 @@ module Extension
           options << "--uuid=#{project.registration_uuid}" if argo_runtime.supports?(:uuid)
           options << "--publicUrl=#{tunnel_url}" if !tunnel_url.nil? && argo_runtime.supports?(:public_url)
           options << "--name=#{project.title}" if argo_runtime.supports?(:name)
+          options << "--resourceUrl=#{resource_url}" if !resource_url.nil? && argo_runtime.supports?(:resource_url)
         end
       end
     end

--- a/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
+++ b/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
@@ -12,6 +12,7 @@ module Extension
         AVAILABLE_FLAGS = [
           :port,
           :public_url,
+          :resource_url,
           :shop,
         ]
 

--- a/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
@@ -12,6 +12,7 @@ module Extension
           flags = [
             :port,
             :public_url,
+            :resource_url,
             :shop,
           ]
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/ui-extensions-private/issues/1618

### WHAT is this pull request doing?

* Adds the `--resourceUrl` flag to `ArgoServe` options if it is present.

🚨 NOTE 🚨 
A separate PR will dynamically pull this info for the end-user: https://github.com/Shopify/shopify-cli/pull/1377
In the meantime, an end-user could add `EXTENSION_RESOURCE_URL` to their extension `.env` file and the resource URL flag would be passed down to the node runtime.

We agreed to release this before the dynamically populated resource URL as an MVP.

### Tophatting 🎩 

* `cd` into a `CHECKOUT_UI_EXTENSION` project
* Open your `.env` file
* Add `EXTENSION_RESOURCE_URL` and add a variant id in this format: `cart/%VARIANT_ID%:1`. If you just want to test the flag, you can simply add `EXTENSION_RESOURCE_URL=/cart/1:1`
* You can find a variant ID by running the following graphql query in graphiql

```
query {
  products(first: 1) {
    edges {
      node {
        id
        variants(first: 1) {
          edges {
            node {
              id
            }
          }
        }
      }
    }
  }
}
```


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
