### PR TITLE
Renew `_secure_session_id` cookie on proxy response during `theme serve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 * [#1386](https://github.com/Shopify/shopify-cli/pull/1386): Update Theme-Check to 1.2
 * [#1457](https://github.com/Shopify/shopify-cli/pull/1457): Fix uploading of binary theme files under Windows
+* [#1480](https://github.com/Shopify/shopify-cli/pull/1480): Fix customers pages not working with `theme serve`
 
 Version 2.2.2
 ------

--- a/lib/shopify-cli/theme/dev_server/header_hash.rb
+++ b/lib/shopify-cli/theme/dev_server/header_hash.rb
@@ -47,6 +47,10 @@ module ShopifyCli
           super(k) || super(@names[k.downcase])
         end
 
+        def fetch(k, default = nil)
+          self[k] || super(@names[k.downcase], default)
+        end
+
         def []=(k, v)
           canonical = k.downcase.freeze
           # .delete is expensive, don't invoke it unless necessary

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -64,6 +64,38 @@ module ShopifyCli
             times: 2)
         end
 
+        def test_update_session_cookie_when_returned_from_backend
+          stub_session_id_request
+          new_secure_session_id = "#{SECURE_SESSION_ID}2"
+
+          # POST response returning a new session cookie (Set-Cookie)
+          stub_request(:post, "https://dev-theme-server-store.myshopify.com/account/login?_fd=0&pb=0")
+            .with(
+              headers: {
+                "Cookie" => "_secure_session_id=#{SECURE_SESSION_ID}",
+              }
+            )
+            .to_return(
+              status: 200,
+              body: "",
+              headers: {
+                "Set-Cookie" => "_secure_session_id=#{new_secure_session_id}",
+              }
+            )
+
+          # GET / passing the new session cookie
+          stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
+            .with(
+              headers: {
+                "Cookie" => "_secure_session_id=#{new_secure_session_id}",
+              }
+            )
+            .to_return(status: 200)
+
+          request.post("/account/login")
+          request.get("/")
+        end
+
         def test_form_data_is_proxied_to_online_store
           stub_request(:post, "https://dev-theme-server-store.myshopify.com/password?_fd=0&pb=0")
             .with(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://community.shopify.com/c/Online-Store-2-0/Unable-to-log-into-customer-account-when-using-shopify-theme/m-p/1289042

`theme serve` didn't work on /account pages because logging in as a customer created a new _secure_session_id cookie, and we didn't updated it in `Proxy`. Only when it expired.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Renew our `_secure_session_id` cookie when getting a new one from a proxy response during `theme serve`.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
