### PR TITLE
Silence npm warnings when determining the version of a script API

### DIFF
--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -40,7 +40,7 @@ module Script
           def extension_point_version
             return extension_point.sdks.assemblyscript.version if extension_point.sdks.assemblyscript.versioned?
 
-            out = command_runner.call("npm show #{extension_point.sdks.assemblyscript.package} version --json")
+            out = command_runner.call("npm -s show #{extension_point.sdks.assemblyscript.package} version --json")
             "^#{JSON.parse(out)}"
           end
 

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
@@ -60,7 +60,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .returns(fake_capture2e_response)
       context
         .expects(:capture2e)
-        .with("npm show @shopify/extension-point-as-fake version --json")
+        .with("npm -s show @shopify/extension-point-as-fake version --json")
         .once
         .returns([JSON.generate("2.0.0"), OpenStruct.new(success?: true)])
 
@@ -88,7 +88,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
 
       context
         .expects(:capture2e)
-        .with("npm show @shopify/extension-point-as-fake version --json")
+        .with("npm -s show @shopify/extension-point-as-fake version --json")
         .never
 
       sdk = mock
@@ -116,7 +116,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
 
       context
         .expects(:capture2e)
-        .with("npm show @shopify/extension-point-as-fake version --json")
+        .with("npm -s show @shopify/extension-point-as-fake version --json")
         .once
         .returns([JSON.generate(""), OpenStruct.new(success?: false)])
 


### PR DESCRIPTION
### WHY are these changes introduced?

If `npm` gives a warning or a notice for whatever reason (like there is a new version available), an error will be raised when fetching the API version because we run `npm show` and JSON parse the output, but the `npm` notice makes the output invalid JSON.

![image](https://user-images.githubusercontent.com/28009669/133467155-17198c03-d468-4022-a598-4416e9d7c818.png)

### WHAT is this pull request doing?

Instead of running `npm show ...`, run `npm -s show` which will run the command in silent mode. 

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing). Scripts is currently hidden and this is a small bug fix, so no need to add a changelog entry.
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
