### PR TITLE
remove unsupported environment ubuntu-16.04

### DIFF
--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -25,7 +25,6 @@ jobs:
           - macos-11
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
       - name: Set Git configuration


### PR DESCRIPTION
Github dropped support for **Ubuntu 16.04**, and as a result, some jobs are stuck on CI. This PR removes `ubuntu-16.04` from the list of environments in our workflow config.

### WHY are these changes introduced?

Full details: https://github.com/actions/virtual-environments/issues/3287