### PR TITLE
Limit the generated name for themes to 50 characters

### DIFF
--- a/lib/shopify-cli/extensions.rb
+++ b/lib/shopify-cli/extensions.rb
@@ -1,0 +1,1 @@
+require "shopify-cli/extensions/string"

--- a/lib/shopify-cli/extensions/string.rb
+++ b/lib/shopify-cli/extensions/string.rb
@@ -1,0 +1,17 @@
+class String
+  # https://github.com/rails/rails/blob/main/activesupport/lib/active_support/core_ext/string/filters.rb
+  def truncate(truncate_at, options = {})
+    return dup unless length > truncate_at
+
+    omission = options[:omission] || "..."
+    length_with_room_for_omission = truncate_at - omission.length
+    stop = \
+      if options[:separator]
+        rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission
+      else
+        length_with_room_for_omission
+      end
+
+    +"#{self[0, stop]}#{omission}"
+  end
+end

--- a/lib/shopify-cli/theme/development_theme.rb
+++ b/lib/shopify-cli/theme/development_theme.rb
@@ -19,7 +19,7 @@ module ShopifyCli
         # could have more than 50 characters and the API rejected them.
         # This code ensures we update the name for those users to ensure
         # the name stays under the limit.
-        if existing_name.length > API_NAME_LIMIT
+        if existing_name == nil || existing_name.length > API_NAME_LIMIT
           generate_theme_name
         else
           existing_name
@@ -65,8 +65,8 @@ module ShopifyCli
 
       private
 
-      def generate_theme_name
-        hostname = Socket.gethostname.split(".").shift + "asdgasdgasdgasdgasgs"
+      def generate_theme_name        
+        hostname = Socket.gethostname.split(".").shift
         hash = SecureRandom.hex(3)
 
         theme_name = "Development ()"

--- a/lib/shopify-cli/theme/development_theme.rb
+++ b/lib/shopify-cli/theme/development_theme.rb
@@ -6,13 +6,24 @@ require "securerandom"
 
 module ShopifyCli
   module Theme
+    API_NAME_LIMIT = 50
+
     class DevelopmentTheme < Theme
       def id
         ShopifyCli::DB.get(:development_theme_id)
       end
 
       def name
-        ShopifyCli::DB.get(:development_theme_name) || generate_theme_name
+        existing_name = ShopifyCli::DB.get(:development_theme_name)
+        # Up to version 2.3.0 (included) generated names stored locally
+        # could have more than 50 characters and the API rejected them.
+        # This code ensures we update the name for those users to ensure
+        # the name stays under the limit.
+        if existing_name.length > API_NAME_LIMIT
+          generate_theme_name
+        else
+          existing_name
+        end
       end
 
       def role
@@ -55,10 +66,13 @@ module ShopifyCli
       private
 
       def generate_theme_name
-        hostname = Socket.gethostname.split(".").shift
+        hostname = Socket.gethostname.split(".").shift + "asdgasdgasdgasdgasgs"
         hash = SecureRandom.hex(3)
 
-        theme_name = "Development (#{hash}-#{hostname})"
+        theme_name = "Development ()"
+        hostname_character_limit = API_NAME_LIMIT - theme_name.length - hash.length - 1
+        identifier = "#{hash}-#{hostname.truncate(hostname_character_limit)}"
+        theme_name = theme_name.gsub("()", "(#{identifier})")
 
         ShopifyCli::DB.set(development_theme_name: theme_name)
 

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -25,6 +25,7 @@ require "cli/ui"
 require "cli/kit"
 require "smart_properties"
 require_relative "shopify-cli/version"
+require "shopify-cli/extensions"
 
 # Enable stdout routing. At this point all calls to STDOUT (and STDERR) will go through this class.
 # See https://github.com/Shopify/cli-ui/blob/main/lib/cli/ui/stdout_router.rb for more info

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -96,6 +96,43 @@ module ShopifyCli
         assert_equal(theme_name, @theme.name)
       end
 
+      def test_name_is_generated_if_the_existing_name_length_is_above_the_api_limit
+         # Given
+         hostname = "theme-dev-lan-very-long-name-that-will-be-truncated"
+         hash = "5676d"
+         theme_name = "Development ()"
+         hostname_character_limit = ShopifyCli::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
+         identifier = "#{hash}-#{hostname.truncate(hostname_character_limit)}"
+         theme_name_without_truncation = "Development (#{hash}-#{hostname})"
+         theme_name = theme_name.gsub("()", "(#{identifier})")
+ 
+         ShopifyCli::DB.stubs(:get).with(:development_theme_name).returns(theme_name_without_truncation)
+         SecureRandom.expects(:hex).returns(hash)
+         Socket.expects(:gethostname).returns(hostname)
+         ShopifyCli::DB.expects(:set).with(development_theme_name: theme_name)
+ 
+         # When/Then
+         assert_equal(theme_name, @theme.name)
+      end
+
+      def test_name_is_truncated_if_its_above_the_api_limit
+        # Given
+        hostname = "theme-dev-lan-very-long-name-that-will-be-truncated"
+        hash = "5676d"
+        theme_name = "Development ()"
+        hostname_character_limit = ShopifyCli::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
+        identifier = "#{hash}-#{hostname.truncate(hostname_character_limit)}"
+        theme_name = theme_name.gsub("()", "(#{identifier})")
+
+        ShopifyCli::DB.stubs(:get).with(:development_theme_name).returns(nil)
+        SecureRandom.expects(:hex).returns(hash)
+        Socket.expects(:gethostname).returns(hostname)
+        ShopifyCli::DB.expects(:set).with(development_theme_name: theme_name)
+
+        # When/Then
+        assert_equal(theme_name, @theme.name)
+      end
+
       def test_delete
         shop = "dev-theme-server-store.myshopify.com"
         theme_id = "12345678"


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli/issues/1494

### WHY are these changes introduced?

There was a [bug](https://github.com/Shopify/shopify-cli/issues/1494) reported that caused the serving of themes to fail because the API returned that the theme name was longer than 50 characters. It turns out that the logic that we use for generating the theme name didn't account for that limit, and there are hosts whose names might lead to a theme name longer than 50.

### WHAT is this pull request doing?

This PR fixes that going forward and adds some code for migrating the users that are currently experiencing the issue.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
