### PR TITLE
[Fix] format colour selector when pushing to a theme

### DIFF
--- a/lib/project_types/theme/forms/select.rb
+++ b/lib/project_types/theme/forms/select.rb
@@ -43,7 +43,7 @@ module Theme
         when "development"
           "blue"
         else
-          "grey"
+          "italic"
         end
 
         tags = ["{{#{color}:[#{theme.role}]}}"]


### PR DESCRIPTION
Fix the default colour for formatting the CLI output when the theme.role is not one of the common set. 

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
