### PR TITLE
[Feature] add local TLS theme server

### DIFF
--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -18,18 +18,18 @@ module Theme
       end
 
       def call(args, _name)
-        root = args.first || "."
+        working_dir = args.first || "."
         delete = !options.flags[:nodelete]
 
         theme = if (theme_id = options.flags[:theme_id])
-          ShopifyCli::Theme::Theme.new(@ctx, root: root, id: theme_id)
+          ShopifyCli::Theme::Theme.new(@ctx, working_dir: working_dir, id: theme_id)
         elsif options.flags[:development]
-          theme = ShopifyCli::Theme::DevelopmentTheme.new(@ctx, root: root)
+          theme = ShopifyCli::Theme::DevelopmentTheme.new(@ctx, working_dir: working_dir)
           theme.ensure_exists!
           theme
         elsif options.flags[:unpublished]
           name = CLI::UI::Prompt.ask(@ctx.message("theme.push.name"), allow_empty: false)
-          theme = ShopifyCli::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
+          theme = ShopifyCli::Theme::Theme.new(@ctx, working_dir: working_dir, name: name, role: "unpublished")
           theme.create
           theme
         else
@@ -37,7 +37,7 @@ module Theme
             @ctx,
             [],
             title: @ctx.message("theme.push.select"),
-            root: root,
+            working_dir: working_dir,
           )
           return unless form
           form.theme
@@ -47,7 +47,7 @@ module Theme
           return unless CLI::UI::Prompt.confirm(@ctx.message("theme.push.live"))
         end
 
-        ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(root)
+        ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(working_dir)
         syncer = ShopifyCli::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
         begin
           syncer.start_threads

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -6,11 +6,12 @@ module Theme
     class Serve < ShopifyCli::SubCommand
       options do |parser, flags|
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
+        parser.on("--path=PATH") { |path| flags[:working_dir] = path.to_s }
       end
 
       def call(*)
         flags = options.flags.dup
-        ShopifyCli::Theme::DevServer.start(@ctx, ".", **flags) do |syncer|
+        ShopifyCli::Theme::DevServer.start(@ctx, **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
       end

--- a/lib/project_types/theme/forms/select.rb
+++ b/lib/project_types/theme/forms/select.rb
@@ -17,7 +17,7 @@ module Theme
       private
 
       def themes
-        @themes ||= ShopifyCli::Theme::Theme.all(@ctx, root: root)
+        @themes ||= ShopifyCli::Theme::Theme.all(@ctx, working_dir: root)
           .sort_by { |theme| theme_sort_order(theme) }
       end
 

--- a/lib/shopify-cli/theme/dev_server.rb
+++ b/lib/shopify-cli/theme/dev_server.rb
@@ -20,7 +20,7 @@ module ShopifyCli
       class << self
         attr_accessor :ctx
 
-        def start(ctx, working_dir: '.', host: 'localhost', port: 9292, use_tls: true)
+        def start(ctx, working_dir: ".", host: "localhost", port: 9292, use_tls: true)
           @ctx = ctx
           theme = DevelopmentTheme.new(ctx, working_dir: working_dir)
           ignore_filter = IgnoreFilter.from_path(working_dir)
@@ -40,7 +40,7 @@ module ShopifyCli
             stop
           end
 
-          protocol = use_tls ? 'https' : 'http'
+          protocol = use_tls ? "https" : "http"
           CLI::UI::Frame.open(@ctx.message("theme.serve.serve")) do
             ctx.print_task("Syncing theme ##{theme.id} on #{theme.shop}")
             @syncer.start_threads
@@ -77,7 +77,7 @@ module ShopifyCli
             Logger: logger,
             AccessLog: [],
             SSLEnable: use_tls,
-            StartCallback: -> {@ctx.open_browser_url!("#{protocol}://#{host}:#{port}")}
+            StartCallback: -> { @ctx.open_browser_url!("#{protocol}://#{host}:#{port}") },
           }
 
           if use_tls

--- a/lib/shopify-cli/theme/dev_server.rb
+++ b/lib/shopify-cli/theme/dev_server.rb
@@ -87,7 +87,7 @@ module ShopifyCli
             intermediate_file = manager.intermediate_certificate
             options[:SSLCertificate] = certificate_file
             options[:SSLPrivateKey] = private_key_file
