### PR TITLE
New method for determining renderer package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [1432](https://github.com/Shopify/shopify-cli/pull/1432) New method for determining renderer package name
+
 Version 2.2.0
 ------
 * [#1424](https://github.com/Shopify/shopify-cli/pull/1424/): Add `--resourceUrl` flag to extension serve command

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -11,7 +11,6 @@ module Extension
       def call(args, name)
         Command::Register.new(@ctx).call(args, name) unless project.registered?
         Command::Build.new(@ctx).call(args, name) unless specification_handler.specification.options[:skip_build]
-
         CLI::UI::Frame.open(@ctx.message("push.frame_title")) do
           updated_draft_version = update_draft
           show_message(updated_draft_version)

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -19,16 +19,6 @@ module Extension
       YARN_RUN_SCRIPT_NAME = %w(build).freeze
       private_constant :YARN_INSTALL_COMMAND, :YARN_INSTALL_PARAMETERS, :YARN_RUN_COMMAND, :YARN_RUN_SCRIPT_NAME
 
-      UI_EXTENSIONS_CHECKOUT = "@shopify/checkout-ui-extensions"
-      UI_EXTENSIONS_ADMIN = "@shopify/admin-ui-extensions"
-      UI_EXTENSIONS_POST_PURCHASE = "@shopify/post-purchase-ui-extensions"
-
-      PACKAGE_NAMES = [
-        UI_EXTENSIONS_CHECKOUT,
-        UI_EXTENSIONS_ADMIN,
-        UI_EXTENSIONS_POST_PURCHASE,
-      ].freeze
-
       def create(directory_name, identifier, context)
         Features::ArgoSetup.new(git_template: git_template).call(directory_name, identifier, context)
       end
@@ -54,7 +44,7 @@ module Extension
       def renderer_package(context)
         js_system = ShopifyCli::JsSystem.new(ctx: context)
         Tasks::FindNpmPackages
-          .exactly_one_of(*PACKAGE_NAMES, js_system: js_system)
+          .exactly_one_of(renderer_package_name, js_system: js_system)
           .unwrap { |err| raise err }
       rescue Extension::PackageResolutionFailed
         context.abort(

--- a/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_post_purchase.rb
@@ -6,12 +6,22 @@ module Extension
     module SpecificationHandlers
       class CheckoutPostPurchase < Default
         PERMITTED_CONFIG_KEYS = [:metafields]
+        RENDERER_PACKAGE_NAME = "@shopify/post-purchase-ui-extensions"
 
         def config(context)
           {
             **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
             **argo.config(context),
           }
+        end
+
+        protected
+
+        def argo
+          Features::Argo.new(
+            git_template: specification.features.argo.git_template,
+            renderer_package_name: RENDERER_PACKAGE_NAME
+          )
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue that prevents partners from pushing their extension.

### WHAT is this pull request doing?

Changes the way we determine the renderer package version. Before, `Argo` would try to guess the appropriate renderer package but fail if an extension is using more than one package, which is the case for Post Purchase extension. However, specification handlers already state their renderer package. This PR removes guessing the renderer package name and uses the information from the specification handler as source of truth.

I've 🎩 the changes and everything is working well now.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
