### PR TITLE
Fix uploading of binary theme files under Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ------
 
 * [#1386](https://github.com/Shopify/shopify-cli/pull/1386): Update Theme-Check to 1.2
+* [#1457](https://github.com/Shopify/shopify-cli/pull/1457): Fix uploading of binary theme files under Windows
 
 Version 2.2.2
 ------

--- a/lib/shopify-cli/theme/file.rb
+++ b/lib/shopify-cli/theme/file.rb
@@ -17,12 +17,20 @@ module ShopifyCli
       end
 
       def read
-        path.read
+        if text?
+          path.read
+        else
+          path.read(mode: "rb")
+        end
       end
 
-      def write(*args)
+      def write(content)
         path.parent.mkpath unless path.parent.directory?
-        path.write(*args)
+        if text?
+          path.write(content)
+        else
+          path.write(content, 0, mode: "wb")
+        end
       end
 
       def delete

--- a/lib/shopify-cli/theme/syncer.rb
+++ b/lib/shopify-cli/theme/syncer.rb
@@ -256,7 +256,7 @@ module ShopifyCli
 
         attachment = body.dig("asset", "attachment")
         value = if attachment
-          file.write(Base64.decode64(attachment), 0, mode: "wb")
+          file.write(Base64.decode64(attachment))
         else
           file.write(body.dig("asset", "value"))
         end

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -88,6 +88,25 @@ module ShopifyCli
           "\"theme_support_url\":\"https:\\/\\/support.shopify.com\\/\"}]"
         assert_equal(Digest::MD5.hexdigest(normalized), @theme["config/settings_schema.json"].checksum)
       end
+
+      def test_read_binary_file
+        file = @theme["assets/logo.png"]
+
+        content = file.read
+        assert_equal(file.path.size, content.bytesize)
+      end
+
+      def test_write_binary_file
+        file = @theme["assets/logo.png"]
+        new_file = @theme["assets/logo2.png"]
+
+        begin
+          new_file.write(file.read)
+          assert_equal(file.path.size, new_file.path.size)
+        ensure
+          ::File.delete(new_file.path) if new_file.exist?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Binary files where not opened in binary mode when read. This broke encoding under Windows. But worked fine under *nix.

Fixes #1401 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Ensure all non-text (binary) theme files are opened in binary mode (`b`) before writing or reading.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Tested under Windows.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
