### PR TITLE
integrate shopify-extensions serve into argo-serve

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -22,22 +22,10 @@ module Extension
             @ctx.abort(message_for_extension["create.errors.directory_exists", form.directory_name])
           end
 
-          return use_new_create_flow(form, message_for_extension) if supports_development_server?(form.type)
-
-          if form.type.create(form.directory_name, @ctx, getting_started: options.flags[:getting_started])
-            ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
-            ExtensionProject.write_env_file(
-              context: @ctx,
-              title: form.name,
-              api_key: form.app.api_key,
-              api_secret: form.app.secret
-            )
-
-            @ctx.puts(message_for_extension["create.ready_to_start", form.directory_name, form.name])
-            @ctx.puts(message_for_extension["create.learn_more", form.type.name])
-          else
-            @ctx.puts(message_for_extension["create.try_again"])
-          end
+          ShopifyCLI::Result.success(supports_development_server?(form.type.identifier))
+            .then { |supported| create_extension(supported, form) }
+            .then { notify_success(form, message_for_extension) }
+            .unwrap { |err| @ctx.puts(message_for_extension["create.try_again"]) unless err.nil? }
         end
       end
 
@@ -55,22 +43,52 @@ module Extension
       end
 
       def supports_development_server?(type)
-        Models::DevelopmentServerRequirements.supported?(type.identifier)
+        Models::DevelopmentServerRequirements.supported?(type)
       end
 
-      def use_new_create_flow(form, msg)
+      def create_extension(supported, form)
+        if supported
+          use_new_create_flow(form)
+        else
+          use_legacy_flow(form)
+        end
+        ShopifyCLI::Result.success(nil)
+      end
+
+      def use_new_create_flow(form)
         Tasks::RunExtensionCommand.new(
           root_dir: form.directory_name,
           template: form.template,
           type: form.type.identifier.downcase,
           command: "create"
         ).call
+        @ctx.chdir(form.directory_name)
+        write_env_file(form)
+      rescue => error
+        raise error
+      end
 
+      def use_legacy_flow(form)
+        if form.type.create(form.directory_name, @ctx, getting_started: options.flags[:getting_started])
+          write_env_file(form)
+        else
+          raise StandardError
+        end
+      end
+
+      def write_env_file(form)
+        ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
+        ExtensionProject.write_env_file(
+          context: @ctx,
+          title: form.name,
+          api_key: form.app.api_key,
+          api_secret: form.app.secret
+        )
+      end
+
+      def notify_success(form, msg)
         @ctx.puts(msg["create.ready_to_start", form.directory_name, form.name])
         @ctx.puts(msg["create.learn_more", form.type.name])
-      rescue => error
-        @ctx.debug(error)
-        @ctx.puts(msg["create.try_again"])
       end
     end
   end

--- a/lib/project_types/extension/models/development_server.rb
+++ b/lib/project_types/extension/models/development_server.rb
@@ -7,9 +7,20 @@ module Extension
 
       include SmartProperties
 
-      EXECUTABLE_PATH = "../../../../../ext/shopify-cli/shopify-extensions/shopify-extensions"
+      EXECUTABLE_DIRECTORY = File.join(ShopifyCLI::ROOT, "ext", "shopify-extensions")
 
-      property! :executable, converts: :to_s, default: File.expand_path(EXECUTABLE_PATH, __FILE__)
+      property :executable, converts: :to_s
+
+      def executable
+        super || begin
+          case RbConfig::CONFIG.fetch("host_os")
+          when /(linux)|(darwin)/
+            File.join(EXECUTABLE_DIRECTORY, "shopify-extensions")
+          else
+            File.join(EXECUTABLE_DIRECTORY, "shopify-extensions.exe")
+          end
+        end
+      end
 
       def create(server_config)
         CLI::Kit::System.capture3(executable, "create", "-", stdin_data: server_config.to_yaml)
@@ -18,17 +29,45 @@ module Extension
       end
 
       def build(server_config)
-        _, error, pid = CLI::Kit::System.capture3(executable, "build", "-", stdin_data: server_config.to_yaml)
-        return if pid.success?
+        _, error, status = CLI::Kit::System.capture3(executable, "build", "-", stdin_data: server_config.to_yaml)
+        return if status.success?
         raise DevelopmentServerError, error
       end
 
