### PR TITLE
new extension build flow

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -109,6 +109,7 @@ module Extension
     autoload :NpmPackage, Project.project_filepath("models/npm_package")
     autoload :Product, Project.project_filepath("models/product")
     autoload :DevelopmentServer, Project.project_filepath("models/development_server")
+    autoload :DevelopmentServerRequirements, Project.project_filepath("models/development_server_requirements")
   end
 
   autoload :ExtensionProjectKeys, Project.project_filepath("extension_project_keys")

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -12,6 +12,34 @@ module Extension
       NPM_BUILD_COMMAND = %w(run-script build)
 
       def call(_args, _command_name)
+        project = ExtensionProject.current(force_reload: true)
+        return run_new_flow(project) if supports_development_server?(project.specification_identifier)
+        run_legacy_flow
+      end
+
+      def self.help
+        ShopifyCli::Context.new.message("build.help", ShopifyCli::TOOL_NAME)
+      end
+
+      private
+
+      def run_new_flow(project)
+        Tasks::RunExtensionCommand.new(
+          type: project.specification_identifier.downcase,
+          command: "build"
+        ).call
+
+        @ctx.puts(@ctx.message("build.build_success_message"))
+      rescue => error
+        if error.message.include?("no such file or directory")
+          @ctx.abort(@ctx.message("build.directory_not_found"))
+        else
+          @ctx.debug(error)
+          @ctx.abort(@ctx.message("build.build_failure_message"))
+        end
+      end
+
+      def run_legacy_flow
         system = ShopifyCli::JsSystem.new(ctx: @ctx)
 
         CLI::UI::Frame.open(@ctx.message("build.frame_title", system.package_manager)) do
@@ -20,8 +48,8 @@ module Extension
         end
       end
 
-      def self.help
-        ShopifyCli::Context.new.message("build.help", ShopifyCli::TOOL_NAME)
+      def supports_development_server?(type)
+        Models::DevelopmentServerRequirements.supported?(type)
       end
     end
   end

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -55,8 +55,7 @@ module Extension
       end
 
       def supports_development_server?(type)
-        return false unless DEVELOPMENT_SERVER_SUPPORTED_TYPES.include?(type.identifier.downcase)
-        ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:extension_server_beta)
+        Models::DevelopmentServerRequirements.supported?(type.identifier)
       end
 
       def use_new_create_flow(form, msg)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -68,6 +68,8 @@ module Extension
         HELP
         frame_title: "Building extension with: %s…",
         build_failure_message: "Failed to build extension code.",
+        build_success_message: "Build was successful!",
+        directory_not_found: "Build directory not found.",
       },
       register: {
         help: <<~HELP,

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require "shopify_cli"
+
+module Extension
+  module Models
+    class DevelopmentServerRequirements
+      SUPPORTED_EXTENSION_TYPES = [
+        "checkout_ui_extension",
+      ]
+
+      def self.supported?(type)
+        return false unless SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
+        ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:extension_server_beta)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/development.rb
+++ b/lib/project_types/extension/models/server_config/development.rb
@@ -10,11 +10,13 @@ module Extension
           "typescript-react",
         ]
 
-        property! :root_dir, accepts: String
+        CURRENT_DIRECTORY = "."
+
+        property :root_dir, accepts: String, default: CURRENT_DIRECTORY
         property! :build_dir, accepts: String, default: "build"
-        property! :template, accepts: VALID_TEMPLATES
-        property! :renderer, accepts: ServerConfig::DevelopmentRenderer
-        property! :entries, accepts: ServerConfig::DevelopmentEntries
+        property :template, accepts: VALID_TEMPLATES
+        property :renderer, accepts: ServerConfig::DevelopmentRenderer
+        property :entries, accepts: ServerConfig::DevelopmentEntries
       end
     end
   end

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -16,8 +16,8 @@ module Extension
         "build",
       ]
 
-      property! :root_dir, accepts: String
-      property! :template, accepts: Models::ServerConfig::Development::VALID_TEMPLATES
+      property :root_dir, accepts: String
+      property :template, accepts: Models::ServerConfig::Development::VALID_TEMPLATES
       property! :type, accepts: SUPPORTED_EXTENSION_TYPES
       property! :command, accepts: SUPPORTED_COMMANDS
 
@@ -26,7 +26,9 @@ module Extension
           .call(&method(:build_extension))
           .then(&method(:build_server_config))
           .then(&method(:run_command))
-          .unwrap { |error| raise error }
+          .unwrap do |error|
+            raise error unless error.nil?
+          end
       end
 
       private
@@ -47,6 +49,8 @@ module Extension
         case command
         when "create"
           Models::DevelopmentServer.new.create(server_config)
