### PR TITLE
Fix CLI::UI::Formatter::FormatError running shopify theme pull

### DIFF
--- a/vendor/deps/cli-ui/lib/cli/ui/formatter.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/formatter.rb
@@ -19,6 +19,7 @@ module CLI
         'blue' => '94', # 9x = high-intensity fg color x
         'magenta' => '35',
         'cyan' => '36',
+        'grey' => '38',
         'bold' => '1',
         'italic' => '3',
         'underline' => '4',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an exception raised in formatter.rb. The exception below can be reproduced by running `shopify theme pull`.

```
/usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:115:in `rescue in block in apply_format': invalid format specifier: grey (CLI::UI::Formatter::FormatError)
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:112:in `block in apply_format'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:110:in `each'
...
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/bin/shopify:32:in `<top (required)>'
	from /usr/local/bin/shopify:6:in `load'
	from /usr/local/bin/shopify:6:in `<main>'
/usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:113:in `fetch': key not found: "grey" (KeyError)
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:113:in `block in apply_format'
...
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui.rb:114:in `fmt'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb:467:in `block (2 levels) in render_options'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/frame.rb:247:in `with_frame_color_override'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui.rb:162:in `with_frame_color'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb:466:in `block in render_options'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb:445:in `each'
	from /usr/local/Cellar/shopify-cli/2.1.0/gems/shopify-cli-2.1.0/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb:445:in `render_options'
```
(on macOS with shopify-cli through HomeBrew)


### WHAT is this pull request doing?

Add "grey" to `formatter.rb` as `color.rb` is expecting that key, in `vendor/deps/cli-ui/lib/cli/ui/`


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
