### PR TITLE
Change extension "Type" to SpecificationIdentifier

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -1,6 +1,6 @@
 mutation ExtensionCreate(
   $api_key: String!
-  $type: ExtensionType!
+  $specification_identifier: String!
   $title: String!
   $config: JSON!
   $extension_context: String
@@ -8,7 +8,7 @@ mutation ExtensionCreate(
   extensionCreate(
     input: {
       apiKey: $api_key
-      type: $type
+      specificationIdentifier: $specification_identifier
       title: $title
       config: $config
       context: $extension_context
@@ -17,7 +17,7 @@ mutation ExtensionCreate(
     extensionRegistration {
       id
       uuid
-      type
+      specificationIdentifier
       title
       draftVersion {
         registrationId

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -7,7 +7,7 @@ module Extension
 
       options do |parser, flags|
         parser.on("--name=NAME") { |name| flags[:name] = name }
-        parser.on("--type=TYPE") { |type| flags[:type] = type.upcase }
+        parser.on("--type=TYPE") { |type| flags[:type] = type.downcase }
         parser.on("--api-key=KEY") { |key| flags[:api_key] = key.downcase }
         parser.on("--getting-started") { flags[:getting_started] = true }
       end

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -36,7 +36,7 @@ module Extension
         Tasks::CreateExtension.call(
           context: @ctx,
           api_key: app.api_key,
-          type: specification_handler.graphql_identifier,
+          specification_identifier: specification_handler.graphql_identifier,
           title: project.title,
           config: {},
           extension_context: specification_handler.extension_context(@ctx)

--- a/lib/project_types/extension/features/runtimes/admin.rb
+++ b/lib/project_types/extension/features/runtimes/admin.rb
@@ -3,7 +3,7 @@ module Extension
     module Runtimes
       class Admin < Base
         ADMIN_UI_EXTENSIONS_RUN = "@shopify/admin-ui-extensions-run"
-        PRODUCT_SUBSCRIPTION = "PRODUCT_SUBSCRIPTION"
+        PRODUCT_SUBSCRIPTION = "product_subscription"
 
         AVAILABLE_FLAGS = [
           :api_key,

--- a/lib/project_types/extension/features/runtimes/checkout_post_purchase.rb
+++ b/lib/project_types/extension/features/runtimes/checkout_post_purchase.rb
@@ -3,7 +3,7 @@ module Extension
     module Runtimes
       class CheckoutPostPurchase < Base
         CHECKOUT_UI_EXTENSIONS_RUN = "@shopify/checkout-ui-extensions-run"
-        CHECKOUT_POST_PURCHASE = "CHECKOUT_POST_PURCHASE"
+        CHECKOUT_POST_PURCHASE = "checkout_post_purchase"
 
         AVAILABLE_FLAGS = [
           :port,

--- a/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
+++ b/lib/project_types/extension/features/runtimes/checkout_ui_extension.rb
@@ -5,8 +5,8 @@ module Extension
         CHECKOUT_UI_EXTENSIONS_RUN = "@shopify/checkout-ui-extensions-run"
 
         IDENTIFIERS = [
-          "CHECKOUT_ARGO_EXTENSION",
-          "CHECKOUT_UI_EXTENSION",
+          "checkout_argo_extension",
+          "checkout_ui_extension",
         ]
 
         AVAILABLE_FLAGS = [

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -8,7 +8,7 @@ module Extension
 
       property! :id, accepts: Integer
       property! :uuid, accepts: String
-      property! :type, accepts: String
+      property! :specification_identifier, accepts: String
       property! :title, accepts: String
       property! :draft_version, accepts: Extension::Models::Version
 

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -11,11 +11,11 @@ module Extension
         end
 
         def identifier
-          specification.identifier.to_s.upcase
+          specification.identifier.to_s
         end
 
         def graphql_identifier
-          specification.graphql_identifier.to_s.upcase
+          specification.graphql_identifier.to_s
         end
 
         def name
@@ -31,7 +31,7 @@ module Extension
         end
 
         def create(directory_name, context, **_args)
-          argo.create(directory_name, identifier, context)
+          argo.create(directory_name, identifier.upcase, context)
         end
 
         def extension_context(_context)

--- a/lib/project_types/extension/models/specifications.rb
+++ b/lib/project_types/extension/models/specifications.rb
@@ -73,7 +73,7 @@ module Extension
         specification_attribute_sets.each do |attributes|
           next unless attributes.fetch(:identifier) == "subscription_management"
           attributes[:identifier] = "product_subscription"
-          attributes[:graphql_identifier] = "SUBSCRIPTION_MANAGEMENT"
+          attributes[:graphql_identifier] = "subscription_management"
         end
       end
 

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -7,7 +7,7 @@ module Extension
       module RegistrationConverter
         ID_FIELD = "id"
         UUID_FIELD = "uuid"
-        TYPE_FIELD = "type"
+        SPECIFICATION_IDENTIFIER_FIELD = "specificationIdentifier"
         TITLE_FIELD = "title"
         DRAFT_VERSION_FIELD = "draftVersion"
 
@@ -17,7 +17,7 @@ module Extension
           Models::Registration.new(
             id: hash[ID_FIELD].to_i,
             uuid: hash[UUID_FIELD],
-            type: hash[TYPE_FIELD],
+            specification_identifier: hash[SPECIFICATION_IDENTIFIER_FIELD],
             title: hash[TITLE_FIELD],
             draft_version: VersionConverter.from_hash(context, hash[DRAFT_VERSION_FIELD])
           )

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -11,10 +11,10 @@ module Extension
       RESPONSE_FIELD = %w(data extensionCreate)
       REGISTRATION_FIELD = "extensionRegistration"
 
-      def call(context:, api_key:, type:, title:, config:, extension_context: nil)
+      def call(context:, api_key:, specification_identifier:, title:, config:, extension_context: nil)
         input = {
           api_key: api_key,
-          type: type,
+          specification_identifier: specification_identifier,
           title: title,
           config: JSON.generate(config),
           extension_context: extension_context,

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -55,7 +55,7 @@ module Extension
         registration = Models::Registration.new(
           id: 55,
           uuid: "123",
-          type: @specification_handler.identifier,
+          specification_identifier: @specification_handler.identifier,
           title: @project.title,
           draft_version: Models::Version.new(
             registration_id: 55,
@@ -73,7 +73,7 @@ module Extension
         Tasks::CreateExtension.any_instance.expects(:call).with(
           context: @context,
           api_key: @app.api_key,
-          type: @specification_handler.graphql_identifier,
+          specification_identifier: @specification_handler.graphql_identifier,
           title: @project.title,
           config: {},
           extension_context: @specification_handler.extension_context(@context)

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -18,7 +18,7 @@ module Extension
       autoload :FetchSpecifications, "project_types/extension/extension_test_helpers/stubs/fetch_specifications"
     end
 
-    def self.test_specifications(type_identifier: "TEST_EXTENSION")
+    def self.test_specifications(type_identifier: "test_extension")
       DummySpecifications.build(
           identifier: type_identifier.downcase,
         custom_handler_root: File.expand_path("../", __FILE__),
@@ -26,7 +26,7 @@ module Extension
         )
     end
 
-    def self.test_specification_handler(type_identifier: "TEST_EXTENSION")
+    def self.test_specification_handler(type_identifier: "test_extension")
       specification_handler = test_specifications[type_identifier]
       if specification_handler.nil?
         raise "Unable to retrieve specification handler due to broken test setup"
@@ -40,7 +40,7 @@ module Extension
       api_key: "TEST_KEY",
       api_secret: "TEST_SECRET",
       title: "Test",
-      type_identifier: "TEST_EXTENSION",
+      type_identifier: "test_extension",
       registration_id: 55,
       registration_uuid: "db946ca8-a925-11eb-bcbc-0242ac130002"
     )

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -7,18 +7,18 @@ module Extension
       module CreateExtension
         include TestHelpers::Partners
 
-        def stub_create_extension(api_key:, type:, title:, config:, extension_context: nil)
+        def stub_create_extension(api_key:, specification_identifier:, title:, config:, extension_context: nil)
           stub_partner_req(
             "extension_create",
             variables: {
               api_key: api_key,
-              type: type,
+              specification_identifier: specification_identifier,
               title: title,
               config: JSON.generate(config),
               extension_context: extension_context,
             },
             resp: {
-              data: yield(title, type, config, extension_context),
+              data: yield(title, specification_identifier, config, extension_context),
             }
           )
         end
@@ -26,13 +26,13 @@ module Extension
         def stub_create_extension_success(**args)
           registration_id = rand(9999)
           registration_uuid = SecureRandom.uuid
-          stub_create_extension(**args) do |title, type|
+          stub_create_extension(**args) do |title, specification_identifier|
             {
               extensionCreate: {
                 extensionRegistration: {
                   id: registration_id,
                   uuid: registration_uuid,
-                  type: type,
+                  specificationIdentifier: specification_identifier,
                   title: title,
                   draftVersion: {
                     registrationId: registration_id,

--- a/test/project_types/extension/extension_test_helpers/test_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension.rb
@@ -10,7 +10,7 @@ module Extension
 
   module ExtensionTestHelpers
     class TestExtension < Models::SpecificationHandlers::Default
-      IDENTIFIER = "TEST_EXTENSION"
+      IDENTIFIER = "test_extension"
 
       def graphql_identifier
         "TEST_EXTENSION_GQL"

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -10,7 +10,7 @@ module Extension
           custom_handler_root: File.expand_path("../", __FILE__),
           custom_handler_namespace: ::Extension::ExtensionTestHelpers,
         )
-        @test_extension_type = specifications["TEST_EXTENSION"]
+        @test_extension_type = specifications["test_extension"]
 
         super
       end

--- a/test/project_types/extension/features/argo_runtime_test.rb
+++ b/test/project_types/extension/features/argo_runtime_test.rb
@@ -10,7 +10,7 @@ module Extension
       def test_admin_runtime_is_returned_for_admin_extensions
         runtime = ArgoRuntime.find(
           cli_package: Models::NpmPackage.new(name: "@shopify/admin-ui-extensions-run", version: "0.13.0"),
-          identifier: "PRODUCT_SUBSCRIPTION"
+          identifier: "product_subscription"
         )
         assert_equal(Runtimes::Admin, runtime.class)
       end
@@ -18,7 +18,7 @@ module Extension
       def test_checkout_ui_extension_runtime_is_returned_for_checkout_ui_extensions
         runtime = ArgoRuntime.find(
           cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
-          identifier: "CHECKOUT_UI_EXTENSION"
+          identifier: "checkout_ui_extension"
         )
         assert_equal(Runtimes::CheckoutUiExtension, runtime.class)
       end
@@ -26,7 +26,7 @@ module Extension
       def test_checkout_ui_extension_runtime_is_returned_for_legacy_checkout_argo_extensions
         runtime = ArgoRuntime.find(
           cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
-          identifier: "CHECKOUT_ARGO_EXTENSION"
+          identifier: "checkout_argo_extension"
         )
         assert_equal(Runtimes::CheckoutUiExtension, runtime.class)
       end
@@ -34,7 +34,7 @@ module Extension
       def test_checkout_post_purchase_runtime_is_returned_for_checkout_post_purchase_extensions
         runtime = ArgoRuntime.find(
           cli_package: Models::NpmPackage.new(name: "@shopify/checkout-ui-extensions-run", version: "0.4.0"),
-          identifier: "CHECKOUT_POST_PURCHASE"
+          identifier: "checkout_post_purchase"
         )
         assert_equal(Runtimes::CheckoutPostPurchase, runtime.class)
       end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -122,7 +122,7 @@ module Extension
       end
 
       def specification_handler
-        ExtensionTestHelpers.test_specifications["TEST_EXTENSION"]
+        ExtensionTestHelpers.test_specifications["test_extension"]
       end
 
       def fake_js_system(success: true)

--- a/test/project_types/extension/features/runtimes/admin_test.rb
+++ b/test/project_types/extension/features/runtimes/admin_test.rb
@@ -30,24 +30,24 @@ module Extension
         end
 
         def test_active_runtime_returns_true_for_valid_identifier_and_package_name
-          active_runtime = runtime.active_runtime?(cli_package, "PRODUCT_SUBSCRIPTION")
+          active_runtime = runtime.active_runtime?(cli_package, "product_subscription")
           assert_equal active_runtime, active
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(invalid_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier
-          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(cli_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_package
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "PRODUCT_SUBSCRIPTION")
+          active_runtime = runtime.active_runtime?(invalid_package, "product_subscription")
           assert_equal active_runtime, inactive
         end
 

--- a/test/project_types/extension/features/runtimes/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/features/runtimes/checkout_post_purchase_test.rb
@@ -24,24 +24,24 @@ module Extension
         end
 
         def test_active_runtime_returns_true_for_valid_identifier_and_package_name
-          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_POST_PURCHASE")
+          active_runtime = runtime.active_runtime?(cli_package, "checkout_post_purchase")
           assert_equal active_runtime, active
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(invalid_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier
-          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(cli_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_package
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "CHECKOUT_POST_PURCHASE")
+          active_runtime = runtime.active_runtime?(invalid_package, "checkout_post_purchase")
           assert_equal active_runtime, inactive
         end
 

--- a/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/features/runtimes/checkout_ui_extension_test.rb
@@ -26,29 +26,29 @@ module Extension
         end
 
         def test_active_runtime_returns_true_for_valid_identifier_and_package_name
-          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_UI_EXTENSION")
+          active_runtime = runtime.active_runtime?(cli_package, "checkout_ui_extension")
           assert_equal active_runtime, active
         end
 
         def test_active_runtime_returns_true_for_legacy_identifier_and_package_name
-          active_runtime = runtime.active_runtime?(cli_package, "CHECKOUT_ARGO_EXTENSION")
+          active_runtime = runtime.active_runtime?(cli_package, "checkout_argo_extension")
           assert_equal active_runtime, active
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier_and_package_name
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(invalid_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_identifier
-          active_runtime = runtime.active_runtime?(cli_package, "INVALID_IDENTIFIER")
+          active_runtime = runtime.active_runtime?(cli_package, "invalid_identifier")
           assert_equal active_runtime, inactive
         end
 
         def test_active_runtime_returns_false_for_invalid_package
           invalid_package = Models::NpmPackage.new(name: "invalid-package", version: "0.11.0")
-          active_runtime = runtime.active_runtime?(invalid_package, "CHECKOUT_UI_EXTENSION")
+          active_runtime = runtime.active_runtime?(invalid_package, "checkout_ui_extension")
           assert_equal active_runtime, inactive
         end
 

--- a/test/project_types/extension/forms/questions/ask_type_test.rb
+++ b/test/project_types/extension/forms/questions/ask_type_test.rb
@@ -14,7 +14,7 @@ module Extension
         end
 
         def test_returns_if_the_given_extension_type_valid
-          ask(type: "TEST_EXTENSION").tap do |result|
+          ask(type: "test_extension").tap do |result|
             assert_predicate(result, :success?)
             result.value.tap do |project_details|
               refute_nil project_details.type
@@ -24,7 +24,7 @@ module Extension
         end
 
         def test_aborts_if_the_given_extension_type_is_invalid
-          ask(type: "INVALID_EXTENSION_IDENTIFIER").tap do |result|
+          ask(type: "invalid_extension_identifier").tap do |result|
             assert_predicate(result, :failure?)
             result.error.tap do |error|
               assert_kind_of(CLI::Kit::Abort, error)

--- a/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
@@ -17,7 +17,7 @@ module Extension
 
           specifications = DummySpecifications.build(identifier: "checkout_post_purchase", surface: "checkout")
 
-          @identifier = "CHECKOUT_POST_PURCHASE"
+          @identifier = "checkout_post_purchase"
           @checkout_post_purchase = specifications[@identifier]
         end
 
@@ -26,7 +26,7 @@ module Extension
 
           Features::Argo.any_instance
             .expects(:create)
-            .with(directory_name, @identifier, @context)
+            .with(directory_name, @identifier.upcase, @context)
             .once
 
           @checkout_post_purchase.create(directory_name, @context)

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -18,7 +18,7 @@ module Extension
 
           specifications = DummySpecifications.build(identifier: "checkout_ui_extension", surface: "checkout")
 
-          @identifier = "CHECKOUT_UI_EXTENSION"
+          @identifier = "checkout_ui_extension"
           @checkout_ui_extension = specifications[@identifier]
         end
 
@@ -27,7 +27,7 @@ module Extension
 
           Features::Argo.any_instance
             .expects(:create)
-            .with(directory_name, @identifier, @context)
+            .with(directory_name, @identifier.upcase, @context)
             .once
 
           @checkout_ui_extension.create(directory_name, @context)

--- a/test/project_types/extension/models/specification_handlers/default_test.rb
+++ b/test/project_types/extension/models/specification_handlers/default_test.rb
@@ -23,10 +23,6 @@ module Extension
           assert_nil(Default.new(specification).extension_context(@context))
         end
 
-        def test_graphql_identifier_is_upcased
-          assert_equal specification.identifier.upcase, Default.new(specification).graphql_identifier
-        end
-
         def test_name_defaults_to_specification_name
           assert_equal "Test Extension", @test_extension_type.name
         end

--- a/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
+++ b/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
@@ -13,7 +13,7 @@ module Extension
           ShopifyCli::ProjectType.load_type(:extension)
           specifications = DummySpecifications.build(identifier: "subscription_management", surface: "admin")
 
-          @identifier = "PRODUCT_SUBSCRIPTION"
+          @identifier = "product_subscription"
           @product_subscription = specifications[@identifier]
         end
 
@@ -22,7 +22,7 @@ module Extension
 
           Features::Argo.any_instance
             .expects(:create)
-            .with(directory_name, @identifier, @context)
+            .with(directory_name, @identifier.upcase, @context)
             .once
 
           @product_subscription.create(directory_name, @context)
@@ -35,11 +35,11 @@ module Extension
         end
 
         def test_custom_identifier
-          assert_equal "PRODUCT_SUBSCRIPTION", @product_subscription.identifier
+          assert_equal "product_subscription", @product_subscription.identifier
         end
 
         def test_custom_graphql_identifier
-          assert_equal "SUBSCRIPTION_MANAGEMENT", @product_subscription.graphql_identifier
+          assert_equal "subscription_management", @product_subscription.graphql_identifier
         end
       end
     end

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -12,7 +12,7 @@ module Extension
           super
           ShopifyCli::ProjectType.load_type(:extension)
           specifications = DummySpecifications.build(identifier: "theme_app_extension")
-          @identifier = "THEME_APP_EXTENSION"
+          @identifier = "theme_app_extension"
           @spec = specifications[@identifier]
           @context.root = Dir.mktmpdir
         end

--- a/test/project_types/extension/models/specifications_test.rb
+++ b/test/project_types/extension/models/specifications_test.rb
@@ -19,7 +19,7 @@ module Extension
 
       def test_supports_retrieving_all_specification_handlers
         specifications = DummySpecifications.build
-        assert_kind_of(SpecificationHandlers::Default, specifications["TEST_EXTENSION"])
+        assert_kind_of(SpecificationHandlers::Default, specifications["test_extension"])
       end
 
       def test_supports_retrieving_an_individual_specification_handler

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -14,7 +14,7 @@ module Extension
 
           @registration_id = 42
           @registration_uuid = "123"
-          @fake_type = "TEST_EXTENSION"
+          @fake_specification_identifier = "test_extension"
           @fake_title = "Fake Title"
           @fake_extension_context = "fake_context"
           @last_user_interaction_at = Time.now.to_s
@@ -32,7 +32,7 @@ module Extension
           hash = {
             Converters::RegistrationConverter::ID_FIELD => @registration_id,
             Converters::RegistrationConverter::UUID_FIELD => @registration_uuid,
-            Converters::RegistrationConverter::TYPE_FIELD => @fake_type,
+            Converters::RegistrationConverter::SPECIFICATION_IDENTIFIER_FIELD => @fake_specification_identifier,
             Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
             Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
               Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
@@ -45,7 +45,7 @@ module Extension
           assert_kind_of(Models::Registration, parsed_registration)
           assert_equal @registration_id, parsed_registration.id
           assert_equal @registration_uuid, parsed_registration.uuid
-          assert_equal @fake_type, parsed_registration.type
+          assert_equal @fake_specification_identifier, parsed_registration.specification_identifier
           assert_equal @fake_title, parsed_registration.title
           assert_equal @registration_id, parsed_registration.draft_version.registration_id
           assert_kind_of(Time, parsed_registration.draft_version.last_user_interaction_at)

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -14,7 +14,7 @@ module Extension
         ShopifyCli::ProjectType.load_type(:extension)
 
         @api_key = "FAKE_API_KEY"
-        @fake_type = "TEST_EXTENSION"
+        @fake_specification_identifier = "test_extension"
         @fake_title = "Fake Title"
         @fake_config = {
           field: "with stuff",
@@ -23,7 +23,7 @@ module Extension
 
         @input = {
           api_key: @api_key,
-          type: @fake_type,
+          specification_identifier: @fake_specification_identifier,
           title: @fake_title,
           config: @fake_config,
           extension_context: @fake_extension_context,
@@ -36,7 +36,7 @@ module Extension
         created_registration = Tasks::CreateExtension.call(
           context: @context,
           api_key: @api_key,
-          type: @fake_type,
+          specification_identifier: @fake_specification_identifier,
           title: @fake_title,
           config: @fake_config,
           extension_context: @fake_extension_context
@@ -52,7 +52,7 @@ module Extension
           Tasks::CreateExtension.call(
             context: @context,
             api_key: @api_key,
-            type: @fake_type,
+            specification_identifier: @fake_specification_identifier,
             title: @fake_title,
             config: @fake_config,
             extension_context: @fake_extension_context
@@ -70,7 +70,7 @@ module Extension
           Tasks::CreateExtension.call(
             context: @context,
             api_key: @api_key,
-            type: @fake_type,
+            specification_identifier: @fake_specification_identifier,
             title: @fake_title,
             config: @fake_config,
             extension_context: @fake_extension_context


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Part of: https://github.com/Shopify/extensions/issues/235
Preceding fix: https://github.com/Shopify/partners/pull/35156

To work more dynamically with new extension types we need to remove the `Type` enum and introduce a new `String` field that can accept any valid `specification_identifier`.

### WHAT is this pull request doing?
Remove the use of "Type" field and introduce "specificationIdentifier" field of type string

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
