### PR TITLE
Don't notify when the list of files is empty

### DIFF
--- a/lib/shopify-cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify-cli/theme/dev_server/hot_reload.rb
@@ -34,11 +34,10 @@ module ShopifyCli
           files = (modified + added).reject { |file| @ignore_filter&.ignore?(file) }
             .map { |file| @theme[file].relative_path }
 
-          @streams.broadcast(JSON.generate(
-            modified: files,
-          ))
-
-          @ctx.debug("[HotReload] Modified #{files.join(", ")}")
+          unless files.empty?
+            @streams.broadcast(JSON.generate(modified: files))
+            @ctx.debug("[HotReload] Modified #{files.join(", ")}")
+          end
         end
 
         private

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -73,6 +73,27 @@ module ShopifyCli
           @watcher.notify_observers(modified, [], [])
         end
 
+        def test_doesnt_broadcast_watcher_events_when_the_list_is_empty
+          root_path = Pathname.new(__dir__)
+          ignore_filter = ShopifyCli::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
+          modified = ["ignored/style.css"]
+          SSE::Streams.any_instance
+            .expects(:broadcast)
+            .with(JSON.generate(modified: modified))
+            .never
+
+          app = -> { [200, {}, []] }
+          HotReload.new(
+            @ctx, app,
+            theme: @theme,
+            watcher: @watcher,
+            ignore_filter: ignore_filter
+          )
+
+          @watcher.changed
+          @watcher.notify_observers(modified, [], [])
+        end
+
         private
 
         def serve(response_body = "", path: "/", headers: {})


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shopify-cli/issues/1526

### WHY are these changes introduced?

As reported [here](https://github.com/Shopify/shopify-cli/issues/1526), hot-reloading of themes caused errors on the Javascript console when an ignored file was modified.

### WHAT is this pull request doing?
It turns out the logic on the Javascript side assumed the notifications always contained a file. I modified the logic on the Ruby side to not notify when the list of files is empty (after filtering out the ignored files).

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
