### PR TITLE
Pulled UploadScript out of ScriptService with additional cleanup

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -52,6 +52,7 @@ module Script
       autoload :ExtensionPointRepository, Project.project_filepath("layers/infrastructure/extension_point_repository")
       autoload :ScriptProjectRepository, Project.project_filepath("layers/infrastructure/script_project_repository")
       autoload :ScriptService, Project.project_filepath("layers/infrastructure/script_service")
+      autoload :ScriptUploader, Project.project_filepath("layers/infrastructure/script_uploader")
 
       module Languages
         autoload :AssemblyScriptProjectCreator,

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -20,7 +20,15 @@ module Script
                 compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata,
               )
-              uuid = package.push(Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key), script_project.api_key, force)
+              uuid = Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key).push(
+                uuid: package.uuid,
+                extension_point_type: package.extension_point_type,
+                script_content: package.script_content,
+                api_key: script_project.api_key,
+                force: force,
+                metadata: package.metadata,
+                script_json: package.script_json,
+              )
               script_project_repo.update_env(uuid: uuid)
               spinner.update_title(p_ctx.message("script.application.pushed"))
             end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -26,7 +26,6 @@ module Script
                 uuid: package.uuid,
                 extension_point_type: package.extension_point_type,
                 script_content: package.script_content,
-                api_key: script_project.api_key,
                 force: force,
                 metadata: package.metadata,
                 script_json: package.script_json,

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -20,7 +20,7 @@ module Script
                 compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata,
               )
-              uuid = package.push(Infrastructure::ScriptService.new(ctx: p_ctx), script_project.api_key, force)
+              uuid = package.push(Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key), script_project.api_key, force)
               script_project_repo.update_env(uuid: uuid)
               spinner.update_title(p_ctx.message("script.application.pushed"))
             end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -22,7 +22,7 @@ module Script
               )
               script_service = Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key)
               module_upload_url = Infrastructure::ScriptUploader.new(script_service).upload(package.script_content)
