### PR TITLE
WIP - Cache specifications by api key

### DIFF
--- a/lib/project_types/extension/tasks/fetch_specifications.rb
+++ b/lib/project_types/extension/tasks/fetch_specifications.rb
@@ -7,11 +7,38 @@ module Extension
       property :api_key
 
       def call
-        response = ShopifyCli::PartnersAPI
-          .query(context, "fetch_specifications", api_key: api_key)
-          .dig("data", "extensionSpecifications")
-        context.abort(context.message("tasks.errors.parse_error")) if response.nil?
-        response
+        # TODO: Need a way to disable this for e.g. extension create
+        cache(api_key) do
+          response = ShopifyCli::PartnersAPI
+            .query(context, "fetch_specifications", api_key: api_key)
+            .dig("data", "extensionSpecifications")
+          context.abort(context.message("tasks.errors.parse_error")) if response.nil?
+          response
+        end
+      end
+
+      private
+
+      def cache(api_key)
+        specifications_dir = File.join(ShopifyCli.cache_dir, "specifications")
+        FileUtils.mkdir_p(specifications_dir)
+        filename = File.join(specifications_dir, "#{api_key}.json")
+
+        begin
+          if File.file?(filename) && File.mtime(filename) > Time.now - 86400
+            # Load from the cache
+            context.debug("cache hit: loading from #{filename}")
+            return JSON.parse(File.read(filename))
+          end
+        rescue JSON::JSONError
+        end
+
+        context.debug("cache miss: fetching specifications")
+        result = yield
+
+        context.debug("cache miss: writing to #{filename}")
+        File.write(filename, JSON.dump(result))
+        result
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Currently most of the extensions commands rely on various specification handlers, which are only instantiated after querying the API for specification configurations available to the user.

The problem is that this requires that many extension commands to fetch the set of specifications first before being able to instantiate the correct object and handing off control to the specific specification handler.

`shopify extension serve` is an example of this. Every time it is invoked, the CLI queries the backend for specification configurations.

### WHAT is this pull request doing?

This PR simply adds a local cache for the specification data, using the api key as the cache key.

Another way we could approach this problem would be to support instantiating specification handlers for active projects without having to query the backend for the configurations. Only commands that involve creating/registering/updating extensions should need to get the updated set of specification configurations?

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
