### PR TITLE
(README.md) shopify theme init, not create

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When prompted, open the provided accounts.shopify.com URL in a browser. In your 
 
 Run:
 
-`shopify theme create`
+`shopify theme init`
 
 To initialize a theme on your current working directory. This will actually clone Shopify's starter theme which you should use as a reference when building themes for Shopify.
 


### PR DESCRIPTION
To initialize a new theme, the correct command is `shopify theme init`