### PR TITLE
Moved PartnersProxyAPI and ScriptServiceAPI out of ScriptService and into ApiClients

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -45,6 +45,7 @@ module Script
     end
 
     module Infrastructure
+      autoload :ApiClients, Project.project_filepath("layers/infrastructure/api_clients")
       autoload :Errors, Project.project_filepath("layers/infrastructure/errors")
       autoload :CommandRunner, Project.project_filepath("layers/infrastructure/command_runner")
       autoload :PushPackageRepository, Project.project_filepath("layers/infrastructure/push_package_repository")

--- a/lib/project_types/script/layers/infrastructure/api_clients.rb
+++ b/lib/project_types/script/layers/infrastructure/api_clients.rb
@@ -1,0 +1,88 @@
+module Script
+  module Layers
+    module Infrastructure
+      class ApiClients
+        def self.default_client(ctx, api_key)
+          if ENV["BYPASS_PARTNERS_PROXY"]
+            ScriptServiceAPI.new(ctx, api_key)
+          else
+            PartnersProxyAPI.new(ctx, api_key)
+          end
+        end
+
+        class ScriptServiceAPI < ShopifyCli::API
+          property(:api_key, accepts: String)
+
+          LOCAL_INSTANCE_URL = "https://script-service.myshopify.io"
+
+          def initialize(ctx, api_key)
+            instance_url = spin_instance_url || LOCAL_INSTANCE_URL
+            super(
+              ctx: ctx,
+              url: "#{instance_url}/graphql",
+              token: { "APP_KEY" => api_key }.compact.to_json,
+              auth_header: "X-Shopify-Authenticated-Tokens",
+              api_key: api_key
+            )
+          end
+
+          private
+
+          def spin_instance_url
+            workspace = ENV["SPIN_WORKSPACE"]
+            namespace = ENV["SPIN_NAMESPACE"]
+            return if workspace.nil? || namespace.nil?
+
+            "https://script-service.#{workspace}.#{namespace}.us.spin.dev"
+          end
+        end
+        private_constant(:ScriptServiceAPI)
+
+        class PartnersProxyAPI
+          def initialize(ctx, api_key)
+            @ctx = ctx
+            @api_key = api_key
+          end
+
+          def query(query_name, variables: {})
+            response = ShimAPI.query(@ctx, query_name, api_key: @api_key, variables: variables.to_json)
+            raise_if_graphql_failed(response)
+            JSON.parse(response["data"]["scriptServiceProxy"])
+          end
+
+          def raise_if_graphql_failed(response)
+            raise Errors::EmptyResponseError if response.nil?
+
+            return unless response.key?("errors")
+            case error_code(response["errors"])
+            when "forbidden"
+              raise Errors::ForbiddenError
+            when "forbidden_on_shop"
+              raise Errors::ShopAuthenticationError
+            when "app_not_installed_on_shop"
+              raise Errors::AppNotInstalledError
+            else
+              raise Errors::GraphqlError, response["errors"]
+            end
+          end
+
+          def error_code(errors)
+            errors.map do |e|
+              code = e.dig("extensions", "code")
+              return code if code
+            end
+          end
+
+          class ShimAPI < ShopifyCli::PartnersAPI
+            def query(query_name, variables: {})
+              variables[:query] = load_query(query_name)
+              super("script_service_proxy", variables: variables)
+            end
+          end
+          private_constant(:ShimAPI)
+        end
+        private_constant(:PartnersProxyAPI)
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -73,93 +73,11 @@ module Script
           response["data"]["appScripts"]
         end
 
-        class ScriptServiceAPI < ShopifyCli::API
-          property(:api_key, accepts: String)
-
-          LOCAL_INSTANCE_URL = "https://script-service.myshopify.io"
-
-          def initialize(ctx, api_key)
-            instance_url = spin_instance_url || LOCAL_INSTANCE_URL
-            super(
-              ctx: ctx,
-              url: "#{instance_url}/graphql",
-              token: { "APP_KEY" => api_key }.compact.to_json,
-              auth_header: "X-Shopify-Authenticated-Tokens",
-              api_key: api_key
-            )
-          end
-
-          private
-
-          def spin_instance_url
-            workspace = ENV["SPIN_WORKSPACE"]
-            namespace = ENV["SPIN_NAMESPACE"]
-            return if workspace.nil? || namespace.nil?
-
-            "https://script-service.#{workspace}.#{namespace}.us.spin.dev"
-          end
-        end
-        private_constant(:ScriptServiceAPI)
-
-        class PartnersProxyAPI
-          def initialize(ctx, api_key)
-            @ctx = ctx
-            @api_key = api_key
-          end
-
-          def query(query_name, variables: {})
-            response = ShimAPI.query(@ctx, query_name, api_key: @api_key, variables: variables.to_json)
-            raise_if_graphql_failed(response)
-            JSON.parse(response["data"]["scriptServiceProxy"])
-          end
-
-          def raise_if_graphql_failed(response)
-            raise Errors::EmptyResponseError if response.nil?
-
-            return unless response.key?("errors")
-            case error_code(response["errors"])
-            when "forbidden"
-              raise Errors::ForbiddenError
-            when "forbidden_on_shop"
-              raise Errors::ShopAuthenticationError
-            when "app_not_installed_on_shop"
-              raise Errors::AppNotInstalledError
-            else
-              raise Errors::GraphqlError, response["errors"]
-            end
-          end
-
-          def error_code(errors)
-            errors.map do |e|
-              code = e.dig("extensions", "code")
-              return code if code
-            end
-          end
-
-          class ShimAPI < ShopifyCli::PartnersAPI
-            def query(query_name, variables: {})
-              variables[:query] = load_query(query_name)
-              super("script_service_proxy", variables: variables)
-            end
-          end
-          private_constant(:ShimAPI)
-        end
-        private_constant(:PartnersProxyAPI)
-
         class MakeRequest
           attr_reader :ctx
 
           def initialize(ctx, api_key)
-            @ctx = ctx
-            @client = if MakeRequest.bypass_partners_proxy
-              ScriptServiceAPI.new(ctx, api_key)
-            else
-              PartnersProxyAPI.new(ctx, api_key)
-            end
-          end
-
-          def self.bypass_partners_proxy
-            !ENV["BYPASS_PARTNERS_PROXY"].nil?
+            @client = ApiClients.default_client(ctx, api_key)
           end
 
           def call(query_name:, variables: {})

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -55,11 +55,6 @@ describe Script::Layers::Infrastructure::ScriptService do
     HERE
   end
 
-  before do
-    ::Script::Layers::Infrastructure::ScriptService::MakeRequest.stubs(:bypass_partners_proxy).returns(false)
-    # script_service.stubs(:bypass_partners_proxy).returns(false)
-  end
-
   describe ".push" do
     let(:script_content) { "(module)" }
     let(:api_key) { "fake_key" }


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Continuing refactors from https://github.com/Shopify/shopify-cli/pull/1471. Separates the API related code from `ScriptService` to focus `ScriptService` purely on querying the backend script-service.

### WHAT is this pull request doing?

Moved both `PartnersProxyAPI` and `ScriptServiceAPI` into a new class: `ApiClients`. This will expose a single method for returning the "default" API client, making this decision opaque to `ScriptService`.

### Update checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
