### PR TITLE
Theme app extensions don't support the serve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1399](https://github.com/Shopify/shopify-cli/pull/1399): Fix error when running `shopify extension serve` in a theme app extension project
 
 Version 2.1.0
 -------------

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -200,6 +200,9 @@ module Extension
               {{*}} You’re ready to start building {{green:%s}}!
             MESSAGE
           },
+          serve: {
+            unsupported: "shopify extension serve is not supported for theme app extensions",
+          },
         },
       },
     }

--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -60,6 +60,18 @@ module Extension
           "Theme App Extension"
         end
 
+        def choose_port?(ctx)
+          ctx.abort(ctx.message("serve.unsupported"))
+        end
+
+        def establish_tunnel?(ctx)
+          ctx.abort(ctx.message("serve.unsupported"))
+        end
+
+        def serve(ctx)
+          ctx.abort(ctx.message("serve.unsupported"))
+        end
+
         private
 
         def validate(filename)


### PR DESCRIPTION
### WHY are these changes introduced?

Theme app extensions don't yet support `extension serve`. Trying to run `shopify extension serve` in an theme app extension project outputs a stack trace and then errors out.

Fixes #1339

### WHAT is this pull request doing?

Output a better error when a user tries to run `shopify extension serve` for a theme app extension project.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
