### PR TITLE
Auto configure resource URL for Checkout Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ------
 * [#1419](https://github.com/Shopify/shopify-cli/pull/1419): Remove analytics prompt when used in CI
+* [#1418](https://github.com/Shopify/shopify-cli/pull/1418): Auto configure resource URL for Checkout Extensions
 * [#1399](https://github.com/Shopify/shopify-cli/pull/1399): Fix error when running `shopify extension serve` in a theme app extension project
 
 Version 2.1.0

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -14,6 +14,24 @@ module Extension
         )
       end
 
+      def update_env_file(context:, **updates)
+        current_config = {
+          title: current.title,
+          shop: current.env.shop,
+          api_key: current.app.api_key,
+          api_secret: current.app.secret,
+          registration_id: current.registration_id,
+          registration_uuid: current.registration_uuid,
+          resource_url: current.resource_url,
+        }
+
+        write_env_file(
+          context: context,
+          **current_config,
+          **updates
+        )
+      end
+
       def write_env_file(
         context:,
         title:,
@@ -21,11 +39,13 @@ module Extension
         api_secret: "",
         registration_id: nil,
         registration_uuid: nil,
-        resource_url: nil
+        resource_url: nil,
+        shop: nil
       )
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
+          shop: shop,
           extra: {
             ExtensionProjectKeys::TITLE_KEY => title,
             ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id,

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -90,7 +90,14 @@ module Extension
           .wrap(project.resource_url)
           .rescue { specification_handler.build_resource_url(shop: project.env.shop, context: context) }
           .then(&method(:persist_resource_url))
-          .unwrap { |e| raise e }
+          .unwrap do |nil_or_exception|
+            case nil_or_exception
+            when nil
+              context.warn(context.message("warnings.resource_url_auto_generation_failed", project.env.shop))
+            else
+              context.abort(nil_or_exception)
+            end
+          end
       end
 
       def persist_resource_url(resource_url)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -173,6 +173,11 @@ module Extension
         unknown_type: "Unknown extension type %s",
         package_not_found: "`%s` package not found.",
       },
+      warnings: {
+        resource_url_auto_generation_failed: "{{*}} {{yellow:Warning:}} Unable to auto generate " \
+        "the extension resource URL because %s does not have any products. " \
+        "Please run {{bold:shopify populate products}} to generate sample products.",
+      },
     }
 
     TYPES = {

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -13,6 +13,10 @@ module Extension
           }
         end
 
+        def supplies_resource_url?
+          true
+        end
+
         def build_resource_url(context:, shop:)
           variant_id = Tasks::GetProduct.call(context, shop).variant_id
           quantity = 1

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -12,6 +12,12 @@ module Extension
             **argo.config(context),
           }
         end
+
+        def build_resource_url(context:, shop:)
+          variant_id = Tasks::GetProduct.call(context, shop).variant_id
+          quantity = 1
+          format("/cart/%d:%d", variant_id, quantity)
+        end
       end
     end
   end

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -18,9 +18,9 @@ module Extension
         end
 
         def build_resource_url(context:, shop:)
-          variant_id = Tasks::GetProduct.call(context, shop).variant_id
-          quantity = 1
-          format("/cart/%d:%d", variant_id, quantity)
+          product = Tasks::GetProduct.call(context, shop)
+          return unless product
+          format("/cart/%<variant_id>d:%<quantity>d", variant_id: product.variant_id, quantity: 1)
         end
       end
     end

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -90,6 +90,10 @@ module Extension
           end
         end
 
+        def build_resource_url(shop)
+          raise NotImplementedError
+        end
+
         protected
 
         def argo

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -90,6 +90,10 @@ module Extension
           end
         end
 
+        def supplies_resource_url?
+          false
+        end
+
         def build_resource_url(shop)
           raise NotImplementedError
         end

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -46,7 +46,7 @@ module Extension
           checkout: {
             git_template: "https://github.com/Shopify/checkout-ui-extensions-template",
             renderer_package_name: "@shopify/checkout-ui-extensions",
-            required_fields: [:shop],
+            required_fields: [:shop, :resource_url],
             cli_package_name: "@shopify/checkout-ui-extensions-run",
           },
         }

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -46,7 +46,7 @@ module Extension
           checkout: {
             git_template: "https://github.com/Shopify/checkout-ui-extensions-template",
             renderer_package_name: "@shopify/checkout-ui-extensions",
-            required_fields: [:shop, :resource_url],
+            required_fields: [:shop],
             cli_package_name: "@shopify/checkout-ui-extensions-run",
           },
         }

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -61,6 +61,11 @@ module Extension
       assert_equal("/cart/13:1", ExtensionProject.current.resource_url)
     end
 
+    def test_write_env_file_persists_shop
+      ExtensionProject.write_env_file(**valid_env_file_attributes_with(shop: "johndoe.myshopify.com"))
+      assert_equal("johndoe.myshopify.com", ExtensionProject.current.env.shop)
+    end
+
     def test_env_file_writes_temporary_uuid_if_no_registration_uuid_present
       ExtensionProject.write_env_file(**valid_env_file_attributes_without(:registration_uuid))
 
@@ -173,6 +178,7 @@ module Extension
         registration_id: 56,
         registration_uuid: "eb946ca8-a925-11eb-bcbc-0242ac130013",
         resource_url: "/cart/1:1",
