### PR TITLE
[Chore] Fix unit tests by properly stubbing out ShopifyCli::Feature

### DIFF
--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -43,8 +43,22 @@ describe Script::Layers::Application::ExtensionPoints do
   end
 
   describe ".available_types" do
-    it "should return an array of all ep types that are not deprecated or in beta" do
-      assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.available_types
+    describe "when beta flag is disabled" do
+      before do
+        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(false).at_least_once
+      end
+      it "should return an array of all ep types that are not deprecated or in beta" do
+        assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.available_types
+      end
+    end
+
+    describe "when beta flag is enabled" do
+      before do
+        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(true).at_least_once
+      end
+      it "should return an array of all ep types that are not deprecated or in beta" do
+        assert_equal %w(discount tax_filter), Script::Layers::Application::ExtensionPoints.available_types
+      end
     end
   end
 


### PR DESCRIPTION
Properly test whether available_type() returns types including beta API types by stubbing ShopifyCli::Features to enable :scripts_beta_extension_points beta flag.

