### PR TITLE
Removed extraneous parameter from call to set_app_script from push_script

### DIFF
--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -25,7 +25,6 @@ module Script
               uuid = script_service.set_app_script(
                 uuid: package.uuid,
                 extension_point_type: package.extension_point_type,
-                script_content: package.script_content,
                 force: force,
                 metadata: package.metadata,
                 script_json: package.script_json,


### PR DESCRIPTION
…

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Parameter was never removed from call site when signature changed.

### WHAT is this pull request doing?

Making it not 💥 

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
