### PR TITLE
Add an acceptance test that ensures that the installation of extensio…

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,16 +11,31 @@ Rake::TestTask.new do |t|
   t.warning = false
 end
 
-desc "Runs the test suite in a Linux Docker environment"
-task :test_linux do
-  system("docker", "build", __dir__, "-t", "shopify-cli") || abort
-  system(
-    "docker", "run",
-    "-t", "--rm",
-    "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
-    "shopify-cli",
-    "bundle", "exec", "rake", "test"
-  ) || abort
+desc "A set of tasks that run in Linux environments"
+namespace :linux do
+  desc "Runs the test suite in a Linux Docker environment"
+  task :test do
+    system("docker", "build", __dir__, "-t", "shopify-cli") || abort
+    system(
+      "docker", "run",
+      "-t", "--rm",
+      "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
+      "shopify-cli",
+      "bundle", "exec", "rake", "test"
+    ) || abort
+  end
+
+  desc "Runs the acceptance tests suite in a Linux Docker environment"
+  task :features do
+    system("docker", "build", __dir__, "-t", "shopify-cli") || abort
+    system(
+      "docker", "run",
+      "-t", "--rm",
+      "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
+      "shopify-cli",
+      "bundle", "exec", "cucumber"
+    ) || abort
+  end
 end
 
 RuboCop::RakeTask.new

--- a/ext/shopify-extensions/extconf.rb
+++ b/ext/shopify-extensions/extconf.rb
@@ -1,6 +1,8 @@
 require_relative "./shopify_extensions"
 
-File.write("Makefile", <<~MAKEFILE)
+installation_dir = ENV.fetch("SHOPIFY_CLI_EXTENSIONS_INSTALLATION_DIR", __dir__)
+
+File.write(File.expand_path("Makefile", installation_dir), <<~MAKEFILE)
   .PHONY: clean
 
   clean: ;
@@ -10,7 +12,7 @@ MAKEFILE
 
 begin
   ShopifyExtensions.install(
-    target: File.join(File.dirname(__FILE__), "shopify-extensions")
+    target: File.expand_path("shopify-extensions", installation_dir)
   )
 rescue ShopifyExtensions::InstallationError => error
   STDERR.puts(error.message)

--- a/features/install.feature
+++ b/features/install.feature
@@ -1,0 +1,6 @@
+Feature: The installation process
+
+  Scenario: The extensions native package is pulled as part of the installation
+    Given I have a working directory
+    When Shopify extensions are installed in the working directory
+    Then I have the right binary for my system's architecture

--- a/features/step_definitions/commands/install.rb
+++ b/features/step_definitions/commands/install.rb
@@ -1,6 +1,6 @@
 require_relative "../../../ext/shopify-extensions/shopify_extensions"
 
-When('Shopify extensions are installed in the working directory') do
+When("Shopify extensions are installed in the working directory") do
   ShopifyExtensions.install(
     version: "v0.1.0",
     target: File.expand_path("shopify-extensions", @working_dir)
@@ -8,7 +8,7 @@ When('Shopify extensions are installed in the working directory') do
 end
 
 Then("I have the right binary for my system's architecture") do
-  system_architecture = `uname -m`
-  binary_architecture = `file #{File.expand_path("shopify-extensions", @working_dir)}`
-  assert binary_architecture.include?(system_architecture)
+  system_architecture = [%x(uname -m).chomp].flat_map { |arch| [arch, arch.gsub("_", "-")] }
+  binary_architecture = %x(file #{File.expand_path("shopify-extensions", @working_dir)})
+  assert system_architecture.any? { |arch| binary_architecture.include?(arch) }
 end

--- a/features/step_definitions/commands/install.rb
+++ b/features/step_definitions/commands/install.rb
@@ -1,0 +1,14 @@
+require_relative "../../../ext/shopify-extensions/shopify_extensions"
+
+When('Shopify extensions are installed in the working directory') do
+  ShopifyExtensions.install(
+    version: "v0.1.0",
+    target: File.expand_path("shopify-extensions", @working_dir)
+  )
+end
+
+Then("I have the right binary for my system's architecture") do
+  system_architecture = `uname -m`
+  binary_architecture = `file #{File.expand_path("shopify-extensions", @working_dir)}`
+  assert binary_architecture.include?(system_architecture)
+end

--- a/test/ext/shopify-extensions/shopify_extensions_test.rb
+++ b/test/ext/shopify-extensions/shopify_extensions_test.rb
@@ -83,7 +83,7 @@ module ShopifyExtensions
         assert_equal "linux-amd64", Platform.new(linux_vm).to_s
       end
 
-      def test_recognices_mac_os
+      def test_recognizes_mac_os
         intel_mac = ruby_config(os: "darwin20.3.0", cpu: "x86_64")
         m1_mac = ruby_config(os: "darwin20.3.0", cpu: "arm64")
 

--- a/test/ext/shopify-extensions/shopify_extensions_test.rb
+++ b/test/ext/shopify-extensions/shopify_extensions_test.rb
@@ -91,7 +91,7 @@ module ShopifyExtensions
         assert_equal "darwin-arm64", Platform.new(m1_mac).to_s
       end
 
-      def test_recognices_windows
+      def test_recognizes_windows
         windows_vm_64_bit = ruby_config(os: "mingw32", cpu: "x64")
         windows_vm_32_bit = ruby_config(os: "mingw32", cpu: "i686")
         assert_equal "windows-amd64", Platform.new(windows_vm_64_bit).to_s


### PR DESCRIPTION
### WHY are these changes introduced?
This PR extends [this PR](https://github.com/Shopify/shopify-cli/pull/1496) to add an acceptance test that ensures that the installation of Shopify Extensions doesn't break.

### WHAT is this pull request doing?
Add an acceptance test that ensures the installation of extensions works.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
