### PR TITLE
Adding configurations so that script service and login work with spin

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -179,9 +179,6 @@ module Rails
         Gem.install(@ctx, name, version)
       end
 
-      def local_debug?
-        @ctx.getenv(ShopifyCli::PartnersAPI::LOCAL_DEBUG)
-      end
     end
   end
 end

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -178,7 +178,6 @@ module Rails
       def install_gem(name, version = nil)
         Gem.install(@ctx, name, version)
       end
-
     end
   end
 end

--- a/lib/project_types/script/layers/infrastructure/api_clients.rb
+++ b/lib/project_types/script/layers/infrastructure/api_clients.rb
@@ -29,10 +29,10 @@ module Script
           private
 
           def script_service_url
-            if ::ShopifyCli::Environment.use_local_partners_instance?
-              LOCAL_INSTANCE_URL
-            elsif ::ShopifyCli::Environment.use_spin_partners_instance?
+            if ::ShopifyCli::Environment.use_spin_partners_instance?
               "https://script-service.#{::ShopifyCli::Environment.spin_url}"
+            else
+              LOCAL_INSTANCE_URL
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/api_clients.rb
+++ b/lib/project_types/script/layers/infrastructure/api_clients.rb
@@ -16,7 +16,7 @@ module Script
           LOCAL_INSTANCE_URL = "https://script-service.myshopify.io"
 
           def initialize(ctx, api_key)
-            instance_url = spin_instance_url || LOCAL_INSTANCE_URL
+            instance_url = script_service_url
             super(
               ctx: ctx,
               url: "#{instance_url}/graphql",
@@ -28,12 +28,12 @@ module Script
 
           private
 
-          def spin_instance_url
-            workspace = ENV["SPIN_WORKSPACE"]
-            namespace = ENV["SPIN_NAMESPACE"]
-            return if workspace.nil? || namespace.nil?
-
-            "https://script-service.#{workspace}.#{namespace}.us.spin.dev"
+          def script_service_url
+            if ::ShopifyCli::Environment.use_local_partners_instance?
+              LOCAL_INSTANCE_URL
+            elsif ::ShopifyCli::Environment.use_spin_partners_instance?
+              "https://script-service.#{::ShopifyCli::Environment.spin_url}"
+            end
           end
         end
         private_constant(:ScriptServiceAPI)

--- a/lib/shopify-cli/constants.rb
+++ b/lib/shopify-cli/constants.rb
@@ -5,6 +5,15 @@ module ShopifyCli
       # the partners dashboard and identity.
       LOCAL_PARTNERS = "SHOPIFY_APP_CLI_LOCAL_PARTNERS"
 
+      # When true the CLI points to a spin instance of spin
+      SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"
+
+      SPIN_WORKSPACE = "SPIN_WORKSPACE"
+
+      SPIN_NAMESPACE = "SPIN_NAMESPACE"
+
+      SPIN_HOST = "SPIN_HOST"
+
       # Set to true when running tests.
       RUNNING_TESTS = "RUNNING_SHOPIFY_CLI_TESTS"
     end

--- a/lib/shopify-cli/environment.rb
+++ b/lib/shopify-cli/environment.rb
@@ -35,7 +35,10 @@ module ShopifyCli
     end
 
     def self.spin_url(env_variables: ENV)
-      "#{spin_workspace(env_variables: env_variables)}.#{spin_namespace(env_variables: env_variables)}.#{spin_host(env_variables: env_variables)}"
+      spin_workspace = spin_workspace(env_variables: env_variables)
+      spin_namespace = spin_namespace(env_variables: env_variables)
+      spin_host = spin_host(env_variables: env_variables)
+      "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
     end
 
     def self.env_variable_truthy?(variable_name, env_variables: ENV)

--- a/lib/shopify-cli/environment.rb
+++ b/lib/shopify-cli/environment.rb
@@ -10,6 +10,13 @@ module ShopifyCli
       )
     end
 