-            # WEBrick doesn't automatically extract the intermediate from the certificate so we must specify it ourselves
+            # WEBrick doesn't automatically extract the intermediate from the certificate so we must specify it.
             # This is more of an issue for Let's Encrypt TLS certificates (vs. self signed where the CA is the cert)
             options[:SSLExtraChainCert] = intermediate_file if intermediate_file
           end

--- a/lib/shopify-cli/theme/dev_server/certificate_manager.rb
+++ b/lib/shopify-cli/theme/dev_server/certificate_manager.rb
@@ -6,72 +6,100 @@ module ShopifyCli
   module Theme
     module DevServer
       class CertificateManager
-        attr_reader :ctx, :domain_name, :certificate, :private_key
-
-        ISSUER_EXTENSIONS = [
-          ["subjectKeyIdentifier", "hash", false],
-          ["authorityKeyIdentifier", "keyid:always", false],
-        ]
-
-        def initialize(ctx, domain_name)
+        def initialize(ctx)
           @ctx = ctx
-          @domain_name = domain_name
         end
 
-        def find_or_create_certificates!
-          @private_key = if (private_key_pem = ShopifyCli::DB.get(:ssl_private_key))
-            OpenSSL::PKey::RSA.new(private_key_pem)
-          else
-            OpenSSL::PKey::RSA.new(2048)
-          end
+        def private_key
+          # private_key_file = OpenSSL::PKey::EC.new(::File.read('./localhost.shoesbycolin.com.key'))
+          return @private_key if @private_key
 
-          @certificate = if (certificate_pem = ShopifyCli::DB.get(:ssl_certificate))
-            OpenSSL::X509::Certificate.new(certificate_pem)
-          else
-            x509_certificate = build_x509_certificate
+          private_key_pem = ShopifyCli::DB.get(:tls_private_key)
+          @private_key = OpenSSL::PKey::EC.new(private_key_pem) if private_key_pem rescue nil
+          return @private_key if @private_key
 
-            sign_certificate!(x509_certificate)
+          @private_key = OpenSSL::PKey::EC.new("secp384r1")
+          @private_key.generate_key
+          ShopifyCli::DB.set(:tls_private_key => @private_key.to_pem)
+          @private_key
+        end
 
-            x509_certificate
-          end
+        def intermediate_certificate
+          # intermediate_file = OpenSSL::X509::Certificate.new(::File.read('./lets-encrypt-r3-cross-signed.pem'))
+          nil
+        end
 
-          ShopifyCli::DB.set(ssl_certificate: certificate.to_pem)
-          ShopifyCli::DB.set(ssl_private_key: private_key.to_pem)
+        def find_or_create_certificate!(host = "localhost")
+          # we generate one certificate per host
+          certificate_cache_key = "#{host}_tls_certificate".to_sym
+          certificate_pem = ShopifyCli::DB.get(certificate_cache_key)
+          certificate = OpenSSL::X509::Certificate.new(certificate_pem) rescue nil
+          # TODO: should we check dh_compute_key is the same as the current private_key in cache?
+          return certificate if certificate && certificate.not_after > Time.now.utc + 1 * 24 * 60 * 60
+
+          certificate = sign_certificate!(host)
+          ShopifyCli::DB.set(certificate_cache_key => certificate.to_pem)
+          certificate
         end
 
         private
 
-        def build_x509_certificate
+        def sign_certificate!(host)
+          # certificate_file = OpenSSL::X509::Certificate.new(::File.read('./localhost.shoesbycolin.com.pem'))
           certificate = OpenSSL::X509::Certificate.new
 
-          certificate.public_key = private_key.public_key
-          certificate.subject = subject
+          # technically we should be able to pass the private_key, but we want to ensure that the private_key doesn't
+          # get bled when calling certificate.public_key, so we create a new ECDSA object and just copy the public_key
+          public_ecdsa_key = OpenSSL::PKey::EC.new("secp384r1")
+          key = private_key
+
+          public_ecdsa_key.public_key = key.public_key
+
+          certificate.public_key = public_ecdsa_key
+          certificate.subject = OpenSSL::X509::Name.new([['CN', host]])
           certificate.version = 2
           certificate.serial = 0x0
 
           certificate.not_before = Time.now.utc
-          certificate.not_after = Time.now.utc + 365 * 24 * 60 * 60
+          certificate.not_after = Time.now.utc + 90 * 24 * 60 * 60
 
