### PR TITLE
Add missing Homebrew packages to the dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,6 +4,11 @@ type:
 
 up:
   - ruby: 2.7.1
+  - homebrew:
+    - dpkg:
+        version: 1.20.9
+    - rpm:
+        version: 4.16.1.3
   - bundler
   - node:
       version: 14.9.0


### PR DESCRIPTION
### WHY are these changes introduced?
While releasing a new version of the CLI yesterday the process failed because there two tools missing in my environment, `dpkg` and `rpm`.

### WHAT is this pull request doing?
This PR updates the `dev.yml` to install them as part of the `dev up` command execution.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
