### PR TITLE
Remove analytics prompt when used in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1419](https://github.com/Shopify/shopify-cli/pull/1419): Remove analytics prompt when used in CI
 * [#1399](https://github.com/Shopify/shopify-cli/pull/1399): Fix error when running `shopify extension serve` in a theme app extension project
 
 Version 2.1.0

--- a/lib/shopify-cli/core/monorail.rb
+++ b/lib/shopify-cli/core/monorail.rb
@@ -46,7 +46,7 @@ module ShopifyCli
 
         # we only want to send Monorail events in production or when explicitly developing
         def enabled?
-          Context.new.system? || ENV["MONORAIL_REAL_EVENTS"] == "1"
+          (Context.new.system? || ENV["MONORAIL_REAL_EVENTS"] == "1") && !Context.new.ci?
         end
 
         def consented?
@@ -54,6 +54,7 @@ module ShopifyCli
         end
 
         def prompt_for_consent
+          return if Context.new.ci?
           return unless enabled?
           return if ShopifyCli::Config.get_section("analytics").key?("enabled")
           msg = Context.message("core.monorail.consent_prompt")

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -42,6 +42,15 @@ module ShopifyCli
         ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
+      def test_log_doesnt_prompt_for_consent_if_in_ci
+        ShopifyCli::Context.any_instance.stubs(:ci?).returns(true)
+        ShopifyCli::Context.any_instance.stubs(:system?).returns(true)
+        CLI::UI::Prompt.expects(:confirm).never
+        Net::HTTP.expects(:start).never
+
+        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+      end
+
       def test_log_event_contains_schema_and_payload_values
         enabled_and_consented(true, true)
         ShopifyCli::Shopifolk.expects(:acting_as_shopify_organization?).returns(true)
@@ -187,6 +196,7 @@ module ShopifyCli
       def enabled_and_consented(enabled, consented)
         ShopifyCli::Config.stubs(:get_section).with("analytics").returns({ "enabled" => consented.to_s })
         ShopifyCli::Context.any_instance.stubs(:system?).returns(enabled)
+        ShopifyCli::Context.any_instance.stubs(:ci?).returns(false)
         ShopifyCli::Config.stubs(:get_bool).with("analytics", "enabled").returns(consented)
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Allows for Shopify CLI to be used within GitHub actions and other CI systems without prompting the user for consent.

### WHAT is this pull request doing?

Checking if it's in a CI environment and bypassing analytics and the prompt.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