-      def serve
-        raise NotImplementedError
+      def serve(context, server_config)
+        CLI::Kit::System.popen3(executable, "serve", "-") do |input, out, err, status|
+          context.puts("Sending configuration data …")
+          input << server_config.to_yaml
+          input.close
+
+          forward_output_to_user(out, err, context)
+
+          status.value
+        end
       end
 
       def version
         raise NotImplementedError
+      end
+
+      private
+
+      def forward_output_to_user(out, err, ctx)
+        ctx.puts("Starting monitoring threads …")
+
+        Thread.new do
+          ctx.puts("Ready to process standard output")
+          while (line = out.gets)
+            ctx.puts(line)
+          end
+        end
+
+        Thread.new do
+          ctx.puts("Ready to process standard error")
+          while (error = err.gets)
+            ctx.puts(error)
+          end
+        end
       end
     end
   end

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -8,9 +8,28 @@ module Extension
         "checkout_ui_extension",
       ]
 
-      def self.supported?(type)
-        return false unless SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
-        ShopifyCLI::Shopifolk.check && ShopifyCLI::Feature.enabled?(:extension_server_beta)
+      UNIX_NAME = "shopify-extensions"
+      WINDOWS_NAME = "shopify-extensions.exe"
+
+      class << self
+        def supported?(type)
+          binary_installed? && type_supported?(type) && beta_enabled?
+        end
+
+        private
+
+        def binary_installed?
+          extension_dir = File.join(ShopifyCLI::ROOT, "ext", "shopify-extensions")
+          File.exist?(File.join(extension_dir, UNIX_NAME)) || File.exist?(File.join(extension_dir, WINDOWS_NAME))
+        end
+
+        def type_supported?(type)
+          SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
+        end
+
+        def beta_enabled?
+          ShopifyCLI::Shopifolk.check && ShopifyCLI::Feature.enabled?(:extension_server_beta)
+        end
       end
     end
   end

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -43,10 +43,12 @@ module Extension
         end
 
         def choose_port?(context)
+          return true if supports_development_server?
           argo_runtime(context).supports?(:port)
         end
 
         def establish_tunnel?(context)
+          return true if supports_development_server?
           argo_runtime(context).supports?(:public_url)
         end
 
@@ -66,6 +68,8 @@ module Extension
         end
 
         def argo_runtime(context)
