### PR TITLE
[Checkout UI Extensions] Accept extension name in config file 

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -4,7 +4,7 @@ module Extension
   module Models
     module SpecificationHandlers
       class CheckoutUiExtension < Default
-        PERMITTED_CONFIG_KEYS = [:metafields, :extension_points]
+        PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name]
 
         def config(context)
           {

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -42,9 +42,10 @@ module Extension
           script_content = "alert(true)"
           metafields = [{ key: "a-key", namespace: "a-namespace" }]
           extension_points = ["Checkout::Feature::Render"]
+          name = "Extension name"
 
           initial_config = { script_content: script_content }
-          yaml_config = { "metafields": metafields, "extension_points": extension_points }
+          yaml_config = { "extension_points": extension_points, "metafields": metafields, "name": name }
 
           Features::Argo.any_instance.expects(:config).with(@context).once.returns(initial_config)
           Features::ArgoConfig.stubs(:parse_yaml).returns(yaml_config)
@@ -52,6 +53,7 @@ module Extension
           config = @checkout_ui_extension.config(@context)
           assert_equal(metafields, config[:metafields])
           assert_equal(extension_points, config[:extension_points])
+          assert_equal(name, config[:name])
           assert_equal(script_content, config[:script_content])
         end
 
@@ -59,7 +61,7 @@ module Extension
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig
             .expects(:parse_yaml)
-            .with(@context, [:metafields, :extension_points])
+            .with(@context, [:extension_points, :metafields, :name])
             .once
             .returns({})
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/checkout-web/issues/6020

We want to allow partners to provide us with a merchant facing name for their extension that will be surfaced in the editor and used by the merchant to identify the extension. Right now, we are using a default one through the template if partners don't change it, but we are thinking an iteration of that would be to prompt partners on the CLI to specify one so it does not confuse merchants and enforcing the name as the same time.

### WHAT is this pull request doing?

Simply adding `name` as a configuration field for the extension.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
