### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ------
 
+Version 2.3.0
+------
+
 * [#1386](https://github.com/Shopify/shopify-cli/pull/1386): Update Theme-Check to 1.2
 * [#1457](https://github.com/Shopify/shopify-cli/pull/1457): Fix uploading of binary theme files under Windows
 * [#1480](https://github.com/Shopify/shopify-cli/pull/1480): Fix customers pages not working with `theme serve`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.2.2)
+    shopify-cli (2.3.0)
       listen (~> 3.5)
       theme-check (~> 1.2)
 

--- a/lib/shopify-cli/version.rb
+++ b/lib/shopify-cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCli
-  VERSION = "2.2.2"
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
I'm releasing a new version of the `shopify-cli`, 2.3.0.