### PR TITLE
Stop showing deprecated and beta script apis in help messages

### DIFF
--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -99,7 +99,7 @@ module Script
             cause_of_error: ShopifyCli::Context.message("script.error.invalid_extension_cause", e.type),
             help_suggestion: ShopifyCli::Context.message(
               "script.error.invalid_extension_help",
-              Script::Layers::Application::ExtensionPoints.types.join(", ")
+              Script::Layers::Application::ExtensionPoints.available_types.join(", ")
             ),
           }
         when Layers::Domain::Errors::ScriptNotFoundError

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -203,6 +203,13 @@ describe Script::UI::ErrorHandler do
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
+
+        it "should not display deprecated or beta APIs" do
+          expected_types = %w(payment_methods shipping_methods)
+          Script::Layers::Application::ExtensionPoints.expects(:available_types).returns(expected_types)
+          io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { subject }
+          assert_match(expected_types.join(", "), io.join)
+        end
       end
 
       describe "when ScriptNotFoundError" do


### PR DESCRIPTION
### WHY are these changes introduced?

If a user tries to create a script with an invalid api (like running `shopify script create --extension-point=invalid`), then we would print an error showing the APIs they can use, even if they are deprecated or not. This shouldn't happen, we should only show them the APIs that are fully supported right now.

![image](https://user-images.githubusercontent.com/28009669/133135287-cf7e830a-e003-4167-9bbe-5333da4066d2.png)

### WHAT is this pull request doing?

Only prints the fully supported API types a user can use. 

![image](https://user-images.githubusercontent.com/28009669/133135262-ca7053d4-577f-42c4-b34c-f8c2a3d7bd13.png)


### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing). None added because scripts is technically hidden right now. 
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
