### PR TITLE
Removed api_key when instantiating ShopifyCli::API

### DIFF
--- a/lib/project_types/script/layers/infrastructure/api_clients.rb
+++ b/lib/project_types/script/layers/infrastructure/api_clients.rb
@@ -19,8 +19,7 @@ module Script
               ctx: ctx,
               url: "#{instance_url}/graphql",
               token: { "APP_KEY" => api_key }.compact.to_json,
-              auth_header: "X-Shopify-Authenticated-Tokens",
-              api_key: api_key
+              auth_header: "X-Shopify-Authenticated-Tokens"
             )
           end
 


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The `api_key` no longer needs to be passed into the `ShopifyCli::API` constructor as `ScriptServiceApiClient` is no longer inheriting from that class.

### WHAT is this pull request doing?

Removed `api_key` from the parameter list when creating `ShopifyCli::API`

### Update checklist
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
