### PR TITLE
add resource_url flag to extension serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1424](https://github.com/Shopify/shopify-cli/pull/1424/): Add `--resourceUrl` flag to extension serve command
 * [#1419](https://github.com/Shopify/shopify-cli/pull/1419): Remove analytics prompt when used in CI
 * [#1418](https://github.com/Shopify/shopify-cli/pull/1418): Auto configure resource URL for Checkout Extensions
 * [#1399](https://github.com/Shopify/shopify-cli/pull/1399): Fix error when running `shopify extension serve` in a theme app extension project

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -9,19 +9,24 @@ module Extension
 
       options do |parser, flags|
         parser.on("-t", "--[no-]tunnel", "Establish an ngrok tunnel") { |tunnel| flags[:tunnel] = tunnel }
+        parser.on("--resourceUrl=RESOURCE_URL", "Provide a resource URL") do |resource_url|
+          flags[:resource_url] = resource_url
+        end
       end
 
       class RuntimeConfiguration
         include SmartProperties
 
         property :tunnel_url, accepts: String, default: nil
+        property :resource_url, accepts: String, default: nil
         property! :tunnel_requested, accepts: [true, false], reader: :tunnel_requested?, default: true
         property! :port, accepts: (1...(2**16)), default: DEFAULT_PORT
       end
 
       def call(_args, _command_name)
         config = RuntimeConfiguration.new(
-          tunnel_requested: tunnel_requested?
+          tunnel_requested: tunnel_requested?,
+          resource_url: options.flags[:resource_url]
         )
 
         ShopifyCli::Result
@@ -74,7 +79,8 @@ module Extension
         specification_handler.serve(
           context: @ctx,
           tunnel_url: runtime_configuration.tunnel_url,
-          port: runtime_configuration.port
+          port: runtime_configuration.port,
+          resource_url: runtime_configuration.resource_url
         )
         runtime_configuration
       end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -12,6 +12,7 @@ module Extension
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: nil
       property! :js_system, accepts: ->(jss) { jss.respond_to?(:call) }, default: ShopifyCli::JsSystem
+      property :resource_url, accepts: String, default: nil
 
       def call
         validate_env!
@@ -20,6 +21,10 @@ module Extension
           next if start_server
           context.abort(context.message("serve.serve_failure_message"))
         end
+      end
+
+      def resource_url
+        super || ExtensionProject.current(force_reload: true).resource_url
       end
 
       private
@@ -69,7 +74,6 @@ module Extension
 
       def options
         project = ExtensionProject.current
-        resource_url = project.resource_url
 
         @serve_options ||= [].tap do |options|
           options << "--port=#{port}" if argo_runtime.supports?(:port)

--- a/lib/project_types/extension/features/runtimes/admin.rb
+++ b/lib/project_types/extension/features/runtimes/admin.rb
@@ -11,6 +11,7 @@ module Extension
           :port,
           :public_url,
           :renderer_version,
+          :resource_url,
           :shop,
           :uuid,
         ]

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -50,13 +50,14 @@ module Extension
           argo_runtime(context).supports?(:public_url)
         end
 
-        def serve(context:, port:, tunnel_url:)
+        def serve(context:, port:, tunnel_url:, resource_url:)
           Features::ArgoServe.new(
             specification_handler: self,
             argo_runtime: argo_runtime(context),
             context: context,
             port: port,
             tunnel_url: tunnel_url,
+            resource_url: resource_url
           ).call
         end
 

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -97,6 +97,18 @@ module Extension
         serve.call([], "serve")
       end
 
+      def test_resource_url_is_forwarded_to_specification_handler_if_one_is_provided
+        serve = ::Extension::Command::Serve.new(@context)
+        expected_resource_url = "foo/bar"
+        stub_specification_handler_options(serve)
+
+        serve.specification_handler
+          .expects(:serve)
+          .with(context: @context, tunnel_url: nil, port: 39351, resource_url: expected_resource_url)
+        serve.options.flags[:resource_url] = expected_resource_url
+        serve.call([], "serve")
+      end
+
       private
 
       def stub_specification_handler_options(serve, choose_port: false, establish_tunnel: false)

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -88,6 +88,29 @@ module Extension
         argo_serve.call
       end
 
+      def test_resource_url_is_used_if_given
+        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+
+        js_system = mock
+        js_system.expects(:call)
+          .with do |_, config|
+            assert_includes config.fetch(:yarn), "--resourceUrl=/provided"
+            assert_includes config.fetch(:npm), "--resourceUrl=/provided"
+          end
+          .returns(true)
+
+        argo_serve = Features::ArgoServe.new(
+          context: @context,
+          argo_runtime: checkout_ui_extension_runtime,
+          specification_handler: specification_handler,
+          js_system: js_system,
+          resource_url: "/provided"
+        )
+
+        argo_serve.call
+      end
+
       private
 
       def admin_ui_extension_runtime

--- a/test/project_types/extension/features/runtimes/admin_test.rb
+++ b/test/project_types/extension/features/runtimes/admin_test.rb
@@ -15,6 +15,7 @@ module Extension
             :port,
             :public_url,
             :renderer_version,
+            :resource_url,
             :shop,
             :uuid,
           ]


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/ui-extensions-private/issues/1625

### WHAT is this pull request doing?

Admin UI Extensions have always supported a `--resourceUrl` to be passed to the node runtime.

This PR adds the ability for a user to provide a `--resourceUrl` via the `shopify extension serve` command.

## User Experience:

**For Admin extensions**

* If `--resourceUrl` is provided, it is passed to the node runtime. If not, nothing is passed.
* `EXTENSION_RESOURCE_URL` is not persisted in the .env file

**For Checkout UI extensions**
* If `--resourceUrl` is provided, it is passed to the node runtime. If not, the `EXTENSION_RESOURCE_URL` in the `.env` file is used, if one is available
* `EXTENSION_RESOURCE_URL` is not overwritten by the user provided `--resourceUrl`

**For Post Purchase extensions**
* `--resourceUrl` is ignored if provided, as it is not supported

## Tophatting

**Admin extensions**

`shopify extension serve --resourceUrl="foo/bar"`

<img width="1833" alt="01 - admin - resource url provided" src="https://user-images.githubusercontent.com/989784/127920732-e4e634a9-739a-424d-a112-e219c4684f62.png">

Notice `EXTENSION_RESOURCE_URL` is not persisted in the `.env` file:

<img width="1055" alt="02 - admin - resource url not persisted" src="https://user-images.githubusercontent.com/989784/127920929-0d23a82b-d6d9-49f6-a967-bb9d2db3cf0a.png">

**Checkout UI Extensions**

`shopify extension serve`: no resource URL provided, we default to the `EXTENSION_RESOURCE_URL` in the `.env` file.

<img width="1827" alt="03 - checkout ui - resource url not provided" src="https://user-images.githubusercontent.com/989784/127920979-08f697df-4b71-4f39-9fb5-4ecb504f66a8.png">

`shopify extension serve --resourceUrl="foo/bar"`: notice the provided URL is used

<img width="1768" alt="04 - checkout ui - resource url provided" src="https://user-images.githubusercontent.com/989784/127920982-340ba5f9-639f-4f20-a732-f45d83c8c4a8.png">

Notice the provided URL is not persisted in the `.env` file:

<img width="1293" alt="05 - checkout ui - resource url not overwritten" src="https://user-images.githubusercontent.com/989784/127920983-498a2f9b-3fc6-40c4-8190-0b0b20f0eb95.png">

**Post Purchase Extensions**

`shopify extension serve --resourceUrl="foo/bar"`: notice the flag is ignored

<img width="1731" alt="06 - post purchase - resource url ignored" src="https://user-images.githubusercontent.com/989784/127921166-5c0d18c9-f61f-48d5-a5ab-865adf88fcbb.png">


### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
