### PR TITLE
remove `ubuntu-16.04` from acceptance tests

### DIFF
--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -57,7 +57,6 @@ jobs:
           - macos-11
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
       - name: Set Git configuration


### PR DESCRIPTION
Followup to: https://github.com/Shopify/shopify-cli/pull/1554