### PR TITLE
Add `theme push` & `pull` option to ignore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 * [#1386](https://github.com/Shopify/shopify-cli/pull/1386): Update Theme-Check to 1.2
 * [#1457](https://github.com/Shopify/shopify-cli/pull/1457): Fix uploading of binary theme files under Windows
 * [#1480](https://github.com/Shopify/shopify-cli/pull/1480): Fix customers pages not working with `theme serve`
+* [#1479](https://github.com/Shopify/shopify-cli/pull/1479): Add theme push & pull option to ignore files per command
 
 Version 2.2.2
 ------

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -9,6 +9,10 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
+        parser.on("-x", "--ignore=PATTERN") do |pattern|
+          flags[:ignores] ||= []
+          flags[:ignores] << pattern
+        end
       end
 
       def call(args, _name)
@@ -29,6 +33,8 @@ module Theme
         end
 
         ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(root)
+        ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
+
         syncer = ShopifyCli::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
         begin
           syncer.start_threads

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -15,6 +15,10 @@ module Theme
         parser.on("-j", "--json") { flags[:json] = true }
         parser.on("-a", "--allow-live") { flags[:allow_live] = true }
         parser.on("-p", "--publish") { flags[:publish] = true }
+        parser.on("-x", "--ignore=PATTERN") do |pattern|
+          flags[:ignores] ||= []
+          flags[:ignores] << pattern
+        end
       end
 
       def call(args, _name)
@@ -48,6 +52,8 @@ module Theme
         end
 
         ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(root)
+        ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
+
         syncer = ShopifyCli::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
         begin
           syncer.start_threads

--- a/lib/shopify-cli/theme/ignore_filter.rb
+++ b/lib/shopify-cli/theme/ignore_filter.rb
@@ -59,6 +59,13 @@ module ShopifyCli
         @globs = globs
       end
 
+      def add_patterns(patterns)
+        regexes, globs = patterns_to_regexes_and_globs(patterns)
+
+        @regexes += regexes
+        @globs += globs
+      end
+
       def match?(path)
         path = path.to_s
 

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -66,6 +66,30 @@ module Theme
         @command.call([], "pull")
       end
 
+      def test_pull_with_ignores
+        ShopifyCli::Theme::Theme.expects(:new)
+          .with(@ctx, root: ".", id: 1234)
+          .returns(@theme)
+
+        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        @ignore_filter.expects(:add_patterns).with(["config/*"])
+
+        ShopifyCli::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:ignores] = ["config/*"]
+        @command.call([], "pull")
+      end
+
       def test_pull_asks_to_select
         CLI::UI::Prompt.expects(:ask).returns(@theme)
         @ctx.expects(:done)

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -146,6 +146,29 @@ module Theme
         @command.call([], "push")
       end
 
+      def test_push_with_ignores
+        ShopifyCli::Theme::Theme.expects(:new)
+          .with(@ctx, root: ".", id: 1234)
+          .returns(@theme)
+
+        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        @ignore_filter.expects(:add_patterns).with(["config/*"])
+
+        ShopifyCli::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:ignores] = ["config/*"]
+        @command.call([], "push")
+      end
+
       def test_push_to_development_theme
         ShopifyCli::Theme::DevelopmentTheme.expects(:new)
           .with(@ctx, root: ".")

--- a/test/shopify-cli/theme/ignore_filter_test.rb
+++ b/test/shopify-cli/theme/ignore_filter_test.rb
@@ -69,20 +69,18 @@ module ShopifyCli
       end
 
       def test_add
-        tests = [
+        filter = IgnoreFilter.new("/tmp")
+        test_cases = [
           { pattern: "config/settings_data.json", glob: "*config/settings_data.json" },
           { pattern: "config/", glob: "*config/*" },
           { pattern: "*.jpg", glob: "*.jpg" },
           { pattern: "/\\.(txt|gif|bat)$/", regex: /\.(txt|gif|bat)$/ },
         ]
 
-        filter = IgnoreFilter.new("/tmp")
-        patterns = tests.map { |testcase| testcase[:pattern] }
-        filter.add_patterns(patterns)
-
-        tests.each do |testcase|
-          assert_includes(filter.globs, testcase[:glob]) unless testcase[:glob].nil?
-          assert_includes(filter.regexes, testcase[:regex]) unless testcase[:regex].nil?
+        test_cases.each do |test_case|
+          filter.add_patterns([test_case.fetch(:pattern)])
+          assert_includes(filter.globs, test_case.fetch(:glob)) if test_case.key?(:glob)
+          assert_includes(filter.regexes, test_case.fetch(:regex)) if test_case.key?(:regex)
         end
       end
     end

--- a/test/shopify-cli/theme/ignore_filter_test.rb
+++ b/test/shopify-cli/theme/ignore_filter_test.rb
@@ -67,6 +67,24 @@ module ShopifyCli
           assert_includes(filter.regexes, testcase[:regex]) unless testcase[:regex].nil?
         end
       end
+
+      def test_add
+        tests = [
+          { pattern: "config/settings_data.json", glob: "*config/settings_data.json" },
+          { pattern: "config/", glob: "*config/*" },
+          { pattern: "*.jpg", glob: "*.jpg" },
+          { pattern: "/\\.(txt|gif|bat)$/", regex: /\.(txt|gif|bat)$/ },
+        ]
+
+        filter = IgnoreFilter.new("/tmp")
+        patterns = tests.map { |testcase| testcase[:pattern] }
+        filter.add_patterns(patterns)
+
+        tests.each do |testcase|
+          assert_includes(filter.globs, testcase[:glob]) unless testcase[:glob].nil?
+          assert_includes(filter.regexes, testcase[:regex]) unless testcase[:regex].nil?
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

It's impossible to ignore some theme files per command. A common pattern is to ignore config/ files.

Fixes #1430 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add an `--ignore` (shorthand `-x`) option to `shopify theme push` and `shopify theme pull` to add patterns to ignore. Same format as https://shopify.dev/themes/tools/cli#excluding-files-from-shopify-cli.

Ex.:

```
shopify theme push --ignore "config/*.json"
```

The ignore option is merged with any pattern defined in `.shopifyignore`


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