+        when "build"
+          Models::DevelopmentServer.new.build(server_config)
         end
       end
     end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require "test_helper"
+require "project_types/extension/extension_test_helpers"
 
 module Extension
   module Commands
     class BuildTest < MiniTest::Test
       include TestHelpers::Partners
       include TestHelpers::FakeUI
-
       def setup
         super
         ShopifyCli::ProjectType.load_type(:extension)
@@ -22,6 +22,7 @@ module Extension
       end
 
       def test_uses_js_system_to_call_yarn_or_npm_commands
+        stub_project
         ShopifyCli::JsSystem.any_instance
           .expects(:call)
           .with(yarn: Command::Build::YARN_BUILD_COMMAND, npm: Command::Build::NPM_BUILD_COMMAND)
@@ -32,8 +33,39 @@ module Extension
       end
 
       def test_aborts_and_informs_the_user_when_build_fails
+        stub_project
         ShopifyCli::JsSystem.any_instance.stubs(:call).returns(false)
         @context.expects(:abort).with(@context.message("build.build_failure_message"))
+
+        run_build
+      end
+
+      def test_runs_new_flow_if_development_server_supported
+        type = "checkout_ui_extension"
+        stub_project(type)
+        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
+
+        extension_command = Tasks::RunExtensionCommand.new(type: type, command: "build")
+        Extension::Tasks::RunExtensionCommand.expects(:new).returns(extension_command) do |mock|
+          mock.expects(:call)
+        end
+
+        Models::ServerConfig::Extension.expects(:build)
+          .with(template: nil, type: type, root_dir: nil)
+          .returns(extension)
+
+        server_config = Models::ServerConfig::Root.new(extensions: [extension])
+        Models::ServerConfig::Root.expects(:new).returns(server_config)
+
+        development_server = Models::DevelopmentServer.new(executable: "fake")
+        Models::DevelopmentServer.expects(:new).returns(development_server) do |mock|
+          mock.expects(:build)
+        end
+
+        CLI::Kit::System.expects(:capture3)
+          .with(development_server.executable, "build", "-", stdin_data: server_config.to_yaml)
+          .returns(["", nil, mock(success?: true)])
 
         run_build
       end
@@ -42,6 +74,20 @@ module Extension
 
       def run_build(*args)
         run_cmd("extension build " + args.join(" "))
+      end
+
+      def stub_project(type = "TEST")
+        project = ExtensionTestHelpers.fake_extension_project(type_identifier: type)
+        ShopifyCli::Project.stubs(:current).returns(project)
+      end
+
+      def extension
+        @extension ||= Models::ServerConfig::Extension.new(
+          type: "checkout_ui_extension",
+          uuid: "00000000-0000-0000-0000-000000000000",
+          user: Models::ServerConfig::User.new,
+          development: Models::ServerConfig::Development.new(build_dir: "test")
+        )
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-cli-extensions/issues/80
Part of https://github.com/Shopify/shopify-cli-extensions/issues/4

### WHAT is this pull request doing?

* Introduce new build flow into `extension build` command:
  * if `extension_server_beta` is enabled, user will be taken to new flow, which uses the go development server to run the build command
  * else user is directed to existing flow

Added:
* `DevelopmentServerRequirements` model to centralize this check
* Fixed path to `shopify-extension` executable
* Made `template`, `root_dir`, and `entries` optional fields in `ServerConfig::Development` to allow us to run the `build` command without a persisted "shopifile".

🎩 Tophatting:

* clone the `shopify-cli-extensions` repo
* cd into `shopify-cli-extensions` if you're not already there
* run `make build`, this will create an executable for you
* run `cp shopify-extensions /Users/%YOUR_USER%/src/github.com/Shopify/shopify-cli/ext/shopify-cli/shopify-extensions/shopify-extensions` to copy the executable into the shopify-cli
* give yourself the required beta flag: `shopify config feature extension_server_beta --enable`
* create a **NEW** `CHECKOUT_UI_EXTENSION` by running `shopify extension create` and selecting "Checkout UI Extension" from the list -- this should create a new extension using the new create flow
* `cd` into your new extension
* run `yarn install` and create a `build` folder
* run `shopify extension build`
* You should now see a `main.js` file in your previously empty `build` folder

PLEASE NOTE:
* New build command only works with new extensions created with the new `shopify-extensions` executable
* We have to run `yarn install` and create a `build` folder currently, but this can be handled by the development server in the future

**NEW FLOW**

https://user-images.githubusercontent.com/989784/133515758-fc5c8124-3f27-4e40-ada4-efd599f54a99.mp4

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~ not public facing yet
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
