### PR TITLE
Add dev style command

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -24,3 +24,7 @@ test:
     else
       bundle exec rake test $@
     fi
+
+commands:
+  style:
+    run: bundle exec rubocop .


### PR DESCRIPTION
### WHY are these changes introduced?

To run rubocop, you currently have to run the command every time. It would save a small amount of time if we could just run `dev style`.

### WHAT is this pull request doing?

Adds a `style` command to `dev.yml` that runs rubocop.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
