### PR TITLE
CI pipeline improvements

### DIFF
--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 3.0.0
+          - 3.0.2
           - 2.6.6
           - 2.7.1
         os:
@@ -27,4 +27,27 @@ jobs:
         run: bundle install
 
       - name: Run Tests
-        run: bundle exec rake
+        run: bundle exec rake test
+  rubocop:
+    name: Rubocop
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - 3.0.2
+        os:
+          - macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby ${{ matrix.version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.version }}
+          bundler-cache: true
+
+      - name: Install Dependencies
+        run: bundle install
+
+      - name: Rubocop
+        run: bundle exec rake rubocop

--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -13,7 +13,11 @@ jobs:
           - 2.6.6
           - 2.7.1
         os:
-          - macos-latest
+          - macos-10.15
+          - macos-11
+          - ubuntu-20.04
+          - ubuntu-18.04
+          - ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -28,6 +28,10 @@ jobs:
           - ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
+      - name: Set Git configuration
+        run: |
+          git config --global user.email "development-lifecycle@shopify.com"
+          git config --global user.name "Development Lifecycle"
 
       - name: Set up Ruby ${{ matrix.version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -1,6 +1,14 @@
 name: Shopify
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: shopify-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# This is a Docker image to test the CLI in UNIX environments other than macOS
+# Build the image: docker build . -t shopify-cli
+# Run tests: docker run -t --rm --volume "$(pwd):/usr/src/app" shopify-cli bundle exec rake test
+FROM cimg/ruby:2.7.1-node
+
+RUN git config --global user.email "development-lifecycle@shopify.com"
+RUN git config --global user.name "Development Lifecycle"
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+COPY shopify-cli.gemspec  shopify-cli.gemspec
+COPY lib/shopify-cli/version.rb  lib/shopify-cli/version.rb
+COPY . .
+
+RUN bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,11 @@ desc "Runs the test suite in a Linux Docker environment"
 task :test_linux do
   system("docker", "build", __dir__, "-t", "shopify-cli") || abort
   system(
-    "docker", "run", 
-    "-t", "--rm", 
-    "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app", 
-    "shopify-cli", 
-    "bundle", "exec", "rake" , "test"
+    "docker", "run",
+    "-t", "--rm",
+    "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
+    "shopify-cli",
+    "bundle", "exec", "rake", "test"
   ) || abort
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,25 @@ require_relative "bin/load_shopify"
 require "rake/testtask"
 require "rubocop/rake_task"
 require "bundler/gem_tasks"
+require "shellwords"
 
 Rake::TestTask.new do |t|
   t.libs += %w(test)
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = false
   t.warning = false
+end
+
+desc "Runs the test suite in a Linux Docker environment"
+task :test_linux do
+  system("docker", "build", __dir__, "-t", "shopify-cli") || abort
+  system(
+    "docker", "run", 
+    "-t", "--rm", 
+    "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app", 
+    "shopify-cli", 
+    "bundle", "exec", "rake" , "test"
+  ) || abort
 end
 
 RuboCop::RakeTask.new

--- a/dev.yml
+++ b/dev.yml
@@ -5,17 +5,18 @@ type:
 up:
   - ruby: 2.7.1
   - homebrew:
-    - dpkg:
-        version: 1.20.9
-    - rpm:
-        version: 4.16.1.3
+      - dpkg:
+          version: 1.20.9
+      - rpm:
+          version: 4.16.1.3
   - bundler
   - node:
       version: 14.9.0
       yarn: true
+  - docker
 
 test:
-  desc: 'Run tests.'
+  desc: "Run tests."
   run: |
     if [ "$#" -eq 1 ] && [[ -f $1 ]];
     then

--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -9,7 +9,7 @@ module Extension
 
       property! :from
       property! :to, default: -> { from + 10 }
-      property! :host, default: "localhost"
+      property! :host, default: "127.0.0.1"
 
       def call
         available_port = port_range(from: from, to: to).find { |p| available?(host, p) }

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -108,8 +108,8 @@ module ShopifyCli
       private
 
       def exec(*args, dir: Dir.pwd, default: nil, ctx: Context.new)
-        args = %w(git) + args
-        out, _, stat = ctx.capture3(*args, chdir: dir)
+        args = %w(git) + ["--git-dir", File.join(dir, ".git")] + args
+        out, err, stat = ctx.capture3(*args)
         return default unless stat.success?
         out.chomp
       end

--- a/lib/shopify-cli/git.rb
+++ b/lib/shopify-cli/git.rb
@@ -109,7 +109,7 @@ module ShopifyCli
 
       def exec(*args, dir: Dir.pwd, default: nil, ctx: Context.new)
         args = %w(git) + ["--git-dir", File.join(dir, ".git")] + args
-        out, err, stat = ctx.capture3(*args)
+        out, _, stat = ctx.capture3(*args)
         return default unless stat.success?
         out.chomp
       end

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -15,7 +15,7 @@ module ShopifyCli
 
         def setup
           super
-          WebMock.disable_net_connect!(allow: "localhost:#{@@port}")
+          WebMock.disable_net_connect!(allow: "127.0.0.1:#{@@port}")
 
           ShopifyCli::DB.expects(:get)
             .with(:shopify_exchange_token)
@@ -153,9 +153,9 @@ module ShopifyCli
           get("/assets/theme.css")
 
           # Send the SSE request
-          socket = TCPSocket.new("localhost", @@port)
+          socket = TCPSocket.new("127.0.0.1", @@port)
           socket.write("GET /hot-reload HTTP/1.1\r\n")
-          socket.write("Host: localhost\r\n")
+          socket.write("Host: 127.0.0.1\r\n")
           socket.write("\r\n")
           socket.flush
           # Read the head
@@ -190,7 +190,7 @@ module ShopifyCli
 
         def get(path)
           with_retries(Errno::ECONNREFUSED) do
-            Net::HTTP.get(URI("http://localhost:#{@@port}#{path}"))
+            Net::HTTP.get(URI("http://127.0.0.1:#{@@port}#{path}"))
           end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,8 @@ require "webmock/minitest"
 
 require "mocha/minitest"
 
+ENV["TEST"] = "1"
+
 Mocha.configure do |c|
   c.stubbing_non_existent_method = :prevent
   c.stubbing_method_on_nil = :prevent


### PR DESCRIPTION
### WHY are these changes introduced?
I noticed there's some room for improvement in our CI pipeline so here's a PR improving the things listed in the section below.

### WHAT is this pull request doing?
- I separated the `rake test` and `rake rubocop` commands. That way we can see the results independently on GitHub's UI.
- I configured Rubocop's step to only run in an os because the step is OS-agnostic.
- Extended the test job to run on macOS 11 and Ubuntu 16.04, 18.04, and 20.04
- Replaced Ruby 3.0.0 with 3.0.2.
- Set it up to cancel previous runs when new commits are pushed.
- Adjusted `on` to run on pushes only when the branch is `main`.


### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
