### PR TITLE
Remove broken link about reduced test cases

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,10 +24,6 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 1.
 1.
 
-## Reduced test case
-
-The best way to get your bug fixed is to provide a [reduced test case](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Reducing_testcases).
-
 
 
 ## Specifications


### PR DESCRIPTION
The GitHub issue template had a broken link on it. I've removed the link and the surrounding text since it doesn't seem necessary and it's not obvious what to replace it with.