+        shop: "test.myshopify.com",
       }
     end
   end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -79,6 +79,7 @@ module Extension
           context: @context,
           argo_runtime: checkout_ui_extension_runtime,
           specification_handler: specification_handler.tap do |handler|
+            handler.expects(:supplies_resource_url?).returns(true)
             handler.expects(:build_resource_url).returns("/generated")
           end,
           js_system: fake_js_system
@@ -98,9 +99,7 @@ module Extension
       end
 
       def specification_handler
-        ExtensionTestHelpers.test_specifications["TEST_EXTENSION"].tap do |handler|
-          handler.specification.features.argo.required_fields << :resource_url
-        end
+        ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
       end
 
       def fake_js_system(success: true)

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -9,14 +9,14 @@ module Extension
 
       def setup
         ShopifyCli::ProjectType.load_type(:extension)
-        stub_package_manager
         super
       end
 
       def test_argo_serve_defers_to_js_system_when_shopifolk_check_is_false
+        stub_package_manager
         argo_serve = Features::ArgoServe.new(
           context: @context,
-          argo_runtime: argo_runtime,
+          argo_runtime: admin_ui_extension_runtime,
           specification_handler: specification_handler,
           js_system: fake_js_system
         )
@@ -26,9 +26,10 @@ module Extension
       end
 
       def test_argo_serve_abort_when_server_start_failed
+        stub_package_manager
         argo_serve = Features::ArgoServe.new(
           context: @context,
-          argo_runtime: argo_runtime,
+          argo_runtime: admin_ui_extension_runtime,
           specification_handler: specification_handler,
           js_system: fake_js_system(success: false)
         )
@@ -43,22 +44,71 @@ module Extension
         )
       end
 
-      private
+      def test_forwards_resource_url
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ExtensionProject.stubs(:update_env_file)
+        ExtensionProject.any_instance.expects(:resource_url).returns("/test").at_least_once
 
-      def argo_runtime
-        Features::ArgoRuntime.find(cli_package: cli, identifier: "PRODUCT_SUBSCRIPTION")
+        js_system = mock
+        js_system.expects(:call)
+          .with do |_, config|
+            assert_includes config.fetch(:yarn), "--resourceUrl=/test"
+            assert_includes config.fetch(:npm), "--resourceUrl=/test"
+          end
+          .returns(true)
+
+        argo_serve = Features::ArgoServe.new(
+          context: @context,
+          argo_runtime: checkout_ui_extension_runtime,
+          specification_handler: specification_handler,
+          js_system: js_system
+        )
+
+        argo_serve.call
       end
 
-      def cli
-        Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.11.0")
+      def test_builds_resource_url_if_necessary
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ExtensionProject.expects(:update_env_file).with(
+          has_entries(context: anything, resource_url: "/generated")
+        )
+
+        argo_serve = Features::ArgoServe.new(
+          context: @context,
+          argo_runtime: checkout_ui_extension_runtime,
+          specification_handler: specification_handler.tap do |handler|
+            handler.expects(:build_resource_url).returns("/generated")
+          end,
+          js_system: fake_js_system
+        )
+
+        argo_serve.call
+      end
+
+      private
+
+      def admin_ui_extension_runtime
+        Features::Runtimes::Admin.new
+      end
+
+      def checkout_ui_extension_runtime
+        Features::Runtimes::CheckoutUiExtension.new
       end
 
       def specification_handler
-        ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
+        ExtensionTestHelpers.test_specifications["TEST_EXTENSION"].tap do |handler|
+          handler.specification.features.argo.required_fields << :resource_url
+        end
       end
 
       def fake_js_system(success: true)
         proc { success }
+      end
+
+      def stub_ensure_env_check
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
       end
 
       def stub_package_manager

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -69,6 +69,24 @@ module Extension
         def test_graphql_identifier
           assert_equal @identifier, @checkout_ui_extension.graphql_identifier
         end
+
+        def test_build_resource_url
+          shop = stub
+          product = mock(variant_id: 0)
+
+          Tasks::GetProduct.expects(:call).with(@context, shop).returns(product)
+
+          resource_url = @checkout_ui_extension.build_resource_url(context: @context, shop: shop)
+          assert_equal "/cart/0:1", resource_url
+        end
+
+        def test_build_resource_url_nil_safety
+          shop = stub
+          Tasks::GetProduct.expects(:call).with(@context, shop).returns(nil)
+
+          resource_url = @checkout_ui_extension.build_resource_url(context: @context, shop: shop)
+          assert_nil resource_url
+        end
       end
     end
   end


### PR DESCRIPTION
When running `shopify extension serve` in a Checkout UI Extensions context, the CLI will now automatically configure the `EXTENSION_RESOURCE_URL` variable and pass its value as `--resourceURL` to the Node.js runtime.

### WHY are these changes introduced?

Closes #1634

### WHAT is this pull request doing?

- Expands the SpecificationHandler API: `SpecificationHandlers::Default#build_resource_url`
- Implements automatic resource URL generation for checkout UI extensions
- Adds `ExtensionProject.update_env_file` for updating individual environment variables
- Persists generated resource URLs in the .env file to avoid future API requests

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