-          certificate
-        end
-
-        def sign_certificate!(certificate)
           ef = OpenSSL::X509::ExtensionFactory.new
 
           ef.subject_certificate = certificate
           ef.issuer_certificate = certificate
 
-          ISSUER_EXTENSIONS.each do |args|
-            certificate.add_extension(ef.create_extension(*args))
-          end
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2
+          # normally unique 160bit hash. For self signed we use =hash
+          certificate.add_extension(ef.create_extension("subjectKeyIdentifier", "hash", false))
 
-          certificate.add_extension(ef.create_extension("subjectAltName", "DNS:#{@domain_name}", false))
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9
+          # Are you (the subject of this certificate) a CA? YES
+          certificate.add_extension(ef.create_extension("basicConstraints", "CA:TRUE", true))
+
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12
+          # KeyUsage=serverAuth is required for ios11+/macos10.15+ https://support.apple.com/en-us/HT210176
+          certificate.add_extension(ef.create_extension("extendedKeyUsage", "serverAuth", false))
+
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
+          # cRLSign: Subject public key is to verify signatures on revocation information, such as a CRL
+          # digitalSignature: Certificate may be used to apply a digital signature
+          # keyCertSign: Subject public key is used to verify signatures on certificates
+          certificate.add_extension(ef.create_extension("keyUsage", "critical,cRLSign,digitalSignature,keyCertSign", false))
+
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1
+          # keyid - indicates that the subject key identifier is copied from the parent certificate.
+          # keyid:always - indicates that the subject key identifier is copied from the parent certificate
+          #   (and an error is returned if the copy fails.)
+          # issuer - indicates that the issuer and serial number is copied from the issuer certificate if the keyid
+          #   option fails or is not specified.
+          # issuer:always - indicates that the issuer and serial number is always copied from the issuer certificate.
+          certificate.add_extension(ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always", false))
+
+          # https://datatracker.ietf.org/doc/html/rfc5280#section-5.2.2
+          certificate.add_extension(ef.create_extension("issuerAltName", "issuer:copy", false))
+          certificate.add_extension(ef.create_extension("subjectAltName", "DNS:#{host},IP:127.0.0.1", false))
 
           certificate.sign(private_key, OpenSSL::Digest.new("SHA256"))
-        end
-
-        def subject
-          OpenSSL::X509::Name.parse("/CN=#{@domain_name}/")
         end
       end
     end

--- a/lib/shopify-cli/theme/dev_server/local_assets.rb
+++ b/lib/shopify-cli/theme/dev_server/local_assets.rb
@@ -43,7 +43,7 @@ module ShopifyCli
         private
 
         def serve_file(path_info)
-          path = @theme.root.join(path_info[1..-1])
+          path = @theme.working_dir.join(path_info[1..-1])
           if path.file? && path.readable?
             [
               200,

--- a/lib/shopify-cli/theme/dev_server/proxy.rb
+++ b/lib/shopify-cli/theme/dev_server/proxy.rb
@@ -22,10 +22,12 @@ module ShopifyCli
         SESSION_COOKIE_REGEXP = /#{SESSION_COOKIE_NAME}=(\h+)/
         SESSION_COOKIE_MAX_AGE = 60 * 60 * 23 # 1 day - leeway of 1h
 
-        def initialize(ctx, theme:, syncer:)
+        def initialize(ctx, theme:, syncer:, host: 'localhost', port: 9292)
           @ctx = ctx
           @theme = theme
           @syncer = syncer
+          @host = host
+          @port = port
           @core_endpoints = Set.new
 
           @secure_session_id = nil
@@ -176,7 +178,7 @@ module ShopifyCli
           response_headers.reject! { |k| HOP_BY_HOP_HEADERS.include?(k.downcase) }
 
           if response_headers["location"]&.include?("myshopify.com")
-            response_headers["location"].gsub!(%r{(https://#{@theme.shop})}, "http://127.0.0.1:9292")
+            response_headers["location"].gsub!(%r{(https://#{@theme.shop})}, "https://#{@host}:#{@port}")
           end
 
           response_headers

--- a/lib/shopify-cli/theme/dev_server/proxy.rb
+++ b/lib/shopify-cli/theme/dev_server/proxy.rb
@@ -22,7 +22,7 @@ module ShopifyCli
         SESSION_COOKIE_REGEXP = /#{SESSION_COOKIE_NAME}=(\h+)/
         SESSION_COOKIE_MAX_AGE = 60 * 60 * 23 # 1 day - leeway of 1h
 
-        def initialize(ctx, theme:, syncer:, host: 'localhost', port: 9292)
+        def initialize(ctx, theme:, syncer:, host: "localhost", port: 9292)
           @ctx = ctx
           @theme = theme
           @syncer = syncer

--- a/lib/shopify-cli/theme/dev_server/watcher.rb
+++ b/lib/shopify-cli/theme/dev_server/watcher.rb
@@ -14,7 +14,7 @@ module ShopifyCli
           @theme = theme
           @syncer = syncer
           @ignore_filter = ignore_filter
-          @listener = Listen.to(@theme.root) do |modified, added, removed|
+          @listener = Listen.to(@theme.working_dir) do |modified, added, removed|
             changed
             notify_observers(modified, added, removed)
           end

--- a/lib/shopify-cli/theme/file.rb
+++ b/lib/shopify-cli/theme/file.rb
@@ -7,13 +7,13 @@ module ShopifyCli
       attr_reader :relative_path
       attr_accessor :remote_checksum
 
-      def initialize(path, root)
+      def initialize(path, working_dir)
         super(Pathname.new(path))
 
         # Path may be relative or absolute depending on the source.
-        # By converting both the path and the root to absolute paths, we
+        # By converting both the path and the working_dir to absolute paths, we
         # can safely fetch a relative path.
-        @relative_path = self.path.expand_path.relative_path_from(root.expand_path)
+        @relative_path = self.path.expand_path.relative_path_from(working_dir.expand_path)
       end
 
       def read

--- a/lib/shopify-cli/theme/syncer.rb
+++ b/lib/shopify-cli/theme/syncer.rb
@@ -272,7 +272,7 @@ module ShopifyCli
           method: "DELETE",
           api_version: API_VERSION,
           body: JSON.generate(asset: {
-            key: file.relative_path.to_s
+            key: file.relative_path.to_s,
           })
         )
 
@@ -315,7 +315,7 @@ module ShopifyCli
       def backoff_if_near_limit!(used, limit)
         if used > limit - @threads.size
           @ctx.debug("Near API call limit, waiting 2 sec…")
-          @backoff_mutex.synchronize { sleep 2 }
+          @backoff_mutex.synchronize { sleep(2) }
         end
       end
 

--- a/lib/shopify-cli/theme/theme.rb
+++ b/lib/shopify-cli/theme/theme.rb
@@ -9,11 +9,11 @@ module ShopifyCli
     class InvalidThemeRole < StandardError; end
 
     class Theme
-      attr_reader :root, :id
+      attr_reader :working_dir, :id
 
-      def initialize(ctx, root: nil, id: nil, name: nil, role: nil)
+      def initialize(ctx, working_dir: nil, id: nil, name: nil, role: nil)
         @ctx = ctx
-        @root = Pathname.new(root) if root
+        @working_dir = Pathname.new(working_dir) if working_dir
         @id = id
         @name = name
         @role = role
@@ -36,7 +36,7 @@ module ShopifyCli
       end
 
       def glob(pattern)
-        root.glob(pattern).map { |path| File.new(path, root) }
+        working_dir.glob(pattern).map { |path| File.new(path, working_dir) }
       end
 
       def theme_file?(file)
@@ -52,9 +52,9 @@ module ShopifyCli
         when File
           file
         when Pathname
-          File.new(file, root)
+          File.new(file, working_dir)
         when String
-          File.new(root.join(file), root)
+          File.new(working_dir.join(file), working_dir)
         end
       end
 
@@ -162,7 +162,7 @@ module ShopifyCli
         }
       end
 
-      def self.all(ctx, root: nil)
+      def self.all(ctx, working_dir: nil)
         _status, body = AdminAPI.rest_request(
           ctx,
           shop: AdminAPI.get_shop_or_abort(ctx),
@@ -176,7 +176,7 @@ module ShopifyCli
           .map do |attributes|
             new(
               ctx,
-              root: root,
+              working_dir: working_dir,
               id: attributes["id"],
               name: attributes["name"],
               role: attributes["role"],

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -27,7 +27,7 @@ module Theme
 
       def test_push_to_theme_id
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -48,7 +48,7 @@ module Theme
 
       def test_push_to_live_theme
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
@@ -73,7 +73,7 @@ module Theme
 
       def test_allow_live
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
@@ -99,7 +99,7 @@ module Theme
 
       def test_push_json
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         @theme.expects(:to_h).returns({})
@@ -125,7 +125,7 @@ module Theme
 
       def test_push_and_publish
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -148,7 +148,7 @@ module Theme
 
       def test_push_to_development_theme
         ShopifyCli::Theme::DevelopmentTheme.expects(:new)
-          .with(@ctx, root: ".")
+          .with(@ctx, working_dir: ".")
           .returns(@theme)
 
         @theme.expects(:ensure_exists!)
@@ -172,7 +172,7 @@ module Theme
 
       def test_push_to_unpublished_theme
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", name: "NAME", role: "unpublished")
+          .with(@ctx, working_dir: ".", name: "NAME", role: "unpublished")
           .returns(@theme)
 
         CLI::UI::Prompt.expects(:ask).returns("NAME")
@@ -198,7 +198,7 @@ module Theme
 
       def test_push_pass_nodelete_to_syncer
         ShopifyCli::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+          .with(@ctx, working_dir: ".", id: 1234)
           .returns(@theme)
 
         ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -9,14 +9,14 @@ module Theme
 
       def test_serve_command
         context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", optionally({}))
+        ShopifyCli::Theme::DevServer.expects(:start).with(context, optionally({}))
 
         Theme::Command::Serve.new(context).call
       end
 
       def test_can_specify_port
         context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", port: 9293)
+        ShopifyCli::Theme::DevServer.expects(:start).with(context, port: 9293)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:port] = 9293
@@ -25,7 +25,7 @@ module Theme
 
       def test_can_specify_env
         context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", env: "staging")
+        ShopifyCli::Theme::DevServer.expects(:start).with(context, env: "staging")
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:env] = "staging"

--- a/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
+++ b/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
@@ -6,22 +6,20 @@ module ShopifyCli
   module Theme
     module DevServer
       class CertificateManagerTest < Minitest::Test
-        def test_find_or_create_certificates!
+        def test_find_or_create_certificate!
           ctx = TestHelpers::FakeContext.new
           domain_name = "test.shopify.local"
 
-          manager = CertificateManager.new(ctx, domain_name)
+          manager = CertificateManager.new(ctx)
 
-          manager.find_or_create_certificates!
-
-          private_key_file = OpenSSL::PKey::RSA.new(manager.private_key)
-          certificate_file = OpenSSL::X509::Certificate.new(manager.certificate)
+          private_key_file = manager.private_key
+          certificate_file = manager.find_or_create_certificate!(domain_name)
 
           expected_common_name = OpenSSL::X509::Name.new([["CN", domain_name]])
 
           assert(private_key_file.private?)
           assert_equal(expected_common_name, certificate_file.subject)
-          assert_includes(certificate_file.extensions.map(&:to_s).flatten, "subjectAltName = DNS:test.shopify.local")
+          assert_includes(certificate_file.extensions.map(&:to_s).flatten, "subjectAltName = DNS:test.shopify.local, IP Address:127.0.0.1")
         end
       end
     end

--- a/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
+++ b/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
@@ -19,7 +19,8 @@ module ShopifyCli
 
           assert(private_key_file.private?)
           assert_equal(expected_common_name, certificate_file.subject)
-          assert_includes(certificate_file.extensions.map(&:to_s).flatten, "subjectAltName = DNS:test.shopify.local, IP Address:127.0.0.1")
+          assert_includes(certificate_file.extensions.map(&:to_s).flatten,
+            "subjectAltName = DNS:test.shopify.local, IP Address:127.0.0.1")
         end
       end
     end

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -11,7 +11,7 @@ module ShopifyCli
           super
           root = ShopifyCli::ROOT + "/test/fixtures/theme"
           @ctx = TestHelpers::FakeContext.new(root: root)
-          @theme = Theme.new(@ctx, root: root)
+          @theme = Theme.new(@ctx, working_dir: root)
           @syncer = stub("Syncer", enqueue_uploads: true)
           @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer)
         end

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -7,7 +7,7 @@ module ShopifyCli
     module DevServer
       class IntegrationTest < Minitest::Test
         include TestHelpers::FakeUI
-        
+
         @@port = 9292 # rubocop:disable Style/ClassVars
 
         THEMES_API_URL = "https://dev-theme-server-store.myshopify.com/admin/api/unstable/themes/123456789.json"
@@ -15,11 +15,11 @@ module ShopifyCli
 
         def setup
           super
-          WebMock.disable_net_connect!(allow_localhost:true)
+          WebMock.disable_net_connect!(allow_localhost: true)
 
           ShopifyCli::DB.expects(:get)
             .with(:shopify_exchange_token)
-            .at_least_once.returns('token123')
+            .at_least_once.returns("token123")
 
           ShopifyCli::DB.expects(:exists?).with(:shop).at_least_once.returns(true)
           ShopifyCli::DB.expects(:get)
@@ -157,7 +157,7 @@ module ShopifyCli
           # Send the SSE request
           tcp_socket = TCPSocket.new("localhost", @@port)
           # setup the TLS socket over the TCP socket
-          ssl_context = OpenSSL::SSL::SSLContext.new()
+          ssl_context = OpenSSL::SSL::SSLContext.new
           ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
           socket = OpenSSL::SSL::SSLSocket.new(tcp_socket, ssl_context)
           socket.sync_close = true

--- a/test/shopify-cli/theme/dev_server/local_assets_test.rb
+++ b/test/shopify-cli/theme/dev_server/local_assets_test.rb
@@ -68,7 +68,7 @@ module ShopifyCli
           end
           root = ShopifyCli::ROOT + "/test/fixtures/theme"
           ctx = TestHelpers::FakeContext.new(root: root)
-          theme = Theme.new(ctx, root: root)
+          theme = Theme.new(ctx, working_dir: root)
           stack = LocalAssets.new(ctx, app, theme: theme)
           request = Rack::MockRequest.new(stack)
           request.get(path)

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -14,7 +14,7 @@ module ShopifyCli
           super
           root = ShopifyCli::ROOT + "/test/fixtures/theme"
           @ctx = TestHelpers::FakeContext.new(root: root)
-          @theme = DevelopmentTheme.new(@ctx, root: root)
+          @theme = DevelopmentTheme.new(@ctx, working_dir: root)
           @syncer = stub(pending_updates: [])
           @proxy = Proxy.new(@ctx, theme: @theme, syncer: @syncer)
 
@@ -116,7 +116,7 @@ module ShopifyCli
           stub_session_id_request
           response = request.get("/")
 
-          assert_equal("http://127.0.0.1:9292/password", response.headers["Location"])
+          assert_equal("https://localhost:9292/password", response.headers["Location"])
         end
 
         def test_non_storefront_redirect_headers_are_not_rewritten

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -9,7 +9,7 @@ module ShopifyCli
         super
         root = ShopifyCli::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
-        @theme = DevelopmentTheme.new(@ctx, root: root)
+        @theme = DevelopmentTheme.new(@ctx, working_dir: root)
         ShopifyCli::DB.stubs(:del).with(:acting_as_shopify_organization)
       end
 

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -10,7 +10,7 @@ module ShopifyCli
         super
         root = ShopifyCli::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
-        @theme = Theme.new(@ctx, root: root)
+        @theme = Theme.new(@ctx, working_dir: root)
         @syncer = Syncer.new(@ctx, theme: @theme)
 
         ShopifyCli::DB.stubs(:exists?).with(:shop).returns(true)

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -9,7 +9,7 @@ module ShopifyCli
         super
         root = ShopifyCli::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
-        @theme = Theme.new(@ctx, root: root, id: "123")
+        @theme = Theme.new(@ctx, working_dir: root, id: "123")
       end
 
       def test_static_assets

--- a/test/shopify-cli/transform_data_structure_test.rb
+++ b/test/shopify-cli/transform_data_structure_test.rb
@@ -91,7 +91,7 @@ module ShopifyCli
     end
 
     def test_replacing_hashes_with_another_associative_array_container
-      TransformDataStructure.new(associative_array_container: OpenStruct).call({ a: 1 }).tap do |result|
+      TransformDataStructure.new(associative_array_container: OpenStruct).call(**{ a: 1 }).tap do |result|
         assert_predicate(result, :success?)
         assert_kind_of(OpenStruct, result.value)
         assert_equal(1, result.value.a)


### PR DESCRIPTION
### WHY are these changes introduced?

Many browser features are only available on a TLS connection. This adds valid Let's Encrypt TLS certificates and falls back to self-signed TLS certificates to the theme serve. 

### WHAT is this pull request doing?

This PR adds --path parameter to set the working dir for the cli to use (default to cwd). Also adds EC self signed certificates and sets up for LE TLS certificate exchanges

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