-              uuid = script_service.push(
+              uuid = script_service.set_app_script(
                 uuid: package.uuid,
                 extension_point_type: package.extension_point_type,
                 script_content: package.script_content,

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -20,7 +20,9 @@ module Script
                 compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata,
               )
-              uuid = Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key).push(
+              script_service = Infrastructure::ScriptService.new(ctx: p_ctx, api_key: script_project.api_key)
+              module_upload_url = Infrastructure::ScriptUploader.new(script_service).upload(package.script_content)
+              uuid = script_service.push(
                 uuid: package.uuid,
                 extension_point_type: package.extension_point_type,
                 script_content: package.script_content,
@@ -28,6 +30,7 @@ module Script
                 force: force,
                 metadata: package.metadata,
                 script_json: package.script_json,
+                module_upload_url: module_upload_url,
               )
               script_project_repo.update_env(uuid: uuid)
               spinner.update_title(p_ctx.message("script.application.pushed"))

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -29,18 +29,6 @@ module Script
           @metadata = metadata
           @script_json = script_json
         end
-
-        def push(script_service, api_key, force)
-          script_service.push(
-            uuid: @uuid,
-            extension_point_type: @extension_point_type,
-            script_content: @script_content,
-            api_key: api_key,
-            force: force,
-            metadata: @metadata,
-            script_json: @script_json,
-          )
-        end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -16,7 +16,7 @@ module Script
           @client = ApiClients.default_client(ctx, api_key)
         end
 
-        def push(
+        def set_app_script(
           uuid:,
           extension_point_type:,
           force: false,

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -9,15 +9,16 @@ module Script
       class ScriptService
         include SmartProperties
         property! :ctx, accepts: ShopifyCli::Context
+        property! :api_key, accepts: String
 
         def initialize(*args, ctx:, api_key:, **kwargs)
+          super(*args, ctx: ctx, api_key: api_key, **kwargs)
           @client = ApiClients.default_client(ctx, api_key)
         end
 
         def push(
           uuid:,
           extension_point_type:,
-          api_key: nil,
           force: false,
           metadata:,
           script_json:,
@@ -65,7 +66,7 @@ module Script
           end
         end
 
-        def get_app_scripts(api_key:, extension_point_type:)
+        def get_app_scripts(extension_point_type:)
           query_name = "get_app_scripts"
           variables = { appKey: api_key, extensionPointName: extension_point_type.upcase }
           response = make_request(query_name: query_name, variables: variables)

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -1,0 +1,27 @@
+module Script
+  module Layers
+    module Infrastructure
+      class ScriptUploader
+        def initialize(script_service)
+          @script_service = script_service
+        end
+
+        def upload(script_content)
+          @script_service.generate_module_upload_url.tap do |url|
+            url = URI(url)
+
+            https = Net::HTTP.new(url.host, url.port)
+            https.use_ssl = true
+
+            request = Net::HTTP::Put.new(url)
+            request["Content-Type"] = "application/wasm"
+            request.body = script_content
+
+            response = https.request(request)
+            raise Errors::ScriptUploadError unless response.code == "200"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -89,7 +89,7 @@ module Script
       end
 
       def ask_script_uuid(app, extension_point_type)
-        script_service = Layers::Infrastructure::ScriptService.new(ctx: ctx)
+        script_service = Layers::Infrastructure::ScriptService.new(ctx: ctx, api_key: app["apiKey"])
         scripts = script_service.get_app_scripts(api_key: app["apiKey"], extension_point_type: extension_point_type)
 
         return nil unless scripts.count > 0 &&

--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -90,7 +90,7 @@ module Script
 
       def ask_script_uuid(app, extension_point_type)
         script_service = Layers::Infrastructure::ScriptService.new(ctx: ctx, api_key: app["apiKey"])
-        scripts = script_service.get_app_scripts(api_key: app["apiKey"], extension_point_type: extension_point_type)
+        scripts = script_service.get_app_scripts(extension_point_type: extension_point_type)
 
         return nil unless scripts.count > 0 &&
           CLI::UI::Prompt.confirm(ctx.message("script.application.ensure_env.ask_connect_to_existing_script"))

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -51,6 +51,7 @@ describe Script::Layers::Application::PushScript do
 
     it "should prepare and push script" do
       script_service_instance = Script::Layers::Infrastructure::ScriptService.new(ctx: @context, api_key: api_key)
+      script_service_instance.expects(:push).returns(uuid)
       Script::Layers::Application::ProjectDependencies
         .expects(:install).with(ctx: @context, task_runner: task_runner)
       Script::Layers::Application::BuildScript.expects(:call).with(
@@ -60,8 +61,6 @@ describe Script::Layers::Application::PushScript do
       )
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)
-      Script::Layers::Domain::PushPackage
-        .any_instance.expects(:push).with(script_service_instance, api_key, force).returns(uuid)
       capture_io { subject }
       assert_equal uuid, script_project_repository.get.uuid
     end

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -50,7 +50,7 @@ describe Script::Layers::Application::PushScript do
     subject { Script::Layers::Application::PushScript.call(ctx: @context, force: force) }
 
     it "should prepare and push script" do
-      script_service_instance = Script::Layers::Infrastructure::ScriptService.new(ctx: @context)
+      script_service_instance = Script::Layers::Infrastructure::ScriptService.new(ctx: @context, api_key: api_key)
       Script::Layers::Application::ProjectDependencies
         .expects(:install).with(ctx: @context, task_runner: task_runner)
       Script::Layers::Application::BuildScript.expects(:call).with(

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -52,7 +52,7 @@ describe Script::Layers::Application::PushScript do
 
     it "should prepare and push script" do
       script_service_instance = Script::Layers::Infrastructure::ScriptService.new(ctx: @context, api_key: api_key)
-      script_service_instance.expects(:push).returns(uuid)
+      script_service_instance.expects(:set_app_script).returns(uuid)
       Script::Layers::Infrastructure::ScriptService
         .expects(:new).returns(script_service_instance)
 

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -35,18 +35,4 @@ describe Script::Layers::Domain::PushPackage do
       assert_equal uuid, subject.uuid
     end
   end
-
-  describe ".push" do
-    subject { push_package.push(script_service, api_key, force) }
-
-    it "should open write to build file and push" do
-      script_service.expect(:push, nil) do |kwargs|
-        kwargs[:extension_point_type] == extension_point_type &&
-          kwargs[:script_content] == script_content &&
-          kwargs[:api_key] == api_key &&
-          kwargs[:uuid] == uuid
-      end
-      subject
-    end
-  end
 end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -55,7 +55,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     HERE
   end
 
-  describe ".push" do
+  describe ".set_app_script" do
     let(:script_content) { "(module)" }
     let(:api_key) { "fake_key" }
     let(:uuid_from_config) { "uuid_from_config" }
@@ -133,7 +133,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
 
     subject do
-      script_service.push(
+      script_service.set_app_script(
         uuid: uuid_from_config,
         extension_point_type: extension_point_type,
         metadata: Script::Layers::Domain::Metadata.new(
@@ -146,7 +146,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       )
     end
 
-    describe "when push to script service succeeds" do
+    describe "when set_app_script to script service succeeds" do
       let(:script_service_response) do
         {
           "data" => {
@@ -177,7 +177,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
     end
 
-    describe "when push to script service responds with errors" do
+    describe "when set_app_script to script service responds with errors" do
       let(:response) do
         {
           data: {
@@ -203,7 +203,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       end
     end
 
-    describe "when push to script service responds with userErrors" do
+    describe "when set_app_script to script service responds with userErrors" do
       describe "when invalid app key" do
         let(:response) do
           {
@@ -224,7 +224,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
-      describe "when repush without a force" do
+      describe "when set_app_script without a force" do
         let(:response) do
           {
             data: {

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -6,8 +6,8 @@ describe Script::Layers::Infrastructure::ScriptService do
   include TestHelpers::Partners
 
   let(:ctx) { TestHelpers::FakeContext.new }
-  let(:script_service) { Script::Layers::Infrastructure::ScriptService.new(ctx: ctx) }
   let(:api_key) { "fake_key" }
+  let(:script_service) { Script::Layers::Infrastructure::ScriptService.new(ctx: ctx, api_key: api_key) }
   let(:extension_point_type) { "DISCOUNT" }
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
@@ -287,7 +287,7 @@ describe Script::Layers::Infrastructure::ScriptService do
   end
 
   describe "UploadScript" do
-    let(:instance) { Script::Layers::Infrastructure::ScriptService::UploadScript.new(ctx) }
+    let(:instance) { Script::Layers::Infrastructure::ScriptService::UploadScript.new(script_service) }
     subject { instance.call(api_key, script_content) }
 
     let(:api_key) { "fake_key" }

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -142,7 +142,6 @@ describe Script::Layers::Infrastructure::ScriptService do
           use_msgpack,
         ),
         script_json: script_json,
-        api_key: api_key,
         module_upload_url: url
       )
     end
@@ -331,7 +330,6 @@ describe Script::Layers::Infrastructure::ScriptService do
 
     subject do
       script_service.get_app_scripts(
-        api_key: api_key,
         extension_point_type: extension_point_type,
       )
     end

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -1,0 +1,122 @@
+describe Script::Layers::Infrastructure::ScriptUploader do
+  include TestHelpers::Partners
+
+  describe "UploadScript" do
+    let(:ctx) { TestHelpers::FakeContext.new }
+    let(:api_key) { "fake_key" }
+    let(:script_service) { Script::Layers::Infrastructure::ScriptService.new(ctx: ctx, api_key: api_key) }
+    let(:instance) { Script::Layers::Infrastructure::ScriptUploader.new(script_service) }
+    subject { instance.upload(script_content) }
+
+    let(:api_key) { "fake_key" }
+    let(:script_content) { "(module)" }
+    let(:module_upload_url_generate) do
+      <<~HERE
+        mutation moduleUploadUrlGenerate {
+          moduleUploadUrlGenerate {
+            url
+            userErrors {
+              field
+              message
+            }
+          }
+        }
+      HERE
+    end
+    let(:url) { "https://some-bucket" }
+    let(:response) do
+      {
+        data: {
+          scriptServiceProxy: JSON.dump(script_service_response),
+        },
+      }
+    end
+    let(:script_service_proxy) do
+      <<~HERE
+        query ProxyRequest($api_key: String, $query: String!, $variables: String) {
+          scriptServiceProxy(
+            apiKey: $api_key
+            query: $query
+            variables: $variables
+          )
+        }
+      HERE
+    end
+
+    before do
+      stub_load_query("script_service_proxy", script_service_proxy)
+      stub_load_query("module_upload_url_generate", module_upload_url_generate)
+      stub_partner_req(
+        "script_service_proxy",
+        variables: {
+          api_key: api_key,
+          variables: {}.to_json,
+          query: module_upload_url_generate,
+        },
+        resp: response
+      )
+    end
+
+    describe "when fail to apply module upload url" do
+      let(:script_service_response) do
+        {
+          "data" => {
+            "moduleUploadUrlGenerate" => {
+              "url" => nil,
+              "userErrors" => [{ "message" => "invalid", "field" => "appKey", "tag" => "user_error" }],
+            },
+          },
+        }
+      end
+
+      it "should raise GraphqlError" do
+        assert_raises(Script::Layers::Infrastructure::Errors::GraphqlError) { subject }
+      end
+    end
+
+    describe "when succeed to apply module upload url" do
+      let(:script_service_response) do
+        {
+          "data" => {
+            "moduleUploadUrlGenerate" => {
+              "url" => url,
+              "userErrors" => [],
+            },
+          },
+        }
+      end
+
+      describe "when fail to upload module" do
+        before do
+          stub_request(:put, url).with(
+            headers: { "Content-Type" => "application/wasm" },
+            body: script_content
+          ).to_return(status: 500)
+        end
+
+        it "should raise an ScriptUploadError" do
+          assert_raises(Script::Layers::Infrastructure::Errors::ScriptUploadError) { subject }
+        end
+      end
+
+      describe "when succeed to upload module" do
+        before do
+          stub_request(:put, url).with(
+            headers: { "Content-Type" => "application/wasm" },
+            body: script_content
+          ).to_return(status: 200)
+        end
+
+        it "should return the url" do
+          assert_equal(url, subject)
+        end
+      end
+    end
+  end
+
+  private
+
+  def stub_load_query(name, body)
+    ShopifyCli::API.any_instance.stubs(:load_query).with(name).returns(body)
+  end
+end

--- a/test/project_types/script/tasks/ensure_env_test.rb
+++ b/test/project_types/script/tasks/ensure_env_test.rb
@@ -97,7 +97,7 @@ describe Script::Tasks::EnsureEnv do
           Script::Layers::Infrastructure::ScriptService
             .any_instance
             .stubs(:get_app_scripts)
-            .with(api_key: selected_api_key, extension_point_type: extension_point_type)
+            .with(extension_point_type: extension_point_type)
             .returns(existing_scripts)
         end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Continues https://github.com/Shopify/shopify-cli/pull/1499.

Further clean up `ScriptService`, focusing it just on interacting with the backend script-service.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Moved `UploadScript` out of `ScriptService` and into `ScriptUploader`. `MakeRequest` has been dissolved into `ScriptService` and a new `generate_module_upload_url` was added for `ScriptUploader` to use instead of relying on `MakeRequest`.

`ScriptService#push` was changed to `ScriptService#set_app_script` to better reflect the web API it was built against. All of the upload and script set orchestration was moved to `PushScript` (this includes removing the delegated call to `ScriptService` in `PushPackage`).

### Update checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