+    def self.use_spin_partners_instance?(env_variables: ENV)
+      env_variable_truthy?(
+        Constants::EnvironmentVariables::SPIN_PARTNERS,
+        env_variables: env_variables
+      )
+    end
+
     def self.running_tests?(env_variables: ENV)
       env_variable_truthy?(
         Constants::EnvironmentVariables::RUNNING_TESTS,
@@ -20,13 +27,31 @@ module ShopifyCli
     def self.partners_domain(env_variables: ENV)
       if use_local_partners_instance?(env_variables: env_variables)
         "partners.myshopify.io"
+      elsif use_spin_partners_instance?(env_variables: env_variables)
+        "partners.#{spin_url(env_variables: env_variables)}"
       else
         "partners.shopify.com"
       end
     end
 
+    def self.spin_url(env_variables: ENV)
+      "#{spin_workspace(env_variables: env_variables)}.#{spin_namespace(env_variables: env_variables)}.#{spin_host(env_variables: env_variables)}"
+    end
+
     def self.env_variable_truthy?(variable_name, env_variables: ENV)
       TRUTHY_ENV_VARIABLE_VALUES.include?(env_variables[variable_name.to_s])
+    end
+
+    def self.spin_workspace(env_variables: ENV)
+      env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
+    end
+
+    def self.spin_namespace(env_variables: ENV)
+      env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
+    end
+
+    def self.spin_host(env_variables: ENV)
+      env_variables[Constants::EnvironmentVariables::SPIN_HOST] || "us.spin.dev"
     end
   end
 end

--- a/lib/shopify-cli/identity_auth.rb
+++ b/lib/shopify-cli/identity_auth.rb
@@ -238,7 +238,7 @@ module ShopifyCli
       if Environment.use_local_partners_instance?
         "https://identity.myshopify.io/oauth"
       elsif Environment.use_spin_partners_instance?
-	      "https://identity.#{Environment.spin_url}/oauth"
+        "https://identity.#{Environment.spin_url}/oauth"
       else
         "https://accounts.shopify.com/oauth"
       end

--- a/lib/shopify-cli/identity_auth.rb
+++ b/lib/shopify-cli/identity_auth.rb
@@ -237,13 +237,15 @@ module ShopifyCli
     def auth_url
       if Environment.use_local_partners_instance?
         "https://identity.myshopify.io/oauth"
+      elsif Environment.use_spin_partners_instance?
+	      "https://identity.#{Environment.spin_url}/oauth"
       else
         "https://accounts.shopify.com/oauth"
       end
     end
 
     def client_id_for_application(application_name)
-      client_ids = if Environment.use_local_partners_instance?
+      client_ids = if Environment.use_local_partners_instance? || Environment.use_spin_partners_instance?
         DEV_APPLICATION_CLIENT_IDS
       else
         APPLICATION_CLIENT_IDS
@@ -259,7 +261,7 @@ module ShopifyCli
     end
 
     def client_id
-      if Environment.use_local_partners_instance?
+      if Environment.use_local_partners_instance? || Environment.use_spin_partners_instance?
         Constants::Identity::CLIENT_ID_DEV
       else
         # In the future we might want to use Identity's dynamic
@@ -268,15 +270,6 @@ module ShopifyCli
         # value for the client
         Constants::Identity::CLIENT_ID
       end
-    end
-
-    def local_identity_running?
-      Net::HTTP.start("identity.myshopify.io", 443, use_ssl: true, open_timeout: 1, read_timeout: 10) do |http|
-        req = Net::HTTP::Get.new(URI.join("https://identity.myshopify.io", "/services/ping"))
-        http.request(req).is_a?(Net::HTTPSuccess)
-      end
-    rescue Timeout::Error, Errno::EHOSTUNREACH, Errno::EHOSTDOWN, Errno::EADDRNOTAVAIL, Errno::ECONNREFUSED
-      false
     end
   end
 end

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -24,6 +24,27 @@ module ShopifyCli
       refute got
     end
 
+    def test_use_spin_partners_instance_returns_true_when_the_env_variable_is_set
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+      }
+
+      # When
+      got = Environment.use_spin_partners_instance?(env_variables: env_variables)
+
+      # Then
+      assert got
+    end
+
+    def test_use_spin_partners_instance_returns_false_when_the_env_variable_is_not_set
+      # Given/When
+      got = Environment.use_spin_partners_instance?(env_variables: {})
+
+      # Then
+      refute got
+    end
+
     def test_partners_domain_returns_the_right_value_when_local_instance
       # Given
       env_variables = {
@@ -37,12 +58,74 @@ module ShopifyCli
       assert_equal "partners.myshopify.io", got
     end
 
+    def test_partners_domain_returns_the_right_value_when_spin_instance
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
+        Constants::EnvironmentVariables::SPIN_HOST.to_s => "us-dev.scvm.io",
+      }
+
+      # When
+      got = Environment.partners_domain(env_variables: env_variables)
+
+      # Then
+      assert_equal "partners.abcd.my-namespace.us-dev.scvm.io", got
+    end
+
+    def test_partners_domain_returns_the_right_value_when_spin_instance_no_host
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
+      }
+
+      # When
+      got = Environment.partners_domain(env_variables: env_variables)
+
+      # Then
+      assert_equal "partners.abcd.my-namespace.us.spin.dev", got
+    end
+
     def test_partners_domain_returns_the_right_value_when_production_instance
       # Given/When
       got = Environment.partners_domain
 
       # Then
       assert_equal "partners.shopify.com", got
+    end
+
+    def test_spin_url_returns_the_right_value
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
+        Constants::EnvironmentVariables::SPIN_HOST.to_s => "us-dev.scvm.io",
+      }
+
+      # When
+      got = Environment.partners_domain(env_variables: env_variables)
+
+      # Then
+      assert_equal "partners.abcd.my-namespace.us-dev.scvm.io", got
+    end
+
+    def test_spin_url_returns_the_right_value_no_host
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
+      }
+
+      # When
+      got = Environment.partners_domain(env_variables: env_variables)
+
+      # Then
+      assert_equal "partners.abcd.my-namespace.us.spin.dev", got
     end
 
     def test_env_variable_truthy


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

Adding configurations so that script service and login work properly with spin

### WHY are these changes introduced?

Fixes #(https://github.com/Shopify/script-service/issues/3593)

We are expanding the spin constellation for script service to include partners and identity so that we have a full end to end environment for quicker and easier testing and closer to production feel. This will eliminate a number of the stubbed services within the script service constellation.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The change add configurations to enable spin communication with the CLI. Similar to the communication for the local environment. It also uses some environment variables to configure a users spin URL and derivces services based off of these configurations.

The ENV variables are as follows:

SHOPIFY_APP_CLI_SPIN_PARTNERS: used to enable spin partner communication, requires the following values
SPIN_WORKSPACE: spin generated workspace name, usually 4 alphanumeric values, ex "a4jd"
SPIN_NAMESPACE: this is derived from your username or email address, ex: john-smith
SPIN_HOST: this value will default to "us.spin.dev" if not set but provides a means to be set for anyone using the non-us spin instance.

There are no UI changes, basically just controls to point to spin.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