+          return if supports_development_server?
+
           @argo_runtime ||= Features::ArgoRuntime.find(
             cli_package: cli_package(context),
             identifier: identifier
@@ -117,6 +121,10 @@ module Extension
 
         def messages
           @messages ||= Messages::TYPES[identifier.downcase.to_sym] || {}
+        end
+
+        def supports_development_server?
+          Models::DevelopmentServerRequirements.supported?(identifier)
         end
       end
     end

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -14,12 +14,15 @@ module Extension
       SUPPORTED_COMMANDS = [
         "create",
         "build",
+        "serve",
       ]
 
       property :root_dir, accepts: String
       property :template, accepts: Models::ServerConfig::Development::VALID_TEMPLATES
       property! :type, accepts: SUPPORTED_EXTENSION_TYPES
       property! :command, accepts: SUPPORTED_COMMANDS
+      property :context, accepts: ShopifyCLI::Context
+      property :port, accepts: Integer, default: 39351
 
       def call
         ShopifyCLI::Result
@@ -42,7 +45,7 @@ module Extension
       end
 
       def build_server_config(extension)
-        Models::ServerConfig::Root.new(extensions: [extension])
+        Models::ServerConfig::Root.new(port: port, extensions: [extension])
       end
 
       def run_command(server_config)
@@ -51,6 +54,10 @@ module Extension
           Models::DevelopmentServer.new.create(server_config)
         when "build"
           Models::DevelopmentServer.new.build(server_config)
+        when "serve"
+          Models::DevelopmentServer.new.serve(context, server_config)
+        else
+          raise NotImplementedError
         end
       end
     end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -45,6 +45,7 @@ module Extension
         stub_project(type)
         ShopifyCLI::Shopifolk.stubs(:check).returns(true)
         ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
+        File.stubs(:exist?).returns(true)
 
         extension_command = Tasks::RunExtensionCommand.new(type: type, command: "build")
         Extension::Tasks::RunExtensionCommand.expects(:new).returns(extension_command) do |mock|

--- a/test/project_types/extension/models/development_server_test.rb
+++ b/test/project_types/extension/models/development_server_test.rb
@@ -5,24 +5,61 @@ module Extension
     class DevelopmentServerTest < MiniTest::Test
       def setup
         ShopifyCLI::ProjectType.load_type(:extension)
+        @development_server = Models::DevelopmentServer.new(executable: "fake")
         super
       end
 
       def test_default_executable_is_shopify_extensions
         development_server = Models::DevelopmentServer.new
-        assert_includes(development_server.executable, "ext/shopify-cli/shopify-extensions")
+        assert_includes(development_server.executable, "ext/shopify-extensions")
       end
 
       def test_create_calls_executable_and_is_successful
         assert_nothing_raised do
-          development_server = Models::DevelopmentServer.new(executable: "fake")
           server_config = Models::ServerConfig::Root.new(extensions: [extension])
 
           CLI::Kit::System.expects(:capture3)
-            .with(development_server.executable, "create", "-", stdin_data: server_config.to_yaml)
+            .with(@development_server.executable, "create", "-", stdin_data: server_config.to_yaml)
             .returns("", nil, true)
 
-          development_server.create(server_config)
+          @development_server.create(server_config)
+        end
+      end
+
+      def test_build_calls_executable_and_is_successful
+        assert_nothing_raised do
+          server_config = Models::ServerConfig::Root.new(extensions: [extension])
+
+          CLI::Kit::System.expects(:capture3)
+            .with(@development_server.executable, "build", "-", stdin_data: server_config.to_yaml)
+            .returns(["", nil, mock(success?: true)])
+
+          @development_server.build(server_config)
+        end
+      end
+
+      def test_build_raises_error_on_failure
+        error_message = "an error from stdout"
+
+        expected_error = assert_raises Models::DevelopmentServer::DevelopmentServerError do
+          server_config = Models::ServerConfig::Root.new(extensions: [extension])
+
+          CLI::Kit::System.expects(:capture3)
+            .with(@development_server.executable, "build", "-", stdin_data: server_config.to_yaml)
+            .returns(["", error_message, mock(success?: false)])
+
+          @development_server.build(server_config)
+        end
+        assert_equal(expected_error.message, error_message)
+      end
+
+      def test_serve_runs_successfully
+        assert_nothing_raised do
+          server_config = Models::ServerConfig::Root.new(extensions: [extension])
+          development_server = Models::DevelopmentServer.new(executable: "fake")
+
+          CLI::Kit::System.stubs(:popen3).with(development_server.executable, "serve", "-").returns(nil)
+          development_server.serve(@ctx, server_config)
         end
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/shopify-cli-extensions/issues/4
Closes: https://github.com/Shopify/shopify-cli-extensions/issues/89

### WHAT is this pull request doing?

* Modifies `shopify extension create` for new extensions built with the new development server so that an `.env` file is created. An `.env` file is needed to check for `shop` and some other values needed to run `serve`.
* Adds `serve` support to `Extension::Tasks::RunExtensionCommand`
* Adds `serve` support to `Models::DevelopmentServer`
  * opens threads to keep track of changes

### 🎩 Tophatting

* clone the shopify-cli-extensions repo
* cd into shopify-cli-extensions if you're not already there
* run make build, this will create an executable for you
* run cp shopify-extensions /Users/%YOUR_USER%/src/github.com/Shopify/shopify-cli/ext/shopify-extensions/shopify-extensions to copy the executable into the shopify-cli
* give yourself the required beta flag: shopify config feature extension_server_beta --enable
* create a NEW CHECKOUT_UI_EXTENSION by running shopify extension create and selecting "Checkout UI Extension" from the list -- this should create a new extension using the new create flow
* cd into your new extension
* run yarn install and create a build folder
* run shopify extension build
* You should now see a main.js file in your previously empty build folder
* run `shopify extension serve` --> you should see output of the serve command from the go binary
* go to http://localhost:39351/extensions/ to view extension output

Expected flow:

https://user-images.githubusercontent.com/989784/133688292-4fddef91-3196-4602-beed-0f346f5cf6b5.mp4

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~ not user facing at this time
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
