### PR TITLE
Add Ubuntu and Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,26 +3,64 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Ruby ${{ matrix.version }}
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        version:
-          - 3.0.0
-          - 2.6.6
-          - 2.7.1
+  rubocop:
+    name: Rubocop
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby ${{ matrix.version }}
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.version }}
-          bundler-cache: true
-
-      - name: Install Dependencies
+          bundler-cache: false
+      
+      - name: Install dependencies
         run: bundle install
 
-      - name: Run Tests
-        run: bundle exec rake
+      - name: Run Rubocop
+        run: bundle exec rake rubocop
+  specs:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        ruby:
+          - '3.0'
+          - '2.7'
+          - '2.6'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+  specs-windows:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+        ruby:
+          - '3.0'
+          - '2.7'
+          - '2.6'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.1.4)
+  bundler (~> 2.2.24)
   byebug
   fakefs (>= 1.0)
   minitest (>= 5.0.0)
@@ -108,4 +108,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.24

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   # `/usr/local/bin/shopify` to that script, in order to "lock" the Ruby used to
   # a single Ruby (useful for debugging in multi-Ruby environments)
 
-  spec.add_development_dependency("bundler", "~> 2.1.4")
+  spec.add_development_dependency("bundler", "~> 2.2.24")
   spec.add_development_dependency("rake", "~> 12.3", ">= 12.3.3")
   spec.add_development_dependency("minitest", "~> 5.0")
 

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -117,6 +117,8 @@ module ShopifyCli
     end
 
     def empty_commit
+      system("git config --local user.email foo@bar.com")
+      system("git config --local user.name 'Foo Bar'")
       Context.new.capture3("git", "commit", "-m", "commit", "--allow-empty")
     end
 


### PR DESCRIPTION
Draft because I can't get Windows CI to work. The `PATHEXT` variable doesn't seem to be set (it's case-sensitive on Windows, and although the `ENV` object knows that, conversion to a `Hash` doesn't - that could be it), and `git` isn't on the path or `open3` isn't working for it.

Any ideas anyone?

### WHY are these changes introduced?

I want to merge #1125, but it's blocked by not being able to demonstrate it works on Windows.

### WHAT is this pull request doing?

Adds Windows CI, to demonstrate that #1125 works on Windows. Also adds Ubuntu CI while we're at it.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
