### PR TITLE
add ServerConfig module, classes

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -87,6 +87,16 @@ module Extension
       autoload :Default, Project.project_filepath("models/specification_handlers/default")
     end
 
+    module ServerConfig
+      autoload :Base, Project.project_filepath("models/server_config/base")
+      autoload :Development, Project.project_filepath("models/server_config/development")
+      autoload :DevelopmentEntries, Project.project_filepath("models/server_config/development_entries")
+      autoload :DevelopmentRenderer, Project.project_filepath("models/server_config/development_renderer")
+      autoload :Extension, Project.project_filepath("models/server_config/extension")
+      autoload :Root, Project.project_filepath("models/server_config/root")
+      autoload :User, Project.project_filepath("models/server_config/user")
+    end
+
     autoload :App, Project.project_filepath("models/app")
     autoload :Registration, Project.project_filepath("models/registration")
     autoload :Version, Project.project_filepath("models/version")

--- a/lib/project_types/extension/models/server_config/base.rb
+++ b/lib/project_types/extension/models/server_config/base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module ServerConfig
+      class Base
+        def to_h
+          to_hash
+        end
+
+        def to_hash
+          is_hashable = ->(obj) { obj.respond_to?(:to_hash) }
+          is_collection_of_hashables = ->(obj) { obj.is_a?(Enumerable) && obj.all?(&is_hashable) }
+
+          self.class.properties.each.reduce({}) do |data, (_, property)|
+            data.merge(property.name.to_s => send(property.reader).yield_self do |value|
+              case value
+              when is_collection_of_hashables
+                value.map { |element| element.to_hash.transform_keys(&:to_s) }
+              when is_hashable
+                value.to_hash.transform_keys(&:to_s)
+              else
+                value
+              end
+            end)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/development.rb
+++ b/lib/project_types/extension/models/server_config/development.rb
@@ -1,0 +1,21 @@
+module Extension
+  module Models
+    module ServerConfig
+      class Development < Base
+        include SmartProperties
+        VALID_TEMPLATES = [
+          "javascript",
+          "javascript-react",
+          "typescript",
+          "typescript-react",
+        ]
+
+        property! :build_dir, accepts: String, default: "build"
+        property! :root_dir, accepts: String
+        property! :template, accepts: VALID_TEMPLATES
+        property! :renderer, accepts: ServerConfig::DevelopmentRenderer
+        property! :entries, accepts: ServerConfig::DevelopmentEntries
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/development_entries.rb
+++ b/lib/project_types/extension/models/server_config/development_entries.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module ServerConfig
+      class DevelopmentEntries < Base
+        include SmartProperties
+
+        VALID_ENTRY_POINTS = [
+          "src/index.js",
+          "src/index.jsx",
+          "src/index.ts",
+          "src/index.tsx",
+        ]
+
+        property! :main, accepts: VALID_ENTRY_POINTS
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module ServerConfig
+      class DevelopmentRenderer < Base
+        include SmartProperties
+
+        VALID_RENDERERS = [
+          "@shopify/admin-ui-extensions",
+          "@shopify/post-purchase-ui-extensions",
+          "@shopify/checkout-ui-extensions",
+        ]
+
+        property! :name, accepts: VALID_RENDERERS
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/extension.rb
+++ b/lib/project_types/extension/models/server_config/extension.rb
@@ -1,0 +1,13 @@
+module Extension
+  module Models
+    module ServerConfig
+      class Extension < Base
+        include SmartProperties
+        property! :uuid, accepts: String
+        property! :type, accepts: String
+        property! :user, accepts: ServerConfig::User
+        property! :development, accepts: ServerConfig::Development
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/root.rb
+++ b/lib/project_types/extension/models/server_config/root.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module ServerConfig
+      class Root < Base
+        include SmartProperties
+
+        property! :port, accepts: Integer, default: 39351
+        property! :extensions, accepts: [ServerConfig::Extension]
+
+        def to_yaml
+          to_h.to_yaml.gsub("---\n", "")
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/user.rb
+++ b/lib/project_types/extension/models/server_config/user.rb
@@ -1,0 +1,10 @@
+module Extension
+  module Models
+    module ServerConfig
+      class User < Base
+        include SmartProperties
+        property! :metafields, accepts: Array, default: -> { [] }
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/development_entries_test.rb
+++ b/test/project_types/extension/models/server_config/development_entries_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class DevelopmentEntriesTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_entries_are_created_with_valid_attributes
+          assert_nothing_raised do
+            ServerConfig::DevelopmentEntries.new(main: "src/index.js")
+          end
+        end
+
+        def test_invalid_entry_raises_error
+          assert_raises SmartProperties::Error do
+            ServerConfig::DevelopmentEntries.new(
+              main: "invalid"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/development_renderer_test.rb
+++ b/test/project_types/extension/models/server_config/development_renderer_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class DevelopmentRendererTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_extension_config_renderer_can_be_instantiated_with_valid_attributes
+          assert_nothing_raised do
+            ServerConfig::DevelopmentRenderer.new(
+              name: "@shopify/checkout-ui-extensions"
+            )
+          end
+        end
+
+        def test_invalid_renderer_name_raises_error
+          assert_raises SmartProperties::Error do
+            ServerConfig::DevelopmentRenderer.new(
+              name: "invalid"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/development_test.rb
+++ b/test/project_types/extension/models/server_config/development_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class DevelopmentTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_server_config_development_can_be_instantiated_with_valid_attributes
+          assert_nothing_raised do
+            ServerConfig::Development.new(
+              build_dir: "test",
+              root_dir: "test",
+              template: "javascript",
+              renderer: renderer,
+              entries: entries,
+            )
+          end
+        end
+
+        def test_invalild_template_raises_error
+          assert_raises SmartProperties::Error do
+            ServerConfig::Development.new(
+              build_dir: "test",
+              root_dir: "test",
+              template: "invalid",
+              renderer: renderer,
+              entries: entries,
+            )
+          end
+        end
+
+        private
+
+        def renderer
+          ServerConfig::DevelopmentRenderer.new(name: "@shopify/checkout-ui-extensions")
+        end
+
+        def entries
+          ServerConfig::DevelopmentEntries.new(main: "src/index.js")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/extension_test.rb
+++ b/test/project_types/extension/models/server_config/extension_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class ExtensionTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_extension_config_can_be_instantiated_with_valid_attributes
+          assert_nothing_raised do
+            ServerConfig::Extension.new(
+              type: "checkout-ui-extension",
+              uuid: "00000000-0000-0000-0000-000000000000",
+              user: ServerConfig::User.new,
+              development: development
+            )
+          end
+        end
+
+        private
+
+        def development
+          renderer = ServerConfig::DevelopmentRenderer.new(name: "@shopify/checkout-ui-extensions")
+          entries = ServerConfig::DevelopmentEntries.new(main: "src/index.js")
+          ServerConfig::Development.new(
+            build_dir: "test",
+            root_dir: "test",
+            template: "javascript",
+            renderer: renderer,
+            entries: entries,
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/root_test.rb
+++ b/test/project_types/extension/models/server_config/root_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class RootTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_root_is_created_with_valid_attributes
+          assert_nothing_raised do
+            Models::ServerConfig::Root.new(
+              extensions: extension
+            )
+          end
+        end
+
+        def test_server_config_root_yaml_output
+          config_file = Models::ServerConfig::Root.new(extensions: extension)
+
+          refute_includes(config_file.to_yaml, "---\n")
+          refute_includes(config_file.to_yaml, "!ruby/")
+          refute_match(/:.+:/, config_file.to_yaml)
+        end
+
+        private
+
+        def extension
+          renderer = ServerConfig::DevelopmentRenderer.new(name: "@shopify/checkout-ui-extensions")
+          entries = ServerConfig::DevelopmentEntries.new(main: "src/index.js")
+          development = ServerConfig::Development.new(
+            build_dir: "test",
+            root_dir: "test",
+            template: "javascript",
+            renderer: renderer,
+            entries: entries,
+          )
+
+          ServerConfig::Extension.new(
+            type: "checkout-ui-extension",
+            uuid: "00000000-0000-0000-0000-000000000000",
+            user: ServerConfig::User.new,
+            development: development
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/server_config/user_test.rb
+++ b/test/project_types/extension/models/server_config/user_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+module Extension
+  module Models
+    module ServerConfig
+      class UserTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_extension_config_user_can_be_instantiated_with_valid_attributes
+          assert_nothing_raised do
+            ServerConfig::User.new
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Part of: https://github.com/Shopify/shopify-cli-extensions/issues/4

### WHAT is this pull request doing?

* Adds `Shopifile` model, which holds the configuration necessary for the new extensions development server
* Adds other models necessary to assemble the data the new extension server needs:
  * Config::Extension
  * Config::User
  * Config::Development
  * Config::DevelopmentSettings::Renderer
  * Config::DevelopmentSettings::Entries 

This will generate YAML on the fly, which we can pass to the extensions server binary. YAML output:

```
port: 39351
extensions:
  uuid: 00000000-0000-0000-0000-000000000000
  type: checkout-ui-extension
  user:
    metafields: []
  development:
    build_dir: test
    root_dir: test
    template: javascript
    renderer:
      name: "@shopify/checkout-ui-extensions"
    entries:
      main: src/index.js
```

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- ~[ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
