### PR TITLE
Use the right production client ID

### DIFF
--- a/lib/shopify-cli/constants.rb
+++ b/lib/shopify-cli/constants.rb
@@ -10,8 +10,8 @@ module ShopifyCli
     end
 
     module Identity
-      CLIENT_ID_DEV = "fbdb2649-e327-4907-8f67-908d24cfd7e3"
-      CLIENT_ID = "e5380e02-312a-7408-5718-e07017e9cf52"
+      CLIENT_ID_DEV = "e5380e02-312a-7408-5718-e07017e9cf52"
+      CLIENT_ID = "fbdb2649-e327-4907-8f67-908d24cfd7e3"
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?
A recent [refactoring](https://github.com/Shopify/shopify-cli/commit/ddbea943193a90198348b2e83cf8215dfb241924) I introduced resulted in the development client id used when pointing to production, and the production one used when pointing to development. 

### WHAT is this pull request doing?
This PR fixes that. I tested locally and the authentication with production works and it adds the `employee` scope when we want to authenticate as a Shopifolk.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
