### PR TITLE
Fix typo in ShopifyCli

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,17 +110,17 @@ namespace :package do
 
   desc("Builds a Debian package of the CLI")
   task :debian do
-    ShopifyCli::Packager.new.build_debian
+    ShopifyCLI::Packager.new.build_debian
   end
 
   desc("Builds an RPM package of the CLI")
   task :rpm do
-    ShopifyCli::Packager.new.build_rpm
+    ShopifyCLI::Packager.new.build_rpm
   end
 
   desc("Builds a Homebrew package of the CLI")
   task :homebrew do
-    ShopifyCli::Packager.new.build_homebrew
+    ShopifyCLI::Packager.new.build_homebrew
   end
 end
 

--- a/bin/shopify
+++ b/bin/shopify
@@ -9,7 +9,7 @@ module Kernel
     original_require(name)
   rescue LoadError => e
     # Special case for readline.so, which fails harmlessly on Windows
-    raise if (name == "readline.so") && ShopifyCli::Context.new.windows?
+    raise if (name == "readline.so") && ShopifyCLI::Context.new.windows?
     # Special case for psych (yaml), which rescues this itself
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
     STDERR.puts "[Note] You cannot use gems with Shopify CLI."
@@ -29,6 +29,6 @@ end
 
 require_relative "./load_shopify"
 
-exit(ShopifyCli::ErrorHandler.call do
-  ShopifyCli::Core::EntryPoint.call(ARGV.dup)
+exit(ShopifyCLI::ErrorHandler.call do
+  ShopifyCLI::Core::EntryPoint.call(ARGV.dup)
 end)

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -3,7 +3,7 @@
 module Extension
   class PackageResolutionFailed < RuntimeError; end
 
-  class Project < ShopifyCli::ProjectType
+  class Project < ShopifyCLI::ProjectType
     hidden_feature
 
     require Project.project_filepath("messages/messages")
@@ -12,7 +12,7 @@ module Extension
     register_messages(Extension::Messages::MessageLoading.load)
   end
 
-  class Command < ShopifyCli::ProjectCommands
+  class Command < ShopifyCLI::ProjectCommands
     hidden_feature
     autoload :ExtensionCommand, Project.project_filepath("commands/extension_command")
 
@@ -26,7 +26,7 @@ module Extension
     subcommand :Tunnel, "tunnel", Project.project_filepath("commands/tunnel")
     subcommand :Check, "check", Project.project_filepath("commands/check")
   end
-  ShopifyCli::Commands.register("Extension::Command", "extension")
+  ShopifyCLI::Commands.register("Extension::Command", "extension")
 
   module Tasks
     autoload :UserErrors, Project.project_filepath("tasks/user_errors")

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -18,7 +18,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("build.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("build.help", ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -40,7 +40,7 @@ module Extension
       end
 
       def run_legacy_flow
-        system = ShopifyCli::JsSystem.new(ctx: @ctx)
+        system = ShopifyCLI::JsSystem.new(ctx: @ctx)
 
         CLI::UI::Frame.open(@ctx.message("build.frame_title", system.package_manager)) do
           success = system.call(yarn: YARN_BUILD_COMMAND, npm: NPM_BUILD_COMMAND)

--- a/lib/project_types/extension/commands/check.rb
+++ b/lib/project_types/extension/commands/check.rb
@@ -4,7 +4,7 @@ require "theme_check"
 module Extension
   class Command
     class Check < ExtensionCommand
-      class CheckOptions < ShopifyCli::Options
+      class CheckOptions < ShopifyCLI::Options
         def initialize(ctx, theme_check)
           super()
           @theme_check = theme_check
@@ -37,7 +37,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.message("check.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("check.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/extension/commands/connect.rb
+++ b/lib/project_types/extension/commands/connect.rb
@@ -19,7 +19,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("connect.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -2,7 +2,7 @@
 
 module Extension
   class Command
-    class Create < ShopifyCli::SubCommand
+    class Create < ShopifyCLI::SubCommand
       DEVELOPMENT_SERVER_SUPPORTED_TYPES = [
         "checkout_ui_extension",
       ]
@@ -42,7 +42,7 @@ module Extension
       end
 
       def self.help
-        @ctx.message("create.help", ShopifyCli::TOOL_NAME)
+        @ctx.message("create.help", ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Extension
   class Command
-    class ExtensionCommand < ShopifyCli::SubCommand
+    class ExtensionCommand < ShopifyCLI::SubCommand
       def project
         @project ||= ExtensionProject.current
       end

--- a/lib/project_types/extension/commands/info.rb
+++ b/lib/project_types/extension/commands/info.rb
@@ -14,7 +14,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("info.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("info.help", ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -18,7 +18,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("push.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("push.help", ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -20,7 +20,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("register.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("register.help", ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -60,7 +60,7 @@ module Extension
 
       def abort_not_registered
         @ctx.puts(@ctx.message("register.confirm_abort"))
-        raise ShopifyCli::AbortSilent
+        raise ShopifyCLI::AbortSilent
       end
     end
   end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -29,7 +29,7 @@ module Extension
           resource_url: options.flags[:resource_url]
         )
 
-        ShopifyCli::Result
+        ShopifyCLI::Result
           .success(config)
           .then(&method(:find_available_port))
           .then(&method(:start_tunnel_if_required))
@@ -38,7 +38,7 @@ module Extension
       end
 
       def self.help
-        ShopifyCli::Context.new.message("serve.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.new.message("serve.help", ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -66,12 +66,12 @@ module Extension
       end
 
       def can_start_tunnel?(runtime_configuration)
-        return true if ShopifyCli::Tunnel.urls.empty?
-        ShopifyCli::Tunnel.running_on?(runtime_configuration.port)
+        return true if ShopifyCLI::Tunnel.urls.empty?
+        ShopifyCLI::Tunnel.running_on?(runtime_configuration.port)
       end
 
       def start_tunnel(runtime_configuration)
-        tunnel_url = ShopifyCli::Tunnel.start(@ctx, port: runtime_configuration.port)
+        tunnel_url = ShopifyCLI::Tunnel.start(@ctx, port: runtime_configuration.port)
         runtime_configuration.tap { |c| c.tunnel_url = tunnel_url }
       end
 

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -21,25 +21,25 @@ module Extension
 
         case subcommand
         when AUTH_SUBCOMMAND then authorize(args)
-        when START_SUBCOMMAND then ShopifyCli::Tunnel.start(@ctx, port: port)
-        when STOP_SUBCOMMAND then ShopifyCli::Tunnel.stop(@ctx)
+        when START_SUBCOMMAND then ShopifyCLI::Tunnel.start(@ctx, port: port)
+        when STOP_SUBCOMMAND then ShopifyCLI::Tunnel.stop(@ctx)
         when STATUS_SUBCOMMAND then status
         else @ctx.puts(self.class.help)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("tunnel.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("tunnel.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("tunnel.extended_help", ShopifyCli::TOOL_NAME, DEFAULT_PORT)
+        ShopifyCLI::Context.message("tunnel.extended_help", ShopifyCLI::TOOL_NAME, DEFAULT_PORT)
       end
 
       private
 
       def status
-        tunnel_urls = ShopifyCli::Tunnel.urls
+        tunnel_urls = ShopifyCLI::Tunnel.urls
         tunnel_url = tunnel_urls.find { |url| url.start_with?("https://") }
         tunnel_url = tunnel_urls.first if tunnel_url.nil?
 
@@ -65,7 +65,7 @@ module Extension
           @ctx.puts(@ctx.message("tunnel.missing_token"))
           @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
         else
-          ShopifyCli::Tunnel.auth(@ctx, token)
+          ShopifyCLI::Tunnel.auth(@ctx, token)
         end
       end
     end

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -3,10 +3,10 @@ require "shopify_cli"
 require "securerandom"
 
 module Extension
-  class ExtensionProject < ShopifyCli::Project
+  class ExtensionProject < ShopifyCLI::Project
     class << self
       def write_cli_file(context:, type:)
-        ShopifyCli::Project.write(
+        ShopifyCLI::Project.write(
           context,
           project_type: :extension,
           organization_id: nil,
@@ -42,7 +42,7 @@ module Extension
         resource_url: nil,
         shop: nil
       )
-        ShopifyCli::Resources::EnvFile.new(
+        ShopifyCLI::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
           shop: shop,
@@ -134,7 +134,7 @@ module Extension
 
     def validate_env_present
       return if env
-      raise ShopifyCli::Abort, "Missing .env file. Run `shopify extension connect` to generate an .env file."
+      raise ShopifyCLI::Abort, "Missing .env file. Run `shopify extension connect` to generate an .env file."
     end
 
     def integer?(value)

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -24,7 +24,7 @@ module Extension
       end
 
       def config(context)
-        js_system = ShopifyCli::JsSystem.new(ctx: context)
+        js_system = ShopifyCLI::JsSystem.new(ctx: context)
         if js_system.package_manager == "yarn"
           run_yarn_install(context, js_system)
           run_yarn_run_script(context, js_system)
@@ -42,7 +42,7 @@ module Extension
       end
 
       def renderer_package(context)
-        js_system = ShopifyCli::JsSystem.new(ctx: context)
+        js_system = ShopifyCLI::JsSystem.new(ctx: context)
         Tasks::FindNpmPackages
           .exactly_one_of(renderer_package_name, js_system: js_system)
           .unwrap { |err| raise err }

--- a/lib/project_types/extension/features/argo_config.rb
+++ b/lib/project_types/extension/features/argo_config.rb
@@ -21,7 +21,7 @@ module Extension
             return {} if config.nil?
 
             unless config.is_a?(Hash)
-              raise ShopifyCli::Abort, ShopifyCli::Context.message("core.yaml.error.not_hash", CONFIG_FILE_NAME)
+              raise ShopifyCLI::Abort, ShopifyCLI::Context.message("core.yaml.error.not_hash", CONFIG_FILE_NAME)
             end
 
             config.transform_keys!(&:to_sym)
@@ -30,8 +30,8 @@ module Extension
             config
           rescue Psych::SyntaxError => e
             raise(
-              ShopifyCli::Abort,
-              ShopifyCli::Context.message("core.yaml.error.invalid", CONFIG_FILE_NAME, e.message)
+              ShopifyCLI::Abort,
+              ShopifyCLI::Context.message("core.yaml.error.invalid", CONFIG_FILE_NAME, e.message)
             )
           end
         end
@@ -45,8 +45,8 @@ module Extension
 
           unless unpermitted_keys.empty?
             raise(
-              ShopifyCli::Abort,
-              ShopifyCli::Context.message(
+              ShopifyCLI::Abort,
+              ShopifyCLI::Context.message(
                 "features.argo.config.unpermitted_keys",
                 CONFIG_FILE_NAME,
                 unpermitted_keys.map { |k| "\n- #{k}" }.join

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -8,10 +8,10 @@ module Extension
 
       property! :specification_handler, accepts: Extension::Models::SpecificationHandlers::Default
       property! :argo_runtime, accepts: -> (runtime) { runtime.class < Features::Runtimes::Base }
-      property! :context, accepts: ShopifyCli::Context
+      property! :context, accepts: ShopifyCLI::Context
       property! :port, accepts: Integer, default: 39351
       property  :tunnel_url, accepts: String, default: nil
-      property! :js_system, accepts: ->(jss) { jss.respond_to?(:call) }, default: ShopifyCli::JsSystem
+      property! :js_system, accepts: ->(jss) { jss.respond_to?(:call) }, default: ShopifyCLI::JsSystem
       property :resource_url, accepts: String, default: nil
 
       def call
@@ -58,8 +58,8 @@ module Extension
 
         return if required_fields.none?
 
-        ShopifyCli::Tasks::EnsureEnv.call(context, required: required_fields)
-        ShopifyCli::Tasks::EnsureDevStore.call(context) if required_fields.include?(:shop)
+        ShopifyCLI::Tasks::EnsureEnv.call(context, required: required_fields)
+        ShopifyCLI::Tasks::EnsureDevStore.call(context) if required_fields.include?(:shop)
 
         project = ExtensionProject.current
         ensure_resource_resource_url! if specification_handler.supplies_resource_url?
@@ -90,7 +90,7 @@ module Extension
       def ensure_resource_resource_url!
         project = ExtensionProject.current(force_reload: true)
 
-        ShopifyCli::Result
+        ShopifyCLI::Result
           .wrap(project.resource_url)
           .rescue { specification_handler.build_resource_url(shop: project.env.shop, context: context) }
           .then(&method(:persist_resource_url))

--- a/lib/project_types/extension/features/argo_setup.rb
+++ b/lib/project_types/extension/features/argo_setup.rb
@@ -26,7 +26,7 @@ module Extension
       end
 
       def run_install_steps(context, steps, identifier, directory_name)
-        system = ShopifyCli::JsSystem.new(ctx: context)
+        system = ShopifyCLI::JsSystem.new(ctx: context)
 
         steps.inject(true) do |success, setup_step|
           success && setup_step.call(context, identifier, directory_name, system)

--- a/lib/project_types/extension/features/argo_setup_step.rb
+++ b/lib/project_types/extension/features/argo_setup_step.rb
@@ -11,7 +11,7 @@ module Extension
       def call(context, identifier, directory_name, js_system)
         step_result = step.call(context, identifier, directory_name, js_system)
         can_fail? ? step_result : true
-      rescue ShopifyCli::Abort => e
+      rescue ShopifyCLI::Abort => e
         context.puts(e.message)
         false
       rescue StandardError => e

--- a/lib/project_types/extension/features/argo_setup_steps.rb
+++ b/lib/project_types/extension/features/argo_setup_steps.rb
@@ -18,7 +18,7 @@ module Extension
       def self.clone_template(git_template)
         ArgoSetupStep.default do |context, _identifier, directory_name, _js_system|
           begin
-            ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
+            ShopifyCLI::Git.clone(git_template, directory_name, ctx: context)
             context.root = File.join(context.root, directory_name)
           rescue StandardError
             context.puts("{{x}} Unable to clone the repository.")
@@ -28,7 +28,7 @@ module Extension
 
       def self.install_dependencies
         ArgoSetupStep.default do |context, _identifier, _directory_name, js_system|
-          ShopifyCli::JsDeps.new(ctx: context, system: js_system).install
+          ShopifyCLI::JsDeps.new(ctx: context, system: js_system).install
         end
       end
 

--- a/lib/project_types/extension/forms/connect.rb
+++ b/lib/project_types/extension/forms/connect.rb
@@ -2,7 +2,7 @@
 
 module Extension
   module Forms
-    class Connect < ShopifyCli::Form
+    class Connect < ShopifyCLI::Form
       attr_reader :registration, :app
 
       flag_arguments :type
@@ -19,7 +19,7 @@ module Extension
       end
 
       def ask
-        ShopifyCli::Result.wrap(ExtensionProjectDetails.new)
+        ShopifyCLI::Result.wrap(ExtensionProjectDetails.new)
           .then(&Questions::AskRegistration.new(ctx: ctx, type: type))
           .unwrap { |e| raise e }
           .tap do |project_details|

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -2,7 +2,7 @@
 
 module Extension
   module Forms
-    class Create < ShopifyCli::Form
+    class Create < ShopifyCLI::Form
       flag_arguments :name, :type, :api_key, :template
 
       attr_reader :app
@@ -21,7 +21,7 @@ module Extension
       end
 
       def ask
-        ShopifyCli::Result.wrap(ExtensionProjectDetails.new)
+        ShopifyCLI::Result.wrap(ExtensionProjectDetails.new)
           .then(&Questions::AskApp.new(ctx: ctx, api_key: api_key))
           .then(&Questions::AskType.new(ctx: ctx, type: type))
           .then(&Questions::AskTemplate.new(ctx: ctx))

--- a/lib/project_types/extension/forms/questions/ask_app.rb
+++ b/lib/project_types/extension/forms/questions/ask_app.rb
@@ -2,7 +2,7 @@ module Extension
   module Forms
     module Questions
       class AskApp
-        include ShopifyCli::MethodObject
+        include ShopifyCLI::MethodObject
 
         property! :ctx
         property :api_key
@@ -45,7 +45,7 @@ module Extension
         def abort_no_apps
           ctx.puts(@ctx.message("create.no_apps"))
           ctx.puts(@ctx.message("create.learn_about_apps"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
       end
     end

--- a/lib/project_types/extension/forms/questions/ask_name.rb
+++ b/lib/project_types/extension/forms/questions/ask_name.rb
@@ -2,7 +2,7 @@ module Extension
   module Forms
     module Questions
       class AskName
-        include ShopifyCli::MethodObject
+        include ShopifyCLI::MethodObject
 
         property! :ctx
         property :name

--- a/lib/project_types/extension/forms/questions/ask_registration.rb
+++ b/lib/project_types/extension/forms/questions/ask_registration.rb
@@ -4,7 +4,7 @@ module Extension
   module Forms
     module Questions
       class AskRegistration
-        include ShopifyCli::MethodObject
+        include ShopifyCLI::MethodObject
 
         property! :ctx
         property! :type
@@ -43,7 +43,7 @@ module Extension
         def abort_no_registrations
           ctx.puts(@ctx.message("connect.no_extensions", type))
           ctx.puts(@ctx.message("connect.learn_about_extensions"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
       end
     end

--- a/lib/project_types/extension/forms/questions/ask_template.rb
+++ b/lib/project_types/extension/forms/questions/ask_template.rb
@@ -2,7 +2,7 @@ module Extension
   module Forms
     module Questions
       class AskTemplate
-        include ShopifyCli::MethodObject
+        include ShopifyCLI::MethodObject
 
         TEMPLATE_REQUIRED_TYPES = [
           "checkout_ui_extension",
@@ -28,7 +28,7 @@ module Extension
         end
 
         def extension_server_beta?
-          ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:extension_server_beta)
+          ShopifyCLI::Shopifolk.check && ShopifyCLI::Feature.enabled?(:extension_server_beta)
         end
 
         def choose_interactively

--- a/lib/project_types/extension/forms/questions/ask_type.rb
+++ b/lib/project_types/extension/forms/questions/ask_type.rb
@@ -2,7 +2,7 @@ module Extension
   module Forms
     module Questions
       class AskType
-        include ShopifyCli::MethodObject
+        include ShopifyCLI::MethodObject
 
         property! :ctx
         property :type
@@ -39,7 +39,7 @@ module Extension
 
         def abort_due_to_missing_specifications
           ctx.puts(@ctx.message("create.no_available_extensions"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
       end
     end

--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -15,9 +15,9 @@ module Extension
       end
 
       def self.load_current_type_messages
-        return unless ShopifyCli::Project.has_current?
+        return unless ShopifyCLI::Project.has_current?
         messages_for_type(
-          ShopifyCli::Project.current.config[Extension::ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY]
+          ShopifyCLI::Project.current.config[Extension::ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY]
         )
       end
 

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -10,7 +10,7 @@ module Extension
 
       def self.supported?(type)
         return false unless SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
-        ShopifyCli::Shopifolk.check && ShopifyCli::Feature.enabled?(:extension_server_beta)
+        ShopifyCLI::Shopifolk.check && ShopifyCLI::Feature.enabled?(:extension_server_beta)
       end
     end
   end

--- a/lib/project_types/extension/models/lazy_specification_handler.rb
+++ b/lib/project_types/extension/models/lazy_specification_handler.rb
@@ -1,6 +1,6 @@
 module Extension
   module Models
-    class LazySpecificationHandler < ShopifyCli::LazyDelegator
+    class LazySpecificationHandler < ShopifyCLI::LazyDelegator
       attr_reader :identifier
 
       def initialize(identifier, &specification_handler_initializer)

--- a/lib/project_types/extension/models/specification.rb
+++ b/lib/project_types/extension/models/specification.rb
@@ -18,7 +18,7 @@ module Extension
         def self.build(feature_set_attributes)
           feature_set_attributes.each_with_object(OpenStruct.new) do |(identifier, feature_attributes), feature_set|
             next if feature_attributes.nil?
-            feature_set[identifier] = ShopifyCli::ResolveConstant
+            feature_set[identifier] = ShopifyCLI::ResolveConstant
               .call(identifier, namespace: Features)
               .rescue { OpenStruct }
               .then { |c| c.new(**feature_attributes) }

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -76,7 +76,7 @@ module Extension
           cli_package_name = specification.features.argo&.cli_package_name
           return unless cli_package_name
 
-          js_system = ShopifyCli::JsSystem.new(ctx: context)
+          js_system = ShopifyCLI::JsSystem.new(ctx: context)
           Tasks::FindNpmPackages.exactly_one_of(cli_package_name, js_system: js_system)
             .unwrap { |_e| context.abort(context.message("errors.package_not_found", cli_package_name)) }
         end
@@ -87,7 +87,7 @@ module Extension
           if (str = messages.dig(*key_parts))
             str % params
           else
-            ShopifyCli::Context.message(key, *params)
+            ShopifyCLI::Context.message(key, *params)
           end
         end
 

--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -15,7 +15,7 @@ module Extension
           context.root = File.join(context.root, directory_name)
 
           if getting_started
-            ShopifyCli::Git.clone("https://github.com/Shopify/theme-extension-getting-started", context.root)
+            ShopifyCLI::Git.clone("https://github.com/Shopify/theme-extension-getting-started", context.root)
             context.rm_r(".git")
           else
             FileUtils.makedirs(SUPPORTED_BUCKETS.map { |b| File.join(context.root, b) })

--- a/lib/project_types/extension/models/specifications.rb
+++ b/lib/project_types/extension/models/specifications.rb
@@ -5,7 +5,7 @@ module Extension
 
       property! :custom_handler_root,
         accepts: ->(d) { File.directory?(d) },
-        default: -> { File.expand_path("lib/project_types/extension/models/specification_handlers", ShopifyCli::ROOT) }
+        default: -> { File.expand_path("lib/project_types/extension/models/specification_handlers", ShopifyCLI::ROOT) }
 
       property! :custom_handler_namespace,
         accepts: ->(m) { m.respond_to?(:const_get) },
@@ -39,9 +39,9 @@ module Extension
       private
 
       def fetch_specifications_and_build_handlers
-        ShopifyCli::Result
+        ShopifyCLI::Result
           .call(&fetch_specifications)
-          .map(&ShopifyCli::TransformDataStructure.new(symbolize_keys: true, underscore_keys: true))
+          .map(&ShopifyCLI::TransformDataStructure.new(symbolize_keys: true, underscore_keys: true))
           .then(&method(:select_cli_extensions))
           .then(&Tasks::ConfigureFeatures)
           .then(&Tasks::ConfigureOptions)
@@ -61,7 +61,7 @@ module Extension
 
       def instantiate_specification_handlers(specifications)
         specifications.each_with_object({}) do |specification, handlers|
-          ShopifyCli::ResolveConstant.call(specification.identifier, namespace: custom_handler_namespace)
+          ShopifyCLI::ResolveConstant.call(specification.identifier, namespace: custom_handler_namespace)
             .rescue { |error| error.is_a?(NameError) ? SpecificationHandlers::Default : raise(error) }
             .then { |handler_class| handler_class.new(specification) }
             .unwrap { |error| raise error }

--- a/lib/project_types/extension/tasks/choose_next_available_port.rb
+++ b/lib/project_types/extension/tasks/choose_next_available_port.rb
@@ -5,7 +5,7 @@ require "socket"
 module Extension
   module Tasks
     class ChooseNextAvailablePort
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       property! :from
       property! :to, default: -> { from + 10 }

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -1,7 +1,7 @@
 module Extension
   module Tasks
     class ConfigureFeatures
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       class Error < RuntimeError; end
       class UnknownSurfaceArea < Error; end

--- a/lib/project_types/extension/tasks/configure_options.rb
+++ b/lib/project_types/extension/tasks/configure_options.rb
@@ -1,7 +1,7 @@
 module Extension
   module Tasks
     class ConfigureOptions
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(specification_attribute_sets)
         specification_attribute_sets.each do |attributes|

--- a/lib/project_types/extension/tasks/converters/product_converter.rb
+++ b/lib/project_types/extension/tasks/converters/product_converter.rb
@@ -12,7 +12,7 @@ module Extension
           variant = hash.dig(*VARIANT_PATH)
           return unless variant
           Models::Product.new(
-            variant_id: ShopifyCli::API.gid_to_id(variant)
+            variant_id: ShopifyCLI::API.gid_to_id(variant)
           )
         end
       end

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class CreateExtension < ShopifyCli::Task
+    class CreateExtension < ShopifyCLI::Task
       include UserErrors
 
       GRAPHQL_FILE = "extension_create"
@@ -20,7 +20,7 @@ module Extension
           extension_context: extension_context,
         }
 
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
+        response = ShopifyCLI::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         abort_if_user_errors(context, response)

--- a/lib/project_types/extension/tasks/fetch_specifications.rb
+++ b/lib/project_types/extension/tasks/fetch_specifications.rb
@@ -1,13 +1,13 @@
 module Extension
   module Tasks
     class FetchSpecifications
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       property :context
       property :api_key
 
       def call
-        response = ShopifyCli::PartnersAPI
+        response = ShopifyCLI::PartnersAPI
           .query(context, "fetch_specifications", api_key: api_key)
           .dig("data", "extensionSpecifications")
         context.abort(context.message("tasks.errors.parse_error")) if response.nil?

--- a/lib/project_types/extension/tasks/find_npm_packages.rb
+++ b/lib/project_types/extension/tasks/find_npm_packages.rb
@@ -1,9 +1,9 @@
 module Extension
   module Tasks
     class FindNpmPackages
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
-      property! :js_system, accepts: ShopifyCli::JsSystem
+      property! :js_system, accepts: ShopifyCLI::JsSystem
       property! :production_only, accepts: [true, false], default: false, reader: :production_only?
 
       def self.at_least_one_of(*package_names, **config)
@@ -69,7 +69,7 @@ module Extension
           raise ArgumentError, "Expected a list of package names"
         end
 
-        ShopifyCli::Result
+        ShopifyCLI::Result
           .call(&method(:list_packages))
           .then(&method(:search_packages).curry[package_names])
           .then(&method(:filter_duplicates))

--- a/lib/project_types/extension/tasks/get_app.rb
+++ b/lib/project_types/extension/tasks/get_app.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class GetApp < ShopifyCli::Task
+    class GetApp < ShopifyCLI::Task
       GRAPHQL_FILE = "get_app_by_api_key"
 
       RESPONSE_FIELD = %w(data)
@@ -12,7 +12,7 @@ module Extension
       def call(context:, api_key:)
         input = { api_key: api_key }
 
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
+        response = ShopifyCLI::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         Converters::AppConverter.from_hash(response.dig(APP_FIELD))

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -3,9 +3,9 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class GetApps < ShopifyCli::Task
+    class GetApps < ShopifyCLI::Task
       def call(context:)
-        organizations = ShopifyCli::PartnersAPI::Organizations.fetch_with_app(context)
+        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_app(context)
         apps_from_organizations(organizations)
       end
 

--- a/lib/project_types/extension/tasks/get_extensions.rb
+++ b/lib/project_types/extension/tasks/get_extensions.rb
@@ -3,9 +3,9 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class GetExtensions < ShopifyCli::Task
+    class GetExtensions < ShopifyCLI::Task
       def call(context:, type:)
-        organizations = ShopifyCli::PartnersAPI::Organizations.fetch_with_extensions(context, type)
+        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type)
         extensions_from_organizations(organizations, context: context)
       end
 

--- a/lib/project_types/extension/tasks/get_product.rb
+++ b/lib/project_types/extension/tasks/get_product.rb
@@ -3,12 +3,12 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class GetProduct < ShopifyCli::Task
+    class GetProduct < ShopifyCLI::Task
       API_VERSION = "2021-07"
       GRAPHQL_FILE = "get_variant_id"
 
       def call(context, shop)
-        response = ShopifyCli::AdminAPI.query(
+        response = ShopifyCLI::AdminAPI.query(
           context,
           GRAPHQL_FILE,
           shop: shop,

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -4,7 +4,7 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class RunExtensionCommand < ShopifyCli::Task
+    class RunExtensionCommand < ShopifyCLI::Task
       include SmartProperties
 
       SUPPORTED_EXTENSION_TYPES = [
@@ -22,7 +22,7 @@ module Extension
       property! :command, accepts: SUPPORTED_COMMANDS
 
       def call
-        ShopifyCli::Result
+        ShopifyCLI::Result
           .call(&method(:build_extension))
           .then(&method(:build_server_config))
           .then(&method(:run_command))

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Extension
   module Tasks
-    class UpdateDraft < ShopifyCli::Task
+    class UpdateDraft < ShopifyCLI::Task
       include UserErrors
 
       GRAPHQL_FILE = "extension_update_draft"
@@ -18,7 +18,7 @@ module Extension
           config: JSON.generate(config),
           extension_context: extension_context,
         }
-        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
+        response = ShopifyCLI::PartnersAPI.query(context, GRAPHQL_FILE, **input).dig(*RESPONSE_FIELD)
         context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         abort_if_user_errors(context, response)

--- a/lib/project_types/node/cli.rb
+++ b/lib/project_types/node/cli.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 module Node
-  class Project < ShopifyCli::ProjectType
+  class Project < ShopifyCLI::ProjectType
     require Project.project_filepath("messages/messages")
     register_messages(Node::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands
-  class Command < ShopifyCli::ProjectCommands
+  class Command < ShopifyCLI::ProjectCommands
     subcommand :Connect, "connect", Project.project_filepath("commands/connect")
     subcommand :Create, "create", Project.project_filepath("commands/create")
     subcommand :Deploy, "deploy", Project.project_filepath("commands/deploy")
@@ -15,7 +15,7 @@ module Node
     subcommand :Serve, "serve", Project.project_filepath("commands/serve")
     subcommand :Tunnel, "tunnel", Project.project_filepath("commands/tunnel")
   end
-  ShopifyCli::Commands.register("Node::Command", "node")
+  ShopifyCLI::Commands.register("Node::Command", "node")
 
   # define/autoload project specific Tasks
   module Tasks

--- a/lib/project_types/node/commands/connect.rb
+++ b/lib/project_types/node/commands/connect.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 module Node
   class Command
-    class Connect < ShopifyCli::SubCommand
+    class Connect < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :node
 
       def call(*)
-        if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
+        if ShopifyCLI::Project.has_current? && ShopifyCLI::Project.current.env
           @ctx.puts(@ctx.message("node.connect.production_warning"))
         end
 
-        app = ShopifyCli::Connect.new(@ctx).default_connect("node")
+        app = ShopifyCLI::Connect.new(@ctx).default_connect("node")
         @ctx.done(@ctx.message("node.connect.connected", app))
       end
 
       def self.help
-        ShopifyCli::Context.message("node.connect.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/create.rb
+++ b/lib/project_types/node/commands/create.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Node
   class Command
-    class Create < ShopifyCli::SubCommand
+    class Create < ShopifyCLI::SubCommand
       prerequisite_task :ensure_authenticated
 
       options do |parser, flags|
@@ -26,37 +26,37 @@ module Node
         check_npm
         build(form.name)
 
-        ShopifyCli::Project.write(
+        ShopifyCLI::Project.write(
           @ctx,
           project_type: "node",
           organization_id: form.organization_id,
         )
 
-        api_client = ShopifyCli::Tasks::CreateApiClient.call(
+        api_client = ShopifyCLI::Tasks::CreateApiClient.call(
           @ctx,
           org_id: form.organization_id,
           title: form.title,
           type: form.type,
         )
 
-        ShopifyCli::Resources::EnvFile.new(
+        ShopifyCLI::Resources::EnvFile.new(
           api_key: api_client["apiKey"],
           secret: api_client["apiSecretKeys"].first["secret"],
           shop: form.shop_domain,
           scopes: "write_products,write_customers,write_draft_orders",
         ).write(@ctx)
 
-        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client["id"])
+        partners_url = ShopifyCLI::PartnersAPI.partners_url_for(form.organization_id, api_client["id"])
 
         @ctx.puts(@ctx.message("apps.create.info.created", form.title, partners_url))
-        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCli::TOOL_NAME, "node"))
-        unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCLI::TOOL_NAME, "node"))
+        unless ShopifyCLI::Shopifolk.acting_as_shopify_organization?
           @ctx.puts(@ctx.message("apps.create.info.install", partners_url, form.title))
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("node.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.create.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -101,12 +101,12 @@ module Node
       end
 
       def build(name)
-        ShopifyCli::Git.clone("https://github.com/Shopify/shopify-app-node.git", name)
+        ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-node.git", name)
 
         @ctx.root = File.join(@ctx.root, name)
 
         set_npm_config
-        ShopifyCli::JsDeps.install(@ctx, !options.flags[:verbose].nil?)
+        ShopifyCLI::JsDeps.install(@ctx, !options.flags[:verbose].nil?)
 
         begin
           @ctx.rm_r(".git")

--- a/lib/project_types/node/commands/deploy.rb
+++ b/lib/project_types/node/commands/deploy.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Node
   class Command
-    class Deploy < ShopifyCli::SubCommand
+    class Deploy < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :node
 
       autoload :Heroku, Project.project_filepath("commands/deploy/heroku")
@@ -21,11 +21,11 @@ module Node
       end
 
       def self.help
-        ShopifyCli::Context.message("node.deploy.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.deploy.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("node.deploy.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.deploy.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/deploy/heroku.rb
+++ b/lib/project_types/node/commands/deploy/heroku.rb
@@ -6,12 +6,12 @@ module Node
     class Deploy
       class Heroku
         def self.help
-          ShopifyCli::Context.message("node.deploy.heroku.help", ShopifyCli::TOOL_NAME)
+          ShopifyCLI::Context.message("node.deploy.heroku.help", ShopifyCLI::TOOL_NAME)
         end
 
         def self.start(ctx)
           spin_group = CLI::UI::SpinGroup.new
-          heroku_service = ShopifyCli::Heroku.new(ctx)
+          heroku_service = ShopifyCLI::Heroku.new(ctx)
 
           spin_group.add(ctx.message("node.deploy.heroku.downloading")) do |spinner|
             heroku_service.download
@@ -29,7 +29,7 @@ module Node
           spin_group.wait
 
           spin_group.add(ctx.message("node.deploy.heroku.git.checking")) do |spinner|
-            ShopifyCli::Git.init(ctx)
+            ShopifyCLI::Git.init(ctx)
             spinner.update_title(ctx.message("node.deploy.heroku.git.initialized"))
           end
           spin_group.wait
@@ -71,7 +71,7 @@ module Node
             end
           end
 
-          branches = ShopifyCli::Git.branches(ctx)
+          branches = ShopifyCLI::Git.branches(ctx)
           if branches.length == 1
             branch_to_deploy = branches[0]
             ctx.puts(ctx.message("node.deploy.heroku.git.branch_selected", branch_to_deploy))

--- a/lib/project_types/node/commands/generate.rb
+++ b/lib/project_types/node/commands/generate.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Node
   class Command
-    class Generate < ShopifyCli::SubCommand
+    class Generate < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :node
 
       def call(*)
@@ -11,7 +11,7 @@ module Node
       end
 
       def self.help
-        ShopifyCli::Context.message("node.generate.help")
+        ShopifyCLI::Context.message("node.generate.help")
       end
 
       def self.extended_help

--- a/lib/project_types/node/commands/open.rb
+++ b/lib/project_types/node/commands/open.rb
@@ -2,16 +2,16 @@ require "shopify_cli"
 
 module Node
   class Command
-    class Open < ShopifyCli::SubCommand
+    class Open < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :node
 
       def call(*)
-        project = ShopifyCli::Project.current
+        project = ShopifyCLI::Project.current
         @ctx.open_url!("#{project.env.host}/auth?shop=#{project.env.shop}")
       end
 
       def self.help
-        ShopifyCli::Context.message("node.open.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.open.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/commands/serve.rb
+++ b/lib/project_types/node/commands/serve.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Node
   class Command
-    class Serve < ShopifyCli::SubCommand
+    class Serve < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :node
       prerequisite_task :ensure_env, :ensure_dev_store
 
@@ -12,11 +12,11 @@ module Node
       end
 
       def call(*)
-        project = ShopifyCli::Project.current
-        url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
+        project = ShopifyCLI::Project.current
+        url = options.flags[:host] || ShopifyCLI::Tunnel.start(@ctx)
         @ctx.abort(@ctx.message("node.serve.error.host_must_be_https")) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @ctx,
           url: url,
           callback_url: "/auth/callback",
@@ -29,17 +29,17 @@ module Node
 
         CLI::UI::Frame.open(@ctx.message("node.serve.running_server")) do
           env = project.env.to_h
-          env["PORT"] = ShopifyCli::Tunnel::PORT.to_s
+          env["PORT"] = ShopifyCLI::Tunnel::PORT.to_s
           @ctx.system("npm run dev", env: env)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("node.serve.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.serve.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("node.serve.extended_help")
+        ShopifyCLI::Context.message("node.serve.extended_help")
       end
     end
   end

--- a/lib/project_types/node/commands/tunnel.rb
+++ b/lib/project_types/node/commands/tunnel.rb
@@ -4,7 +4,7 @@ require "shopify_cli"
 
 module Node
   class Command
-    class Tunnel < ShopifyCli::SubCommand
+    class Tunnel < ShopifyCLI::SubCommand
       # subcommands :auth, :start, :stop
 
       prerequisite_task ensure_project_type: :node
@@ -18,23 +18,23 @@ module Node
             @ctx.puts(@ctx.message("node.tunnel.error.token_argument_missing"))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
-            ShopifyCli::Tunnel.auth(@ctx, token)
+            ShopifyCLI::Tunnel.auth(@ctx, token)
           end
         when "start"
-          ShopifyCli::Tunnel.start(@ctx)
+          ShopifyCLI::Tunnel.start(@ctx)
         when "stop"
-          ShopifyCli::Tunnel.stop(@ctx)
+          ShopifyCLI::Tunnel.stop(@ctx)
         else
           @ctx.puts(self.class.help)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("node.tunnel.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.tunnel.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("node.tunnel.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("node.tunnel.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/node/forms/create.rb
+++ b/lib/project_types/node/forms/create.rb
@@ -2,7 +2,7 @@ require "uri"
 
 module Node
   module Forms
-    class Create < ShopifyCli::Form
+    class Create < ShopifyCLI::Form
       attr_accessor :name
       flag_arguments :title, :organization_id, :shop_domain, :type
 
@@ -10,7 +10,7 @@ module Node
         self.title ||= CLI::UI::Prompt.ask(ctx.message("node.forms.create.app_name"))
         self.name = format_name
         self.type = ask_type
-        res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
+        res = ShopifyCLI::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
         self.organization_id = res[:organization_id]
         self.shop_domain = res[:shop_domain]
       end
@@ -34,7 +34,7 @@ module Node
           end
         end
 
-        unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
+        unless ShopifyCLI::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
           ctx.abort(ctx.message("node.forms.create.error.invalid_app_type", type))
         end
         ctx.puts(ctx.message("node.forms.create.app_type.selected", type))

--- a/lib/project_types/rails/cli.rb
+++ b/lib/project_types/rails/cli.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 module Rails
-  class Project < ShopifyCli::ProjectType
+  class Project < ShopifyCLI::ProjectType
     require Project.project_filepath("messages/messages")
     register_messages(Rails::Messages::MESSAGES)
   end
 
   # define/autoload project specific Commands
-  class Command < ShopifyCli::ProjectCommands
+  class Command < ShopifyCLI::ProjectCommands
     subcommand :Connect, "connect", Project.project_filepath("commands/connect")
     subcommand :Create, "create", Project.project_filepath("commands/create")
     subcommand :Deploy, "deploy", Project.project_filepath("commands/deploy")
@@ -15,7 +15,7 @@ module Rails
     subcommand :Serve, "serve", Project.project_filepath("commands/serve")
     subcommand :Tunnel, "tunnel", Project.project_filepath("commands/tunnel")
   end
-  ShopifyCli::Commands.register("Rails::Command", "rails")
+  ShopifyCLI::Commands.register("Rails::Command", "rails")
 
   # define/autoload project specific Tasks
   module Tasks

--- a/lib/project_types/rails/commands/connect.rb
+++ b/lib/project_types/rails/commands/connect.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 module Rails
   class Command
-    class Connect < ShopifyCli::SubCommand
+    class Connect < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :rails
 
       def call(*)
-        if ShopifyCli::Project.has_current? && ShopifyCli::Project.current.env
+        if ShopifyCLI::Project.has_current? && ShopifyCLI::Project.current.env
           @ctx.puts(@ctx.message("rails.connect.production_warning"))
         end
 
-        app = ShopifyCli::Connect.new(@ctx).default_connect("rails")
+        app = ShopifyCLI::Connect.new(@ctx).default_connect("rails")
         @ctx.done(@ctx.message("rails.connect.connected", app))
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.connect.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Rails
   class Command
-    class Create < ShopifyCli::SubCommand
+    class Create < ShopifyCLI::SubCommand
       prerequisite_task :ensure_authenticated
 
       USER_AGENT_CODE = <<~USERAGENT
@@ -43,37 +43,37 @@ module Rails
 
         build(form.name, form.db)
         set_custom_ua
-        ShopifyCli::Project.write(
+        ShopifyCLI::Project.write(
           @ctx,
           project_type: "rails",
           organization_id: form.organization_id,
         )
 
-        api_client = ShopifyCli::Tasks::CreateApiClient.call(
+        api_client = ShopifyCLI::Tasks::CreateApiClient.call(
           @ctx,
           org_id: form.organization_id,
           title: form.title,
           type: form.type,
         )
 
-        ShopifyCli::Resources::EnvFile.new(
+        ShopifyCLI::Resources::EnvFile.new(
           api_key: api_client["apiKey"],
           secret: api_client["apiSecretKeys"].first["secret"],
           shop: form.shop_domain,
           scopes: "write_products,write_customers,write_draft_orders",
         ).write(@ctx)
 
-        partners_url = ShopifyCli::PartnersAPI.partners_url_for(form.organization_id, api_client["id"])
+        partners_url = ShopifyCLI::PartnersAPI.partners_url_for(form.organization_id, api_client["id"])
 
         @ctx.puts(@ctx.message("apps.create.info.created", form.title, partners_url))
-        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCli::TOOL_NAME, "rails"))
-        unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        @ctx.puts(@ctx.message("apps.create.info.serve", form.name, ShopifyCLI::TOOL_NAME, "rails"))
+        unless ShopifyCLI::Shopifolk.acting_as_shopify_organization?
           @ctx.puts(@ctx.message("apps.create.info.install", partners_url, form.title))
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.create.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.create.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -84,7 +84,7 @@ module Rails
           @ctx.abort(@ctx.message("rails.create.error.node_required")) unless @ctx.windows?
           @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.node_required") + "}}")
           @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "node"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
 
         version, stat = @ctx.capture2e("node", "-v")
@@ -93,7 +93,7 @@ module Rails
           # execution stops above if not Windows
           @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.node_version_failure") + "}}")
           @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "node"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
 
         @ctx.done(@ctx.message("rails.create.node_version", version))
@@ -105,7 +105,7 @@ module Rails
           @ctx.abort(@ctx.message("rails.create.error.yarn_required")) unless @ctx.windows?
           @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.yarn_required") + "}}")
           @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "yarn"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
 
         version, stat = @ctx.capture2e("yarn", "-v")
@@ -113,7 +113,7 @@ module Rails
           @ctx.abort(@ctx.message("rails.create.error.yarn_version_failure")) unless @ctx.windows?
           @ctx.puts("{{x}} {{red:" + @ctx.message("rails.create.error.yarn_version_failure") + "}}")
           @ctx.puts(@ctx.message("rails.create.info.open_new_shell", "yarn"))
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         end
 
         @ctx.done(@ctx.message("rails.create.yarn_version", version))

--- a/lib/project_types/rails/commands/deploy.rb
+++ b/lib/project_types/rails/commands/deploy.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Rails
   class Command
-    class Deploy < ShopifyCli::SubCommand
+    class Deploy < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :rails
 
       autoload :Heroku, Project.project_filepath("commands/deploy/heroku")
@@ -21,11 +21,11 @@ module Rails
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.deploy.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.deploy.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("rails.deploy.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.deploy.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/deploy/heroku.rb
+++ b/lib/project_types/rails/commands/deploy/heroku.rb
@@ -9,7 +9,7 @@ module Rails
           DB_CHECK_CMD = 'bundle exec rails runner "puts ActiveRecord::Base.connection.adapter_name.downcase"'
 
           def help
-            ShopifyCli::Context.message("rails.deploy.heroku.help", ShopifyCli::TOOL_NAME)
+            ShopifyCLI::Context.message("rails.deploy.heroku.help", ShopifyCLI::TOOL_NAME)
           end
 
           def start(ctx)
@@ -23,7 +23,7 @@ module Rails
             end
 
             spin_group = CLI::UI::SpinGroup.new
-            heroku_service = ShopifyCli::Heroku.new(ctx)
+            heroku_service = ShopifyCLI::Heroku.new(ctx)
 
             spin_group.add(ctx.message("rails.deploy.heroku.downloading")) do |spinner|
               heroku_service.download
@@ -36,7 +36,7 @@ module Rails
               spinner.update_title(ctx.message("rails.deploy.heroku.installed"))
             end
             spin_group.add(ctx.message("rails.deploy.heroku.git.checking")) do |spinner|
-              ShopifyCli::Git.init(ctx)
+              ShopifyCLI::Git.init(ctx)
               spinner.update_title(ctx.message("rails.deploy.heroku.git.initialized"))
             end
             spin_group.wait
@@ -78,7 +78,7 @@ module Rails
               end
             end
 
-            branches = ShopifyCli::Git.branches(ctx)
+            branches = ShopifyCLI::Git.branches(ctx)
             if branches.length == 1
               branch_to_deploy = branches[0]
               ctx.puts(ctx.message("rails.deploy.heroku.git.branch_selected", branch_to_deploy))

--- a/lib/project_types/rails/commands/generate.rb
+++ b/lib/project_types/rails/commands/generate.rb
@@ -3,7 +3,7 @@ require "shopify_cli"
 
 module Rails
   class Command
-    class Generate < ShopifyCli::SubCommand
+    class Generate < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :rails
 
       autoload :Webhook, Project.project_filepath("commands/generate/webhook")
@@ -21,7 +21,7 @@ module Rails
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.generate.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.generate.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
@@ -34,7 +34,7 @@ module Rails
           end
           extended_help += "\n"
         end
-        extended_help += ShopifyCli::Context.message("rails.generate.extended_help", ShopifyCli::TOOL_NAME)
+        extended_help += ShopifyCLI::Context.message("rails.generate.extended_help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.run_generate(script, name, ctx)

--- a/lib/project_types/rails/commands/generate/webhook.rb
+++ b/lib/project_types/rails/commands/generate/webhook.rb
@@ -7,7 +7,7 @@ module Rails
         class << self
           def start(ctx, args)
             selected_type = args.first
-            schema = ShopifyCli::AdminAPI::Schema.get(ctx)
+            schema = ShopifyCLI::AdminAPI::Schema.get(ctx)
             webhooks = schema.get_names_from_type("WebhookSubscriptionTopic")
             unless selected_type && webhooks.include?(selected_type)
               selected_type = CLI::UI::Prompt.ask(ctx.message("rails.generate.webhook.select")) do |handler|
@@ -25,12 +25,12 @@ module Rails
           end
 
           def help
-            ShopifyCli::Context.message("rails.generate.webhook.help", ShopifyCli::TOOL_NAME)
+            ShopifyCLI::Context.message("rails.generate.webhook.help", ShopifyCLI::TOOL_NAME)
           end
 
           def generate_command(selected_type, ctx)
             parts = selected_type.downcase.split("_")
-            host = ShopifyCli::Project.current.env.host
+            host = ShopifyCLI::Project.current.env.host
             selected_type = parts[0..-2].join("_") + "/" + parts[-1]
             command = ctx.windows? ? "ruby bin\\rails" : "bin/rails"
             "#{command} g shopify_app:add_webhook -t #{selected_type} -a #{host}/webhooks/#{selected_type.downcase}"

--- a/lib/project_types/rails/commands/open.rb
+++ b/lib/project_types/rails/commands/open.rb
@@ -2,16 +2,16 @@ require "shopify_cli"
 
 module Rails
   class Command
-    class Open < ShopifyCli::SubCommand
+    class Open < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :rails
 
       def call(*)
-        project = ShopifyCli::Project.current
+        project = ShopifyCLI::Project.current
         @ctx.open_url!("#{project.env.host}/login?shop=#{project.env.shop}")
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.open.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.open.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/serve.rb
+++ b/lib/project_types/rails/commands/serve.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Rails
   class Command
-    class Serve < ShopifyCli::SubCommand
+    class Serve < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :rails
       prerequisite_task :ensure_env, :ensure_dev_store
 
@@ -12,11 +12,11 @@ module Rails
       end
 
       def call(*)
-        project = ShopifyCli::Project.current
-        url = options.flags[:host] || ShopifyCli::Tunnel.start(@ctx)
+        project = ShopifyCLI::Project.current
+        url = options.flags[:host] || ShopifyCLI::Tunnel.start(@ctx)
         @ctx.abort(@ctx.message("rails.serve.error.host_must_be_https")) if url.match(/^https/i).nil?
         project.env.update(@ctx, :host, url)
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @ctx,
           url: url,
           callback_url: "/auth/shopify/callback",
@@ -28,9 +28,9 @@ module Rails
         end
 
         CLI::UI::Frame.open(@ctx.message("rails.serve.running_server")) do
-          env = ShopifyCli::Project.current.env.to_h
+          env = ShopifyCLI::Project.current.env.to_h
           env.delete("HOST")
-          env["PORT"] = ShopifyCli::Tunnel::PORT.to_s
+          env["PORT"] = ShopifyCLI::Tunnel::PORT.to_s
           env["GEM_PATH"] = Gem.gem_path(@ctx)
           if @ctx.windows?
             @ctx.system("ruby bin\\rails server", env: env)
@@ -41,11 +41,11 @@ module Rails
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.serve.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.serve.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("rails.serve.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.serve.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/commands/tunnel.rb
+++ b/lib/project_types/rails/commands/tunnel.rb
@@ -4,7 +4,7 @@ require "shopify_cli"
 
 module Rails
   class Command
-    class Tunnel < ShopifyCli::SubCommand
+    class Tunnel < ShopifyCLI::SubCommand
       # subcommands :auth, :start, :stop
 
       prerequisite_task ensure_project_type: :rails
@@ -18,23 +18,23 @@ module Rails
             @ctx.puts(@ctx.message("rails.tunnel.error.token_argument_missing"))
             @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
           else
-            ShopifyCli::Tunnel.auth(@ctx, token)
+            ShopifyCLI::Tunnel.auth(@ctx, token)
           end
         when "start"
-          ShopifyCli::Tunnel.start(@ctx)
+          ShopifyCLI::Tunnel.start(@ctx)
         when "stop"
-          ShopifyCli::Tunnel.stop(@ctx)
+          ShopifyCLI::Tunnel.stop(@ctx)
         else
           @ctx.puts(self.class.help)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("rails.tunnel.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.tunnel.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("rails.tunnel.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("rails.tunnel.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/rails/forms/create.rb
+++ b/lib/project_types/rails/forms/create.rb
@@ -2,7 +2,7 @@ require "uri"
 
 module Rails
   module Forms
-    class Create < ShopifyCli::Form
+    class Create < ShopifyCLI::Form
       attr_accessor :name
       flag_arguments :title, :organization_id, :shop_domain, :type, :db
       VALID_DB_TYPES = ["sqlite3",
@@ -22,7 +22,7 @@ module Rails
         self.title ||= CLI::UI::Prompt.ask(ctx.message("rails.forms.create.app_name"))
         self.name = format_name
         self.type = ask_type
-        res = ShopifyCli::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
+        res = ShopifyCLI::Tasks::SelectOrgAndShop.call(ctx, organization_id: organization_id, shop_domain: shop_domain)
         self.organization_id = res[:organization_id]
         self.shop_domain = res[:shop_domain]
         self.db = ask_db
@@ -48,7 +48,7 @@ module Rails
           end
         end
 
-        unless ShopifyCli::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
+        unless ShopifyCLI::Tasks::CreateApiClient::VALID_APP_TYPES.include?(type)
           ctx.abort(ctx.message("rails.forms.create.error.invalid_app_type", type))
         end
         ctx.puts(ctx.message("rails.forms.create.app_type.selected", type))

--- a/lib/project_types/rails/gem.rb
+++ b/lib/project_types/rails/gem.rb
@@ -5,7 +5,7 @@ module Rails
   class Gem
     include SmartProperties
 
-    property :ctx, accepts: ShopifyCli::Context, required: true
+    property :ctx, accepts: ShopifyCLI::Context, required: true
     property :name, converts: :to_s, required: true
     property :version, converts: :to_s
 

--- a/lib/project_types/rails/ruby.rb
+++ b/lib/project_types/rails/ruby.rb
@@ -4,7 +4,7 @@ module Rails
 
     VERSION_STRING = /ruby ([\d\.]+)/
 
-    property :ctx, accepts: ShopifyCli::Context, required: true
+    property :ctx, accepts: ShopifyCLI::Context, required: true
 
     class << self
       def version(ctx)

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Script
-  class Project < ShopifyCli::ProjectType
+  class Project < ShopifyCLI::ProjectType
     hidden_feature(feature_set: :script_project)
 
     require Project.project_filepath("messages/messages")
@@ -9,12 +9,12 @@ module Script
   end
 
   # define/autoload project specific Commands
-  class Command < ShopifyCli::ProjectCommands
+  class Command < ShopifyCLI::ProjectCommands
     hidden_feature(feature_set: :script_project)
     subcommand :Create, "create", Project.project_filepath("commands/create")
     subcommand :Push, "push", Project.project_filepath("commands/push")
   end
-  ShopifyCli::Commands.register("Script::Command", "script")
+  ShopifyCLI::Commands.register("Script::Command", "script")
 
   # define/autoload project specific Forms
   module Forms

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -2,7 +2,7 @@
 
 module Script
   class Command
-    class Create < ShopifyCli::SubCommand
+    class Create < ShopifyCLI::SubCommand
       prerequisite_task :ensure_authenticated
 
       options do |parser, flags|
@@ -35,7 +35,7 @@ module Script
 
       def self.help
         allowed_values = Script::Layers::Application::ExtensionPoints.available_types.map { |type| "{{cyan:#{type}}}" }
-        ShopifyCli::Context.message("script.create.help", ShopifyCli::TOOL_NAME, allowed_values.join(", "))
+        ShopifyCLI::Context.message("script.create.help", ShopifyCLI::TOOL_NAME, allowed_values.join(", "))
       end
     end
   end

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -2,7 +2,7 @@
 
 module Script
   class Command
-    class Push < ShopifyCli::SubCommand
+    class Push < ShopifyCLI::SubCommand
       prerequisite_task ensure_project_type: :script
 
       options do |parser, flags|
@@ -28,7 +28,7 @@ module Script
       end
 
       def self.help
-        ShopifyCli::Context.message("script.push.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("script.push.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/script/forms/create.rb
+++ b/lib/project_types/script/forms/create.rb
@@ -2,7 +2,7 @@
 
 module Script
   module Forms
-    class Create < ShopifyCli::Form
+    class Create < ShopifyCLI::Form
       flag_arguments :extension_point, :name, :language
 
       def ask

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -15,7 +15,7 @@ module Script
         def self.available_types
           Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
             next false if ep.deprecated?
-            !ep.beta? || ShopifyCli::Feature.enabled?(:scripts_beta_extension_points)
+            !ep.beta? || ShopifyCLI::Feature.enabled?(:scripts_beta_extension_points)
           end.map(&:type)
         end
 
@@ -28,7 +28,7 @@ module Script
 
         def self.languages(type:)
           get(type: type).sdks.all.map do |sdk|
-            next nil if sdk.beta? && !ShopifyCli::Feature.enabled?(:scripts_beta_languages)
+            next nil if sdk.beta? && !ShopifyCLI::Feature.enabled?(:scripts_beta_languages)
             sdk.class.language
           end.compact
         end

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -9,7 +9,7 @@ module Script
         UUID_ENV_KEY = "UUID"
 
         property! :id, accepts: String
-        property :env, accepts: ShopifyCli::Resources::EnvFile
+        property :env, accepts: ShopifyCLI::Resources::EnvFile
 
         property! :extension_point_type, accepts: String
         property! :script_name, accepts: String
@@ -20,7 +20,7 @@ module Script
         def initialize(*)
           super
 
-          ShopifyCli::Core::Monorail.metadata = {
+          ShopifyCLI::Core::Monorail.metadata = {
             "script_name" => script_name,
             "extension_point_type" => extension_point_type,
             "language" => language,

--- a/lib/project_types/script/layers/infrastructure/api_clients.rb
+++ b/lib/project_types/script/layers/infrastructure/api_clients.rb
@@ -15,7 +15,7 @@ module Script
 
           def initialize(ctx, api_key)
             instance_url = script_service_url
-            @api = ShopifyCli::API.new(
+            @api = ShopifyCLI::API.new(
               ctx: ctx,
               url: "#{instance_url}/graphql",
               token: { "APP_KEY" => api_key }.compact.to_json,
@@ -30,8 +30,8 @@ module Script
           private
 
           def script_service_url
-            if ::ShopifyCli::Environment.use_spin_partners_instance?
-              "https://script-service.#{::ShopifyCli::Environment.spin_url}"
+            if ::ShopifyCLI::Environment.use_spin_partners_instance?
+              "https://script-service.#{::ShopifyCLI::Environment.spin_url}"
             else
               LOCAL_INSTANCE_URL
             end
@@ -74,7 +74,7 @@ module Script
             end
           end
 
-          class ShimAPI < ShopifyCli::PartnersAPI
+          class ShimAPI < ShopifyCLI::PartnersAPI
             def query(query_name, variables: {})
               variables[:query] = load_query(query_name)
               super("script_service_proxy", variables: variables)

--- a/lib/project_types/script/layers/infrastructure/command_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/command_runner.rb
@@ -6,7 +6,7 @@ module Script
       class CommandRunner
         include SmartProperties
 
-        property! :ctx, accepts: ShopifyCli::Context
+        property! :ctx, accepts: ShopifyCLI::Context
 
         def call(cmd)
           out, status = ctx.capture2e(cmd)

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -6,7 +6,7 @@ module Script
       module Languages
         class AssemblyScriptProjectCreator
           include SmartProperties
-          property! :ctx, accepts: ShopifyCli::Context
+          property! :ctx, accepts: ShopifyCLI::Context
           property! :extension_point, accepts: Domain::ExtensionPoint
           property! :script_name, accepts: String
           property! :path_to_project, accepts: String

--- a/lib/project_types/script/layers/infrastructure/languages/rust_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/rust_project_creator.rb
@@ -6,7 +6,7 @@ module Script
       module Languages
         class RustProjectCreator
           include SmartProperties
-          property! :ctx, accepts: ShopifyCli::Context
+          property! :ctx, accepts: ShopifyCLI::Context
           property! :extension_point, accepts: Domain::ExtensionPoint
           property! :script_name, accepts: String
           property! :path_to_project, accepts: String

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -5,7 +5,7 @@ module Script
     module Infrastructure
       class PushPackageRepository
         include SmartProperties
-        property! :ctx, accepts: ShopifyCli::Context
+        property! :ctx, accepts: ShopifyCLI::Context
 
         def create_push_package(script_project:, script_content:, compiled_type:, metadata:)
           build_file_path = file_path(script_project.id, compiled_type)

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -5,7 +5,7 @@ module Script
     module Infrastructure
       class ScriptProjectRepository
         include SmartProperties
-        property! :ctx, accepts: ShopifyCli::Context
+        property! :ctx, accepts: ShopifyCLI::Context
 
         SCRIPT_JSON_FILENAME = "script.json"
         MUTABLE_ENV_VALUES = %i(uuid)
@@ -13,7 +13,7 @@ module Script
         def create(script_name:, extension_point_type:, language:)
           validate_metadata!(extension_point_type, language)
 
-          ShopifyCli::Project.write(
+          ShopifyCLI::Project.write(
             ctx,
             project_type: :script,
             organization_id: nil,
@@ -63,7 +63,7 @@ module Script
         end
 
         def create_env(api_key:, secret:, uuid:)
-          ShopifyCli::Resources::EnvFile.new(
+          ShopifyCLI::Resources::EnvFile.new(
             api_key: api_key,
             secret: secret,
             extra: {
@@ -125,7 +125,7 @@ module Script
         end
 
         def project
-          @project ||= ShopifyCli::Project.current(force_reload: true)
+          @project ||= ShopifyCLI::Project.current(force_reload: true)
         end
 
         def default_language
@@ -142,7 +142,7 @@ module Script
 
         class ScriptJsonRepository
           include SmartProperties
-          property! :ctx, accepts: ShopifyCli::Context
+          property! :ctx, accepts: ShopifyCLI::Context
 
           def get
             current_script_json || raise(Domain::Errors::NoScriptJsonFile)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -8,7 +8,7 @@ module Script
     module Infrastructure
       class ScriptService
         include SmartProperties
-        property! :ctx, accepts: ShopifyCli::Context
+        property! :ctx, accepts: ShopifyCLI::Context
         property! :api_key, accepts: String
 
         def initialize(*args, ctx:, api_key:, **kwargs)

--- a/lib/project_types/script/tasks/ensure_env.rb
+++ b/lib/project_types/script/tasks/ensure_env.rb
@@ -2,7 +2,7 @@ require "shopify_cli"
 
 module Script
   module Tasks
-    class EnsureEnv < ShopifyCli::Task
+    class EnsureEnv < ShopifyCLI::Task
       attr_accessor :ctx
 
       def call(ctx)
@@ -31,11 +31,11 @@ module Script
       def ask_org
         return stubbed_org if partner_proxy_bypass
 
-        if ShopifyCli::Shopifolk.check && wants_to_run_against_shopify_org?
-          ShopifyCli::Shopifolk.act_as_shopify_organization
+        if ShopifyCLI::Shopifolk.check && wants_to_run_against_shopify_org?
+          ShopifyCLI::Shopifolk.act_as_shopify_organization
         end
 
-        orgs = ShopifyCli::PartnersAPI::Organizations.fetch_with_app(ctx)
+        orgs = ShopifyCLI::PartnersAPI::Organizations.fetch_with_app(ctx)
         if orgs.count == 1
           default = orgs.first
           ctx.puts(ctx.message("script.application.ensure_env.organization", default["businessName"], default["id"]))
@@ -69,7 +69,7 @@ module Script
       end
 
       def ask_app(apps)
-        unless ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        unless ShopifyCLI::Shopifolk.acting_as_shopify_organization?
           apps = apps.select { |app| app["appType"] == "custom" }
         end
 

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -4,7 +4,7 @@ module Script
   module UI
     module ErrorHandler
       def self.display(failed_op:, cause_of_error:, help_suggestion:)
-        $stderr.puts(CLI::UI.fmt(ShopifyCli::Context.message("script.error.generic")))
+        $stderr.puts(CLI::UI.fmt(ShopifyCLI::Context.message("script.error.generic")))
         full_msg = failed_op ? failed_op.dup : ""
         full_msg << " #{cause_of_error}" if cause_of_error
         full_msg << " #{help_suggestion}" if help_suggestion
@@ -13,7 +13,7 @@ module Script
 
       def self.display_and_raise(failed_op: nil, cause_of_error: nil, help_suggestion: nil)
         display(failed_op: failed_op, cause_of_error: cause_of_error, help_suggestion: help_suggestion)
-        raise(ShopifyCli::AbortSilent)
+        raise(ShopifyCLI::AbortSilent)
       end
 
       def self.pretty_print_and_raise(e, failed_op: nil)
@@ -26,85 +26,85 @@ module Script
         case e
         when Errno::EACCES
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.eacces_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.eacces_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.eacces_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.eacces_help"),
           }
         when Errno::ENOSPC
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.enospc_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.enospc_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.enospc_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.enospc_help"),
           }
-        when ShopifyCli::IdentityAuth::Error
+        when ShopifyCLI::IdentityAuth::Error
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.oauth_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.oauth_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.oauth_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.oauth_help"),
           }
         when Layers::Infrastructure::Errors::InvalidContextError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_context_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.invalid_context_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_context_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_context_help"),
           }
         when Errors::InvalidConfigProps
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_config_props_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.invalid_config_props_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_config_props_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_config_props_help"),
           }
         when Errors::InvalidConfigYAMLError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_config", e.config_file),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_config", e.config_file),
           }
         when Layers::Infrastructure::Errors::InvalidLanguageError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_language_cause", e.language),
-            help_suggestion: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_language_cause", e.language),
+            help_suggestion: ShopifyCLI::Context.message(
               "script.error.invalid_language_help",
               Script::Layers::Application::ExtensionPoints.languages(type: e.extension_point_type).join(", ")
             ),
           }
         when Errors::InvalidScriptNameError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_script_name_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.invalid_script_name_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_script_name_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_script_name_help"),
           }
         when Errors::NoExistingAppsError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_apps_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.no_existing_apps_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.no_existing_apps_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.no_existing_apps_help"),
           }
         when Errors::NoExistingOrganizationsError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_orgs_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.no_existing_orgs_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.no_existing_orgs_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.no_existing_orgs_help"),
           }
         when Errors::NoExistingStoresError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.no_existing_stores_cause"),
-            help_suggestion: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message("script.error.no_existing_stores_cause"),
+            help_suggestion: ShopifyCLI::Context.message(
               "script.error.no_existing_stores_help",
               organization_id: e.organization_id
             ),
           }
         when Layers::Infrastructure::Errors::ScriptProjectAlreadyExistsError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.project_exists_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.project_exists_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.project_exists_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.project_exists_help"),
           }
         when Layers::Infrastructure::Errors::DeprecatedEPError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.deprecated_ep", e.ep),
-            help_suggestion: ShopifyCli::Context.message("script.error.deprecated_ep_cause"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.deprecated_ep", e.ep),
+            help_suggestion: ShopifyCLI::Context.message("script.error.deprecated_ep_cause"),
           }
         when Layers::Domain::Errors::InvalidExtensionPointError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_extension_cause", e.type),
-            help_suggestion: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_extension_cause", e.type),
+            help_suggestion: ShopifyCLI::Context.message(
               "script.error.invalid_extension_help",
               Script::Layers::Application::ExtensionPoints.available_types.join(", ")
             ),
           }
         when Layers::Domain::Errors::ScriptNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.script_not_found_cause",
               e.script_name,
               e.extension_point_type
@@ -112,135 +112,135 @@ module Script
           }
         when Layers::Domain::Errors::MetadataValidationError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.metadata_validation_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.metadata_validation_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_validation_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.metadata_validation_help"),
           }
         when Layers::Domain::Errors::MetadataNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.metadata_not_found_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.metadata_not_found_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.metadata_not_found_help"),
           }
         when Layers::Domain::Errors::MissingScriptJsonFieldError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.missing_script_json_field_cause", e.field),
-            help_suggestion: ShopifyCli::Context.message("script.error.missing_script_json_field_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.missing_script_json_field_cause", e.field),
+            help_suggestion: ShopifyCLI::Context.message("script.error.missing_script_json_field_help"),
           }
         when Layers::Domain::Errors::InvalidScriptJsonDefinitionError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_script_json_definition_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.invalid_script_json_definition_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_help"),
           }
         when Layers::Domain::Errors::NoScriptJsonFile
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.no_script_json_file_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.no_script_json_file_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.no_script_json_file_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.no_script_json_file_help"),
           }
         when Layers::Infrastructure::Errors::AppNotInstalledError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.app_not_installed_cause"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.app_not_installed_cause"),
           }
         when Layers::Infrastructure::Errors::BuildError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.build_error_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.build_error_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.build_error_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.build_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptJsonSyntaxError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.configuration_syntax_error_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.configuration_syntax_error_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.configuration_syntax_error_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.configuration_syntax_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptJsonMissingKeysError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_missing_keys_error_cause",
               missing_keys: e.missing_keys
             ),
-            help_suggestion: ShopifyCli::Context.message("script.error.configuration_missing_keys_error_help"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.configuration_missing_keys_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptJsonInvalidValueError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_invalid_value_error_cause",
               valid_input_modes: e.valid_input_modes
             ),
-            help_suggestion: ShopifyCli::Context.message("script.error.configuration_invalid_value_error_help"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.configuration_invalid_value_error_help"),
           }
         when Layers::Infrastructure::Errors::ScriptJsonFieldsMissingKeysError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_schema_field_missing_keys_error_cause",
               missing_keys: e.missing_keys
             ),
-            help_suggestion: ShopifyCli::Context.message(
+            help_suggestion: ShopifyCLI::Context.message(
               "script.error.configuration_definition_schema_field_missing_keys_error_help"
             ),
           }
         when Layers::Infrastructure::Errors::ScriptJsonFieldsInvalidValueError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_schema_field_invalid_value_error_cause",
               valid_types: e.valid_types
             ),
-            help_suggestion: ShopifyCli::Context.message(
+            help_suggestion: ShopifyCLI::Context.message(
               "script.error.configuration_schema_field_invalid_value_error_help"
             ),
           }
         when Layers::Infrastructure::Errors::DependencyInstallError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.dependency_install_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.dependency_install_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.dependency_install_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.dependency_install_help"),
           }
         when Layers::Infrastructure::Errors::EmptyResponseError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.failed_api_request_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.failed_api_request_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.failed_api_request_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.failed_api_request_help"),
           }
         when Layers::Infrastructure::Errors::ForbiddenError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.forbidden_error_cause"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.forbidden_error_cause"),
           }
         when Layers::Infrastructure::Errors::GraphqlError
           {
-            cause_of_error: ShopifyCli::Context.message(
+            cause_of_error: ShopifyCLI::Context.message(
               "script.error.graphql_error_cause", JSON.pretty_generate(e.errors)
             ),
-            help_suggestion: ShopifyCli::Context.message("script.error.graphql_error_help"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.graphql_error_help"),
           }
         when Layers::Infrastructure::Errors::SystemCallFailureError
           {
-            cause_of_error: ShopifyCli::Context
+            cause_of_error: ShopifyCLI::Context
               .message("script.error.system_call_failure_cause", cmd: e.cmd),
-            help_suggestion: ShopifyCli::Context.message("script.error.system_call_failure_help", out: e.out),
+            help_suggestion: ShopifyCLI::Context.message("script.error.system_call_failure_help", out: e.out),
           }
         when Layers::Infrastructure::Errors::ScriptRepushError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.script_repush_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.script_repush_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.script_repush_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.script_repush_help"),
           }
         when Layers::Infrastructure::Errors::ShopAuthenticationError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.shop_auth_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.shop_auth_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.shop_auth_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.shop_auth_help"),
           }
         when Layers::Infrastructure::Errors::BuildScriptNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.build_script_not_found"),
-            help_suggestion: ShopifyCli::Context.message("script.error.build_script_suggestion"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.build_script_not_found"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.build_script_suggestion"),
           }
         when Layers::Infrastructure::Errors::InvalidBuildScriptError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.invalid_build_script"),
-            help_suggestion: ShopifyCli::Context.message("script.error.build_script_suggestion"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_build_script"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.build_script_suggestion"),
           }
         when Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.web_assembly_binary_not_found"),
-            help_suggestion: ShopifyCli::Context.message("script.error.web_assembly_binary_not_found_suggestion"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.web_assembly_binary_not_found"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.web_assembly_binary_not_found_suggestion"),
           }
         when Layers::Infrastructure::Errors::ScriptUploadError
           {
-            cause_of_error: ShopifyCli::Context.message("script.error.script_upload_cause"),
-            help_suggestion: ShopifyCli::Context.message("script.error.script_upload_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.script_upload_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.script_upload_help"),
           }
         end
       end

--- a/lib/project_types/script/ui/printing_spinner.rb
+++ b/lib/project_types/script/ui/printing_spinner.rb
@@ -35,7 +35,7 @@ module Script
       # Printing within spinners requires the manipulation of ANSI escape
       # sequences in order to make sure the CLI::UI::Spinner does not overwrite
       # previously printed content.
-      class PrintingSpinnerContext < ShopifyCli::Context
+      class PrintingSpinnerContext < ShopifyCLI::Context
         include SmartProperties
         property :spinner, required: true
 

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module Theme
-  class Project < ShopifyCli::ProjectType
+  class Project < ShopifyCLI::ProjectType
     require Project.project_filepath("messages/messages")
     register_messages(Theme::Messages::MESSAGES)
   end
 
-  class Command < ShopifyCli::ProjectCommands
+  class Command < ShopifyCLI::ProjectCommands
     subcommand :Init, "init", Project.project_filepath("commands/init")
     subcommand :Serve, "serve", Project.project_filepath("commands/serve")
     subcommand :Pull, "pull", Project.project_filepath("commands/pull")
@@ -16,7 +16,7 @@ module Theme
     subcommand :Package, "package", Project.project_filepath("commands/package")
     subcommand :LanguageServer, "language-server", Project.project_filepath("commands/language_server")
   end
-  ShopifyCli::Commands.register("Theme::Command", "theme")
+  ShopifyCLI::Commands.register("Theme::Command", "theme")
 
   module Forms
     autoload :ConfirmStore, Project.project_filepath("forms/confirm_store")

--- a/lib/project_types/theme/commands/check.rb
+++ b/lib/project_types/theme/commands/check.rb
@@ -3,8 +3,8 @@ require "theme_check"
 
 module Theme
   class Command
-    class Check < ShopifyCli::SubCommand
-      class Options < ShopifyCli::Options
+    class Check < ShopifyCLI::SubCommand
+      class Options < ShopifyCLI::Options
         def initialize(theme_check)
           super()
           @theme_check = theme_check
@@ -26,7 +26,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.check.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.check.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/delete.rb
+++ b/lib/project_types/theme/commands/delete.rb
@@ -4,7 +4,7 @@ require "shopify_cli/theme/development_theme"
 
 module Theme
   class Command
-    class Delete < ShopifyCli::SubCommand
+    class Delete < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-a", "--show-all") { flags[:show_all] = true }
@@ -13,9 +13,9 @@ module Theme
 
       def call(args, _name)
         themes = if options.flags[:development]
-          [ShopifyCli::Theme::DevelopmentTheme.new(@ctx)]
+          [ShopifyCLI::Theme::DevelopmentTheme.new(@ctx)]
         elsif args.any?
-          args.map { |id| ShopifyCli::Theme::Theme.new(@ctx, id: id) }
+          args.map { |id| ShopifyCLI::Theme::Theme.new(@ctx, id: id) }
         else
           form = Forms::Select.ask(
             @ctx,
@@ -38,7 +38,7 @@ module Theme
           end
           theme.delete
           deleted += 1
-        rescue ShopifyCli::API::APIRequestNotFoundError
+        rescue ShopifyCLI::API::APIRequestNotFoundError
           @ctx.puts(@ctx.message("theme.delete.not_found", theme.id))
         end
 
@@ -46,7 +46,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.delete.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.delete.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/theme/commands/init.rb
+++ b/lib/project_types/theme/commands/init.rb
@@ -2,7 +2,7 @@
 
 module Theme
   class Command
-    class Init < ShopifyCli::SubCommand
+    class Init < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("-u", "--clone-url URL") { |url| flags[:clone_url] = url }
       end
@@ -16,7 +16,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.init.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.init.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -26,7 +26,7 @@ module Theme
       end
 
       def clone(url, name)
-        ShopifyCli::Git.clone(url, name)
+        ShopifyCLI::Git.clone(url, name)
 
         @ctx.root = File.join(@ctx.root, name)
 

--- a/lib/project_types/theme/commands/language_server.rb
+++ b/lib/project_types/theme/commands/language_server.rb
@@ -3,13 +3,13 @@ require "theme_check"
 
 module Theme
   class Command
-    class LanguageServer < ShopifyCli::SubCommand
+    class LanguageServer < ShopifyCLI::SubCommand
       def call(*)
         ThemeCheck::LanguageServer.start
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.language_server.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.language_server.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/package.rb
+++ b/lib/project_types/theme/commands/package.rb
@@ -4,7 +4,7 @@ require "json"
 
 module Theme
   class Command
-    class Package < ShopifyCli::SubCommand
+    class Package < ShopifyCLI::SubCommand
       THEME_DIRECTORIES = %w[
         assets
         config
@@ -25,7 +25,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.package.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.package.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       private

--- a/lib/project_types/theme/commands/publish.rb
+++ b/lib/project_types/theme/commands/publish.rb
@@ -3,14 +3,14 @@ require "shopify_cli/theme/theme"
 
 module Theme
   class Command
-    class Publish < ShopifyCli::SubCommand
+    class Publish < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("-f", "--force") { flags[:force] = true }
       end
 
       def call(args, *)
         theme = if (theme_id = args.first)
-          ShopifyCli::Theme::Theme.new(@ctx, id: theme_id)
+          ShopifyCLI::Theme::Theme.new(@ctx, id: theme_id)
         else
           form = Forms::Select.ask(
             @ctx,
@@ -31,12 +31,12 @@ module Theme
 
         theme.publish
         @ctx.done(@ctx.message("theme.publish.done", theme.preview_url))
-      rescue ShopifyCli::API::APIRequestNotFoundError
+      rescue ShopifyCLI::API::APIRequestNotFoundError
         @ctx.puts(@ctx.message("theme.publish.not_found", theme.id))
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.publish.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.publish.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -5,7 +5,7 @@ require "shopify_cli/theme/syncer"
 
 module Theme
   class Command
-    class Pull < ShopifyCli::SubCommand
+    class Pull < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
@@ -20,7 +20,7 @@ module Theme
         delete = !options.flags[:nodelete]
 
         theme = if (theme_id = options.flags[:theme_id])
-          ShopifyCli::Theme::Theme.new(@ctx, root: root, id: theme_id)
+          ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         else
           form = Forms::Select.ask(
             @ctx,
@@ -32,17 +32,17 @@ module Theme
           form.theme
         end
 
-        ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(root)
+        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root)
         ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
 
-        syncer = ShopifyCli::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
+        syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
         begin
           syncer.start_threads
           CLI::UI::Frame.open(@ctx.message("theme.pull.pulling", theme.name, theme.id, theme.shop)) do
             UI::SyncProgressBar.new(syncer).progress(:download_theme!, delete: delete)
           end
           @ctx.done(@ctx.message("theme.pull.done"))
-        rescue ShopifyCli::API::APIRequestNotFoundError
+        rescue ShopifyCLI::API::APIRequestNotFoundError
           @ctx.abort(@ctx.message("theme.pull.theme_not_found", theme.id))
         ensure
           syncer.shutdown
@@ -50,7 +50,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.pull.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.pull.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -6,7 +6,7 @@ require "shopify_cli/theme/syncer"
 
 module Theme
   class Command
-    class Push < ShopifyCli::SubCommand
+    class Push < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
@@ -26,14 +26,14 @@ module Theme
         delete = !options.flags[:nodelete]
 
         theme = if (theme_id = options.flags[:theme_id])
-          ShopifyCli::Theme::Theme.new(@ctx, root: root, id: theme_id)
+          ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         elsif options.flags[:development]
-          theme = ShopifyCli::Theme::DevelopmentTheme.new(@ctx, root: root)
+          theme = ShopifyCLI::Theme::DevelopmentTheme.new(@ctx, root: root)
           theme.ensure_exists!
           theme
         elsif options.flags[:unpublished]
           name = CLI::UI::Prompt.ask(@ctx.message("theme.push.name"), allow_empty: false)
-          theme = ShopifyCli::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
+          theme = ShopifyCLI::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
           theme.create
           theme
         else
@@ -51,10 +51,10 @@ module Theme
           return unless CLI::UI::Prompt.confirm(@ctx.message("theme.push.live"))
         end
 
-        ignore_filter = ShopifyCli::Theme::IgnoreFilter.from_path(root)
+        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root)
         ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
 
-        syncer = ShopifyCli::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
+        syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme, ignore_filter: ignore_filter)
         begin
           syncer.start_threads
           if options.flags[:json]
@@ -72,7 +72,7 @@ module Theme
               @ctx.done(@ctx.message("theme.push.done", theme.preview_url, theme.editor_url))
             end
           end
-        rescue ShopifyCli::API::APIRequestNotFoundError
+        rescue ShopifyCLI::API::APIRequestNotFoundError
           @ctx.abort(@ctx.message("theme.push.theme_not_found", theme.id))
         ensure
           syncer.shutdown
@@ -80,7 +80,7 @@ module Theme
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.push.help", ShopifyCli::TOOL_NAME, ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.push.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -3,20 +3,20 @@ require "shopify_cli/theme/dev_server"
 
 module Theme
   class Command
-    class Serve < ShopifyCli::SubCommand
+    class Serve < ShopifyCLI::SubCommand
       options do |parser, flags|
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
       end
 
       def call(*)
         flags = options.flags.dup
-        ShopifyCli::Theme::DevServer.start(@ctx, ".", **flags) do |syncer|
+        ShopifyCLI::Theme::DevServer.start(@ctx, ".", **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("theme.serve.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.serve.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/project_types/theme/forms/confirm_store.rb
+++ b/lib/project_types/theme/forms/confirm_store.rb
@@ -1,6 +1,6 @@
 module Theme
   module Forms
-    class ConfirmStore < ShopifyCli::Form
+    class ConfirmStore < ShopifyCLI::Form
       flag_arguments :title, :force
 
       def ask

--- a/lib/project_types/theme/forms/select.rb
+++ b/lib/project_types/theme/forms/select.rb
@@ -1,6 +1,6 @@
 module Theme
   module Forms
-    class Select < ShopifyCli::Form
+    class Select < ShopifyCLI::Form
       attr_accessor :theme
       flag_arguments :root, :title, :exclude_roles, :include_foreign_developments
 
@@ -17,7 +17,7 @@ module Theme
       private
 
       def themes
-        @themes ||= ShopifyCli::Theme::Theme.all(@ctx, root: root)
+        @themes ||= ShopifyCLI::Theme::Theme.all(@ctx, root: root)
           .sort_by { |theme| theme_sort_order(theme) }
       end
 

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -36,7 +36,7 @@ CLI::UI::StdoutRouter.enable
 #
 # It is recommended to read through CLI Kit (https://github.com/shopify/cli-kit) and a CLI Kit example
 # (https://github.com/Shopify/cli-kit-example) to fully understand how shopify-cli functions
-module ShopifyCli
+module ShopifyCLI
   extend CLI::Kit::Autocall
 
   TOOL_NAME         = "shopify"
@@ -75,21 +75,21 @@ module ShopifyCli
   # application and CLI kit framework.
   # To understand how this works, read https://github.com/Shopify/cli-kit/blob/main/lib/cli/kit.rb
 
-  # ShopifyCli::Config
+  # ShopifyCLI::Config
   autocall(:Config)   { CLI::Kit::Config.new(tool_name: TOOL_NAME) }
-  # ShopifyCli::Logger
-  autocall(:Logger)   { CLI::Kit::Logger.new(debug_log_file: ShopifyCli.debug_log_file) }
-  # ShopifyCli::Resolver
+  # ShopifyCLI::Logger
+  autocall(:Logger)   { CLI::Kit::Logger.new(debug_log_file: ShopifyCLI.debug_log_file) }
+  # ShopifyCLI::Resolver
   autocall(:Resolver) do
-    ShopifyCli::Core::HelpResolver.new(
+    ShopifyCLI::Core::HelpResolver.new(
       tool_name: TOOL_NAME,
-      command_registry: ShopifyCli::Commands::Registry
+      command_registry: ShopifyCLI::Commands::Registry
     )
   end
-  # ShopifyCli::ErrorHandler
+  # ShopifyCLI::ErrorHandler
   autocall(:ErrorHandler) do
     CLI::Kit::ErrorHandler.new(
-      log_file: ShopifyCli.log_file,
+      log_file: ShopifyCLI.log_file,
       exception_reporter: nil,
     )
   end
@@ -131,7 +131,7 @@ module ShopifyCli
   autoload :Tunnel, "shopify_cli/tunnel"
 
   require "shopify_cli/messages/messages"
-  Context.load_messages(ShopifyCli::Messages::MESSAGES)
+  Context.load_messages(ShopifyCLI::Messages::MESSAGES)
 
   def self.cache_dir
     cache_dir = if Environment.running_tests?
@@ -168,6 +168,6 @@ module ShopifyCli
 
   def self.sha
     return @sha if defined?(@sha)
-    @sha = Git.sha(dir: ShopifyCli::ROOT)
+    @sha = Git.sha(dir: ShopifyCLI::ROOT)
   end
 end

--- a/lib/shopify_cli/admin_api.rb
+++ b/lib/shopify_cli/admin_api.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::AdminAPI wraps our graphql functionality with authentication so that
+  # ShopifyCLI::AdminAPI wraps our graphql functionality with authentication so that
   # these concerns are taken care of.
   #
   class AdminAPI < API
@@ -24,10 +24,10 @@ module ShopifyCli
       #
       # #### Raises
       #
-      # * http 404 will raise a ShopifyCli::API::APIRequestNotFoundError
-      # * http 400..499 will raise a ShopifyCli::API::APIRequestClientError
-      # * http 500..599 will raise a ShopifyCli::API::APIRequestServerError
-      # * All other codes will raise ShopifyCli::API::APIRequestUnexpectedError
+      # * http 404 will raise a ShopifyCLI::API::APIRequestNotFoundError
+      # * http 400..499 will raise a ShopifyCLI::API::APIRequestClientError
+      # * http 500..599 will raise a ShopifyCLI::API::APIRequestServerError
+      # * All other codes will raise ShopifyCLI::API::APIRequestUnexpectedError
       #
       # #### Returns
       #
@@ -35,18 +35,18 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::AdminAPI.query(@ctx, 'all_organizations')
+      #   ShopifyCLI::AdminAPI.query(@ctx, 'all_organizations')
       #
       def query(ctx, query_name, shop:, api_version: nil, **variables)
         CLI::Kit::Util.begin do
           api_client(ctx, api_version, shop).query(query_name, variables: variables)
         end.retry_after(API::APIRequestUnauthorizedError, retries: 1) do
-          ShopifyCli::IdentityAuth.new(ctx: ctx).reauthenticate
+          ShopifyCLI::IdentityAuth.new(ctx: ctx).reauthenticate
         end
       rescue API::APIRequestUnauthorizedError
         ctx.abort(ctx.message("core.api.error.failed_auth"))
       rescue API::APIRequestForbiddenError
-        ctx.abort(ctx.message("core.api.error.forbidden", ShopifyCli::TOOL_NAME))
+        ctx.abort(ctx.message("core.api.error.forbidden", ShopifyCLI::TOOL_NAME))
       end
 
       ##
@@ -65,10 +65,10 @@ module ShopifyCli
       #
       # #### Raises
       #
-      # * http 404 will raise a ShopifyCli::API::APIRequestNotFoundError
-      # * http 400..499 will raise a ShopifyCli::API::APIRequestClientError
-      # * http 500..599 will raise a ShopifyCli::API::APIRequestServerError
-      # * All other codes will raise ShopifyCli::API::APIRequestUnexpectedError
+      # * http 404 will raise a ShopifyCLI::API::APIRequestNotFoundError
+      # * http 400..499 will raise a ShopifyCLI::API::APIRequestClientError
+      # * http 500..599 will raise a ShopifyCLI::API::APIRequestServerError
+      # * All other codes will raise ShopifyCLI::API::APIRequestUnexpectedError
       #
       # #### Returns
       #
@@ -76,38 +76,38 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::AdminAPI.rest_request(@ctx,
+      #   ShopifyCLI::AdminAPI.rest_request(@ctx,
       #                                     shop: 'shop.myshopify.com',
       #                                     path: 'data.json',
       #                                     token: 'password')
       #
       def rest_request(ctx, shop:, path:, query: nil, body: nil, method: "GET", api_version: nil, token: nil)
         CLI::Kit::Util.begin do
-          ShopifyCli::DB.set(shopify_exchange_token: token) unless token.nil?
+          ShopifyCLI::DB.set(shopify_exchange_token: token) unless token.nil?
           url = URI::HTTPS.build(
             host: shop,
             path: "/admin/api/#{fetch_api_version(ctx, api_version, shop)}/#{path}",
             query: query,
           )
           resp = api_client(ctx, api_version, shop, path: path).request(url: url.to_s, body: body, method: method)
-          ShopifyCli::DB.set(shopify_exchange_token: nil) unless token.nil?
+          ShopifyCLI::DB.set(shopify_exchange_token: nil) unless token.nil?
           resp
         end.retry_after(API::APIRequestUnauthorizedError) do
-          ShopifyCli::IdentityAuth.new(ctx: ctx).reauthenticate
+          ShopifyCLI::IdentityAuth.new(ctx: ctx).reauthenticate
         end
       end
 
       def get_shop_or_abort(ctx)
         ctx.abort(
-          ctx.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME)
-        ) unless ShopifyCli::DB.exists?(:shop)
-        ShopifyCli::DB.get(:shop)
+          ctx.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME)
+        ) unless ShopifyCLI::DB.exists?(:shop)
+        ShopifyCLI::DB.get(:shop)
       end
 
       private
 
       def authenticate(ctx, _shop)
-        ShopifyCli::IdentityAuth.new(ctx: ctx).authenticate
+        ShopifyCLI::IdentityAuth.new(ctx: ctx).authenticate
       end
 
       def api_client(ctx, api_version, shop, path: "graphql.json")
@@ -119,9 +119,9 @@ module ShopifyCli
       end
 
       def access_token(ctx, shop)
-        ShopifyCli::DB.get(:shopify_exchange_token) do
+        ShopifyCLI::DB.get(:shopify_exchange_token) do
           authenticate(ctx, shop)
-          ShopifyCli::DB.get(:shopify_exchange_token)
+          ShopifyCLI::DB.get(:shopify_exchange_token)
         end
       end
 
@@ -141,12 +141,12 @@ module ShopifyCli
             .sort
             .reverse[0]
         end.retry_after(API::APIRequestUnauthorizedError, retries: 1) do
-          ShopifyCli::IdentityAuth.new(ctx: ctx).reauthenticate
+          ShopifyCLI::IdentityAuth.new(ctx: ctx).reauthenticate
         end
       rescue API::APIRequestUnauthorizedError
         ctx.abort(ctx.message("core.api.error.failed_auth"))
       rescue API::APIRequestForbiddenError
-        ctx.abort(ctx.message("core.api.error.forbidden", ShopifyCli::TOOL_NAME))
+        ctx.abort(ctx.message("core.api.error.forbidden", ShopifyCLI::TOOL_NAME))
       end
     end
 

--- a/lib/shopify_cli/admin_api/populate_resource_command.rb
+++ b/lib/shopify_cli/admin_api/populate_resource_command.rb
@@ -1,9 +1,9 @@
 require "shopify_cli"
 require "optparse"
 
-module ShopifyCli
+module ShopifyCLI
   class AdminAPI
-    class PopulateResourceCommand < ShopifyCli::SubCommand
+    class PopulateResourceCommand < ShopifyCLI::SubCommand
       DEFAULT_COUNT = 5
 
       attr_reader :input
@@ -40,7 +40,7 @@ module ShopifyCli
           return @ctx.puts(output)
         end
 
-        ShopifyCli::Tasks::ConfirmStore.call(@ctx) unless @skip_shop_confirmation
+        ShopifyCLI::Tasks::ConfirmStore.call(@ctx) unless @skip_shop_confirmation
         @shop = AdminAPI.get_shop_or_abort(@ctx)
         if @silent
           spin_group = CLI::UI::SpinGroup.new

--- a/lib/shopify_cli/admin_api/schema.rb
+++ b/lib/shopify_cli/admin_api/schema.rb
@@ -1,19 +1,19 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class AdminAPI
     class Schema < Hash
       class << self
         def get(ctx)
-          unless ShopifyCli::DB.exists?(:shopify_admin_schema)
+          unless ShopifyCLI::DB.exists?(:shopify_admin_schema)
             shop = AdminAPI.get_shop_or_abort(ctx)
             schema = AdminAPI.query(ctx, "admin_introspection", shop: shop)
-            ShopifyCli::DB.set(shopify_admin_schema: JSON.dump(schema))
+            ShopifyCLI::DB.set(shopify_admin_schema: JSON.dump(schema))
           end
           # This is ruby magic for making a new hash with another hash.
           # It wraps the JSON in our Schema Class to have the helper methods
           # available
-          self[JSON.parse(ShopifyCli::DB.get(:shopify_admin_schema))]
+          self[JSON.parse(ShopifyCLI::DB.get(:shopify_admin_schema))]
         end
       end
 

--- a/lib/shopify_cli/api.rb
+++ b/lib/shopify_cli/api.rb
@@ -1,10 +1,10 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class API
     include SmartProperties
 
-    property! :ctx, accepts: ShopifyCli::Context
+    property! :ctx, accepts: ShopifyCLI::Context
     property! :token, accepts: String
     property :auth_header, accepts: String
     property! :url, accepts: String
@@ -91,14 +91,14 @@ module ShopifyCli
     protected
 
     def load_query(name)
-      project_type = ShopifyCli::Project.current_project_type
+      project_type = ShopifyCLI::Project.current_project_type
       project_file_path = File.join(
-        ShopifyCli::ROOT, "lib", "project_types", project_type.to_s, "graphql", "#{name}.graphql"
+        ShopifyCLI::ROOT, "lib", "project_types", project_type.to_s, "graphql", "#{name}.graphql"
       )
       if !project_type.nil? && File.exist?(project_file_path)
         File.read(project_file_path)
       else
-        File.read(File.join(ShopifyCli::ROOT, "lib", "graphql", "#{name}.graphql"))
+        File.read(File.join(ShopifyCLI::ROOT, "lib", "graphql", "#{name}.graphql"))
       end
     end
 
@@ -106,8 +106,8 @@ module ShopifyCli
 
     def default_headers
       {
-        "User-Agent" => "Shopify CLI; v=#{ShopifyCli::VERSION}",
-        "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCli::VERSION} sha=#{ShopifyCli.sha}",
+        "User-Agent" => "Shopify CLI; v=#{ShopifyCLI::VERSION}",
+        "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCLI::VERSION} sha=#{ShopifyCLI.sha}",
         "Sec-CH-UA-PLATFORM" => ctx.os.to_s,
       }.tap do |headers|
         headers["X-Shopify-Cli-Employee"] = "1" if Shopifolk.acting_as_shopify_organization?

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class Command < CLI::Kit::BaseCommand
     extend Feature::Set
 
@@ -55,7 +55,7 @@ module ShopifyCli
       end
 
       def task_registry
-        @task_registry || ShopifyCli::Tasks::Registry
+        @task_registry || ShopifyCLI::Tasks::Registry
       end
 
       def call_help(*cmds)
@@ -75,7 +75,7 @@ module ShopifyCli
 
     def initialize(ctx = nil)
       super()
-      @ctx = ctx || ShopifyCli::Context.new
+      @ctx = ctx || ShopifyCLI::Context.new
       self.options = Options.new
     end
   end

--- a/lib/shopify_cli/commands.rb
+++ b/lib/shopify_cli/commands.rb
@@ -1,6 +1,6 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     Registry = CLI::Kit::CommandRegistry.new(
       default: "help",

--- a/lib/shopify_cli/commands/config.rb
+++ b/lib/shopify_cli/commands/config.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Config < ShopifyCli::Command
+    class Config < ShopifyCLI::Command
       hidden_feature(feature_set: :debug)
 
       subcommand :Feature, "feature"
@@ -13,12 +13,12 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message("core.config.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.config.help", ShopifyCLI::TOOL_NAME)
       end
 
-      class Feature < ShopifyCli::SubCommand
+      class Feature < ShopifyCLI::SubCommand
         def self.help
-          ShopifyCli::Context.message("core.config.feature.help", ShopifyCli::TOOL_NAME)
+          ShopifyCLI::Context.message("core.config.feature.help", ShopifyCLI::TOOL_NAME)
         end
 
         options do |parser, flags|
@@ -29,13 +29,13 @@ module ShopifyCli
 
         def call(args, _name)
           feature_name = args.shift
-          return @ctx.puts(@ctx.message("core.config.help", ShopifyCli::TOOL_NAME)) if feature_name.nil?
-          is_enabled = ShopifyCli::Feature.enabled?(feature_name)
+          return @ctx.puts(@ctx.message("core.config.help", ShopifyCLI::TOOL_NAME)) if feature_name.nil?
+          is_enabled = ShopifyCLI::Feature.enabled?(feature_name)
           if options.flags[:action] == "disable" && is_enabled
-            ShopifyCli::Feature.disable(feature_name)
+            ShopifyCLI::Feature.disable(feature_name)
             @ctx.puts(@ctx.message("core.config.feature.disabled", feature_name))
           elsif options.flags[:action] == "enable" && !is_enabled
-            ShopifyCli::Feature.enable(feature_name)
+            ShopifyCLI::Feature.enable(feature_name)
             @ctx.puts(@ctx.message("core.config.feature.enabled", feature_name))
           elsif is_enabled
             @ctx.puts(@ctx.message("core.config.feature.is_enabled", feature_name))
@@ -45,9 +45,9 @@ module ShopifyCli
         end
       end
 
-      class Analytics < ShopifyCli::SubCommand
+      class Analytics < ShopifyCLI::SubCommand
         def self.help
-          ShopifyCli::Context.message("core.config.analytics.help", ShopifyCli::TOOL_NAME)
+          ShopifyCLI::Context.message("core.config.analytics.help", ShopifyCLI::TOOL_NAME)
         end
 
         options do |parser, flags|
@@ -57,12 +57,12 @@ module ShopifyCli
         end
 
         def call(_args, _name)
-          is_enabled = ShopifyCli::Config.get_bool("analytics", "enabled")
+          is_enabled = ShopifyCLI::Config.get_bool("analytics", "enabled")
           if options.flags[:action] == "disable" && is_enabled
-            ShopifyCli::Config.set("analytics", "enabled", false)
+            ShopifyCLI::Config.set("analytics", "enabled", false)
             @ctx.puts(@ctx.message("core.config.analytics.disabled"))
           elsif options.flags[:action] == "enable" && !is_enabled
-            ShopifyCli::Config.set("analytics", "enabled", true)
+            ShopifyCLI::Config.set("analytics", "enabled", true)
             @ctx.puts(@ctx.message("core.config.analytics.enabled"))
           elsif is_enabled
             @ctx.puts(@ctx.message("core.config.analytics.is_enabled"))

--- a/lib/shopify_cli/commands/help.rb
+++ b/lib/shopify_cli/commands/help.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Help < ShopifyCli::Command
+    class Help < ShopifyCLI::Command
       def call(args, _name)
         command = args.shift
         if command && command != "help"
@@ -20,7 +20,7 @@ module ShopifyCli
           end
         end
 
-        preamble = @ctx.message("core.help.preamble", ShopifyCli::TOOL_NAME)
+        preamble = @ctx.message("core.help.preamble", ShopifyCLI::TOOL_NAME)
         @ctx.puts(preamble)
 
         available_commands = resolved_commands.select { |_name, c| !c.hidden? }
@@ -43,7 +43,7 @@ module ShopifyCli
       end
 
       def resolved_commands
-        ShopifyCli::Commands::Registry
+        ShopifyCLI::Commands::Registry
           .resolved_commands
           .sort
       end

--- a/lib/shopify_cli/commands/login.rb
+++ b/lib/shopify_cli/commands/login.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Login < ShopifyCli::Command
+    class Login < ShopifyCLI::Command
       PROTOCOL_REGEX = /^https?\:\/\//
       PERMANENT_DOMAIN_SUFFIX = /\.myshopify\.(com|io)$/
 
@@ -15,7 +15,7 @@ module ShopifyCli
 
       def call(*)
         shop = (options.flags[:shop] || @ctx.getenv("SHOPIFY_SHOP" || nil))
-        ShopifyCli::DB.set(shop: self.class.validate_shop(shop)) unless shop.nil?
+        ShopifyCLI::DB.set(shop: self.class.validate_shop(shop)) unless shop.nil?
 
         if shop.nil? && Shopifolk.check
           Shopifolk.reset
@@ -28,17 +28,17 @@ module ShopifyCli
 
         # As password auth will soon be deprecated, we enable only in CI
         if @ctx.ci? && (password = options.flags[:password] || @ctx.getenv("SHOPIFY_PASSWORD"))
-          ShopifyCli::DB.set(shopify_exchange_token: password)
+          ShopifyCLI::DB.set(shopify_exchange_token: password)
         else
           IdentityAuth.new(ctx: @ctx).authenticate
           org = select_organization
-          ShopifyCli::DB.set(organization_id: org["id"].to_i) unless org.nil?
+          ShopifyCLI::DB.set(organization_id: org["id"].to_i) unless org.nil?
           Whoami.call([], "whoami")
         end
       end
 
       def self.help
-        ShopifyCli::Context.message("core.login.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.login.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.validate_shop(shop)
@@ -75,7 +75,7 @@ module ShopifyCli
       private
 
       def select_organization
-        organizations = ShopifyCli::PartnersAPI::Organizations.fetch_all(@ctx)
+        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_all(@ctx)
 
         if organizations.count == 0
           nil

--- a/lib/shopify_cli/commands/logout.rb
+++ b/lib/shopify_cli/commands/logout.rb
@@ -1,37 +1,37 @@
 require "shopify_cli"
 require "shopify_cli/theme/development_theme"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Logout < ShopifyCli::Command
+    class Logout < ShopifyCLI::Command
       def call(*)
         try_delete_development_theme
-        ShopifyCli::IdentityAuth.delete_tokens_and_keys
-        ShopifyCli::DB.del(:shop) if has_shop?
-        ShopifyCli::DB.del(:organization_id) if has_organization_id?
-        ShopifyCli::Shopifolk.reset
+        ShopifyCLI::IdentityAuth.delete_tokens_and_keys
+        ShopifyCLI::DB.del(:shop) if has_shop?
+        ShopifyCLI::DB.del(:organization_id) if has_organization_id?
+        ShopifyCLI::Shopifolk.reset
         @ctx.puts(@ctx.message("core.logout.success"))
       end
 
       def self.help
-        ShopifyCli::Context.message("core.logout.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.logout.help", ShopifyCLI::TOOL_NAME)
       end
 
       private
 
       def has_shop?
-        ShopifyCli::DB.exists?(:shop)
+        ShopifyCLI::DB.exists?(:shop)
       end
 
       def has_organization_id?
-        ShopifyCli::DB.exists?(:organization_id)
+        ShopifyCLI::DB.exists?(:organization_id)
       end
 
       def try_delete_development_theme
         return unless has_shop?
 
-        ShopifyCli::Theme::DevelopmentTheme.delete(@ctx)
-      rescue ShopifyCli::API::APIRequestError
+        ShopifyCLI::Theme::DevelopmentTheme.delete(@ctx)
+      rescue ShopifyCLI::API::APIRequestError
         # Ignore since we can't delete it
       end
     end

--- a/lib/shopify_cli/commands/populate.rb
+++ b/lib/shopify_cli/commands/populate.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Populate < ShopifyCli::Command
+    class Populate < ShopifyCLI::Command
       subcommand :Customer, "customers", "shopify_cli/commands/populate/customer"
       subcommand :DraftOrder, "draftorders", "shopify_cli/commands/populate/draft_order"
       subcommand :Product, "products", "shopify_cli/commands/populate/product"
@@ -12,11 +12,11 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message("core.populate.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.populate.help", ShopifyCLI::TOOL_NAME)
       end
 
       def self.extended_help
-        ShopifyCli::Context.message("core.populate.extended_help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.populate.extended_help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify_cli/commands/populate/customer.rb
+++ b/lib/shopify_cli/commands/populate/customer.rb
@@ -1,13 +1,13 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class Populate
-      class Customer < ShopifyCli::AdminAPI::PopulateResourceCommand
+      class Customer < ShopifyCLI::AdminAPI::PopulateResourceCommand
         @input_type = :CustomerInput
 
         def defaults
-          first_name, last_name = ShopifyCli::Helpers::Haikunator.name
+          first_name, last_name = ShopifyCLI::Helpers::Haikunator.name
           {
             firstName: first_name,
             lastName: last_name,
@@ -16,7 +16,7 @@ module ShopifyCli
 
         def message(data)
           ret = data["customerCreate"]["customer"]
-          id = ShopifyCli::API.gid_to_id(ret["id"])
+          id = ShopifyCLI::API.gid_to_id(ret["id"])
           @ctx.message("core.populate.customer.added", ret["displayName"], @shop, admin_url, id)
         end
       end

--- a/lib/shopify_cli/commands/populate/draft_order.rb
+++ b/lib/shopify_cli/commands/populate/draft_order.rb
@@ -1,9 +1,9 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class Populate
-      class DraftOrder < ShopifyCli::AdminAPI::PopulateResourceCommand
+      class DraftOrder < ShopifyCLI::AdminAPI::PopulateResourceCommand
         @input_type = :DraftOrderInput
 
         def defaults
@@ -12,14 +12,14 @@ module ShopifyCli
               originalUnitPrice: price,
               quantity: 1,
               weight: { value: 10, unit: "GRAMS" },
-              title: ShopifyCli::Helpers::Haikunator.title,
+              title: ShopifyCLI::Helpers::Haikunator.title,
             }],
           }
         end
 
         def message(data)
           ret = data["draftOrderCreate"]["draftOrder"]
-          id = ShopifyCli::API.gid_to_id(ret["id"])
+          id = ShopifyCLI::API.gid_to_id(ret["id"])
           @ctx.message("core.populate.draft_order.added", @shop, admin_url, id)
         end
       end

--- a/lib/shopify_cli/commands/populate/product.rb
+++ b/lib/shopify_cli/commands/populate/product.rb
@@ -1,21 +1,21 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class Populate
-      class Product < ShopifyCli::AdminAPI::PopulateResourceCommand
+      class Product < ShopifyCLI::AdminAPI::PopulateResourceCommand
         @input_type = :ProductInput
 
         def defaults
           {
-            title: ShopifyCli::Helpers::Haikunator.title,
+            title: ShopifyCLI::Helpers::Haikunator.title,
             variants: [{ price: price }],
           }
         end
 
         def message(data)
           ret = data["productCreate"]["product"]
-          id = ShopifyCli::API.gid_to_id(ret["id"])
+          id = ShopifyCLI::API.gid_to_id(ret["id"])
           @ctx.message("core.populate.product.added", ret["title"], @shop, admin_url, id)
         end
       end

--- a/lib/shopify_cli/commands/store.rb
+++ b/lib/shopify_cli/commands/store.rb
@@ -1,14 +1,14 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Store < ShopifyCli::Command
+    class Store < ShopifyCLI::Command
       def call(_args, _name)
-        @ctx.puts(@ctx.message("core.store.shop", ShopifyCli::AdminAPI.get_shop_or_abort(@ctx)))
+        @ctx.puts(@ctx.message("core.store.shop", ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)))
       end
 
       def self.help
-        ShopifyCli::Context.message("core.store.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.store.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify_cli/commands/switch.rb
+++ b/lib/shopify_cli/commands/switch.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Switch < ShopifyCli::Command
+    class Switch < ShopifyCLI::Command
       options do |parser, flags|
         parser.on("--store=STORE") { |url| flags[:shop] = url }
         # backwards compatibility allow 'shop' for now
@@ -18,11 +18,11 @@ module ShopifyCli
         shop = if options.flags[:shop]
           Login.validate_shop(options.flags[:shop])
         elsif (org_id = DB.get(:organization_id))
-          res = ShopifyCli::Tasks::SelectOrgAndShop.call(@ctx, organization_id: org_id)
+          res = ShopifyCLI::Tasks::SelectOrgAndShop.call(@ctx, organization_id: org_id)
           res[:shop_domain]
         else
           AdminAPI.get_shop_or_abort(@ctx)
-          res = ShopifyCli::Tasks::SelectOrgAndShop.call(@ctx)
+          res = ShopifyCLI::Tasks::SelectOrgAndShop.call(@ctx)
           res[:shop_domain]
         end
         DB.set(shop: shop)
@@ -32,7 +32,7 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message("core.switch.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.switch.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify_cli/commands/system.rb
+++ b/lib/shopify_cli/commands/system.rb
@@ -1,9 +1,9 @@
 require "shopify_cli"
 require "rbconfig"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class System < ShopifyCli::Command
+    class System < ShopifyCLI::Command
       hidden_feature(feature_set: :debug)
 
       def call(args, _name)
@@ -28,7 +28,7 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message("core.system.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.system.help", ShopifyCLI::TOOL_NAME)
       end
 
       private
@@ -50,21 +50,21 @@ module ShopifyCli
 
         @ctx.puts(@ctx.message("core.system.header"))
         cli_constants.each do |s|
-          @ctx.puts("  " + @ctx.message("core.system.const", s, ShopifyCli.const_get(s.to_sym)) + "\n")
+          @ctx.puts("  " + @ctx.message("core.system.const", s, ShopifyCLI.const_get(s.to_sym)) + "\n")
         end
 
         if show_all_details
           cli_path_methods.each do |m|
-            @ctx.puts("  " + @ctx.message("core.system.const", m.upcase, ShopifyCli.send(m)) + "\n")
+            @ctx.puts("  " + @ctx.message("core.system.const", m.upcase, ShopifyCLI.send(m)) + "\n")
           end
         end
       end
 
       def display_shopify_store(_show_all_details)
-        shop = if ShopifyCli::DB.exists?(:shop)
-          ShopifyCli::AdminAPI.get_shop_or_abort(@ctx)
+        shop = if ShopifyCLI::DB.exists?(:shop)
+          ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
         else
-          @ctx.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME)
+          @ctx.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME)
         end
 
         @ctx.puts("\n" + @ctx.message("core.system.shop_header"))
@@ -96,7 +96,7 @@ module ShopifyCli
       end
 
       def display_ngrok
-        ngrok_location = File.join(ShopifyCli.cache_dir, "ngrok#{@ctx.executable_file_extension}")
+        ngrok_location = File.join(ShopifyCLI.cache_dir, "ngrok#{@ctx.executable_file_extension}")
         if File.exist?(ngrok_location)
           @ctx.puts("  " + @ctx.message("core.system.ngrok_available", ngrok_location))
         else
@@ -154,7 +154,7 @@ module ShopifyCli
       end
 
       def display_shopify_staff_identity
-        is_shopifolk = ShopifyCli::Shopifolk.check
+        is_shopifolk = ShopifyCLI::Shopifolk.check
         if is_shopifolk
           @ctx.puts("\n" + @ctx.message("core.system.identity_header"))
           @ctx.puts("  " + @ctx.message("core.system.identity_is_shopifolk"))

--- a/lib/shopify_cli/commands/version.rb
+++ b/lib/shopify_cli/commands/version.rb
@@ -1,14 +1,14 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Version < ShopifyCli::Command
+    class Version < ShopifyCLI::Command
       def self.help
-        ShopifyCli::Context.message("core.version.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.version.help", ShopifyCLI::TOOL_NAME)
       end
 
       def call(_args, _name)
-        @ctx.puts(ShopifyCli::VERSION.to_s)
+        @ctx.puts(ShopifyCLI::VERSION.to_s)
       end
     end
   end

--- a/lib/shopify_cli/commands/whoami.rb
+++ b/lib/shopify_cli/commands/whoami.rb
@@ -1,15 +1,15 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class Whoami < ShopifyCli::Command
+    class Whoami < ShopifyCLI::Command
       def call(_args, _name)
-        shop = ShopifyCli::DB.get(:shop)
-        org_id = ShopifyCli::DB.get(:organization_id)
-        org = ShopifyCli::PartnersAPI::Organizations.fetch(@ctx, id: org_id) unless org_id.nil?
+        shop = ShopifyCLI::DB.get(:shop)
+        org_id = ShopifyCLI::DB.get(:organization_id)
+        org = ShopifyCLI::PartnersAPI::Organizations.fetch(@ctx, id: org_id) unless org_id.nil?
 
         output = if shop.nil? && org.nil?
-          @ctx.message("core.whoami.not_logged_in", ShopifyCli::TOOL_NAME)
+          @ctx.message("core.whoami.not_logged_in", ShopifyCLI::TOOL_NAME)
         elsif !shop.nil? && org.nil?
           @ctx.message("core.whoami.logged_in_shop_only", shop)
         elsif shop.nil? && !org.nil?
@@ -21,7 +21,7 @@ module ShopifyCli
       end
 
       def self.help
-        ShopifyCli::Context.message("core.whoami.help", ShopifyCli::TOOL_NAME)
+        ShopifyCLI::Context.message("core.whoami.help", ShopifyCLI::TOOL_NAME)
       end
     end
   end

--- a/lib/shopify_cli/connect.rb
+++ b/lib/shopify_cli/connect.rb
@@ -1,6 +1,6 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class Connect
     def initialize(ctx)
       @ctx = ctx
@@ -10,14 +10,14 @@ module ShopifyCli
       if Project.current&.env
         @ctx.puts(@ctx.message("core.connect.already_connected_warning"))
       end
-      org = ShopifyCli::Tasks::EnsureEnv.call(@ctx, regenerate: true)
+      org = ShopifyCLI::Tasks::EnsureEnv.call(@ctx, regenerate: true)
       write_cli_yml(project_type, org["id"]) unless Project.has_current?
       api_key = Project.current(force_reload: true).env["api_key"]
       get_app(org["apps"], api_key).first["title"]
     end
 
     def write_cli_yml(project_type, org_id)
-      ShopifyCli::Project.write(
+      ShopifyCLI::Project.write(
         @ctx,
         project_type: project_type,
         organization_id: org_id,

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   module Constants
     module EnvironmentVariables
       # When true the CLI points to a local instance of

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -5,7 +5,7 @@ require "rbconfig"
 require "net/http"
 require "json"
 
-module ShopifyCli
+module ShopifyCLI
   ##
   # Context captures a lot about the current running command. It captures the
   # environment, output, system and file operations. It is useful to have the
@@ -97,7 +97,7 @@ module ShopifyCli
     # See `#development?` for checking for development environment.
     #
     def system?
-      !Dir.exist?(File.join(ShopifyCli::ROOT, "test"))
+      !Dir.exist?(File.join(ShopifyCLI::ROOT, "test"))
     end
 
     # will return true if the cli is running on your development instance.
@@ -382,7 +382,7 @@ module ShopifyCli
     # * `text` - a string message to output
     #
     def abort(text)
-      raise ShopifyCli::Abort, "{{x}} #{text}"
+      raise ShopifyCLI::Abort, "{{x}} #{text}"
     end
 
     # outputs a message, prefixed by a red `DEBUG` tag. This will only output to
@@ -559,7 +559,7 @@ module ShopifyCli
       if (time_of_last_check + VERSION_CHECK_INTERVAL) < (now = Time.now.to_i)
         update_time_of_last_check(now)
         latest_version = retrieve_latest_gem_version
-        latest_version unless latest_version == ShopifyCli::VERSION
+        latest_version unless latest_version == ShopifyCLI::VERSION
       end
     end
 
@@ -600,11 +600,11 @@ module ShopifyCli
     end
 
     def time_of_last_check
-      (val = ShopifyCli::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0
+      (val = ShopifyCLI::Config.get(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD)) ? val.to_i : 0
     end
 
     def update_time_of_last_check(time)
-      ShopifyCli::Config.set(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD, time)
+      ShopifyCLI::Config.set(VERSION_CHECK_SECTION, LAST_CHECKED_AT_FIELD, time)
     end
   end
 end

--- a/lib/shopify_cli/core.rb
+++ b/lib/shopify_cli/core.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   module Core
     autoload :EntryPoint, "shopify_cli/core/entry_point"
     autoload :Executor, "shopify_cli/core/executor"

--- a/lib/shopify_cli/core/entry_point.rb
+++ b/lib/shopify_cli/core/entry_point.rb
@@ -1,26 +1,26 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
           if ctx.development?
             ctx.warn(
-              ctx.message("core.warning.development_version", File.join(ShopifyCli::ROOT, "bin", ShopifyCli::TOOL_NAME))
+              ctx.message("core.warning.development_version", File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME))
             )
           elsif !ctx.testing?
             new_version = ctx.new_version
-            ctx.warn(ctx.message("core.warning.new_version", ShopifyCli::VERSION, new_version)) unless new_version.nil?
+            ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, new_version)) unless new_version.nil?
           end
 
           ProjectType.load_all
 
-          task_registry = ShopifyCli::Tasks::Registry
+          task_registry = ShopifyCLI::Tasks::Registry
 
-          command, command_name, args = ShopifyCli::Resolver.call(args)
-          executor = ShopifyCli::Core::Executor.new(ctx, task_registry, log_file: ShopifyCli.log_file)
-          ShopifyCli::Core::Monorail.log(command_name, args) do
+          command, command_name, args = ShopifyCLI::Resolver.call(args)
+          executor = ShopifyCLI::Core::Executor.new(ctx, task_registry, log_file: ShopifyCLI.log_file)
+          ShopifyCLI::Core::Monorail.log(command_name, args) do
             executor.call(command, command_name, args)
           end
         end

--- a/lib/shopify_cli/core/executor.rb
+++ b/lib/shopify_cli/core/executor.rb
@@ -1,11 +1,11 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class Executor < CLI::Kit::Executor
       def initialize(ctx, task_registry, *args, **kwargs)
-        @ctx = ctx || ShopifyCli::Context.new
-        @task_registry = task_registry || ShopifyCli::Tasks::TaskRegistry.new
+        @ctx = ctx || ShopifyCLI::Context.new
+        @task_registry = task_registry || ShopifyCLI::Tasks::TaskRegistry.new
         super(*args, **kwargs)
       end
 

--- a/lib/shopify_cli/core/finalize.rb
+++ b/lib/shopify_cli/core/finalize.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   module Core
     # This class is just a dummy to make sure that we don't trigger warnings on the first time the updated code runs.
     # The old code would try to call the Finalizer after it is done updating, which would then trigger an autoload of

--- a/lib/shopify_cli/core/help_resolver.rb
+++ b/lib/shopify_cli/core/help_resolver.rb
@@ -1,6 +1,6 @@
 require "cli/kit"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class HelpResolver < CLI::Kit::Resolver
       def call(args)
@@ -10,7 +10,7 @@ module ShopifyCli
           help = Commands::Help
           help.ctx = Context.new
           help.call([], nil)
-          raise ShopifyCli::AbortSilent
+          raise ShopifyCLI::AbortSilent
         else
           super(args)
         end

--- a/lib/shopify_cli/core/monorail.rb
+++ b/lib/shopify_cli/core/monorail.rb
@@ -3,7 +3,7 @@ require "net/http"
 require "time"
 require "rbconfig"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     module Monorail
       ENDPOINT_URI = URI.parse("https://monorail-edge.shopifycloud.com/v1/produce")
@@ -50,16 +50,16 @@ module ShopifyCli
         end
 
         def consented?
-          ShopifyCli::Config.get_bool("analytics", "enabled")
+          ShopifyCLI::Config.get_bool("analytics", "enabled")
         end
 
         def prompt_for_consent
           return if Context.new.ci?
           return unless enabled?
-          return if ShopifyCli::Config.get_section("analytics").key?("enabled")
+          return if ShopifyCLI::Config.get_section("analytics").key?("enabled")
           msg = Context.message("core.monorail.consent_prompt")
           opt = CLI::UI::Prompt.confirm(msg)
-          ShopifyCli::Config.set("analytics", "enabled", opt)
+          ShopifyCLI::Config.set("analytics", "enabled", opt)
         end
 
         def send_event(start_time, commands, args, err = nil)
@@ -100,12 +100,12 @@ module ShopifyCli
               success: err.nil?,
               error_message: err,
               uname: RbConfig::CONFIG["host"],
-              cli_version: ShopifyCli::VERSION,
+              cli_version: ShopifyCLI::VERSION,
               ruby_version: RUBY_VERSION,
-              is_employee: ShopifyCli::Shopifolk.acting_as_shopify_organization?,
+              is_employee: ShopifyCLI::Shopifolk.acting_as_shopify_organization?,
             }.tap do |payload|
               payload[:api_key] = metadata.delete(:api_key)
-              payload[:partner_id] = metadata.delete(:organization_id) || ShopifyCli::DB.get(:organization_id)
+              payload[:partner_id] = metadata.delete(:organization_id) || ShopifyCLI::DB.get(:organization_id)
               if Project.has_current?
                 project = Project.current(force_reload: true)
                 payload[:api_key] = project.env&.api_key
@@ -117,7 +117,7 @@ module ShopifyCli
         end
 
         def project_type_from_dir_or_cmd(command)
-          Project.current_project_type || (command unless ShopifyCli::Commands.core_command?(command)) || nil
+          Project.current_project_type || (command unless ShopifyCLI::Commands.core_command?(command)) || nil
         end
       end
     end

--- a/lib/shopify_cli/db.rb
+++ b/lib/shopify_cli/db.rb
@@ -1,7 +1,7 @@
 require "pstore"
 require "forwardable"
 
-module ShopifyCli
+module ShopifyCLI
   # Persists transient data like access tokens that may be cleared
   # when user clears their session
   #
@@ -14,7 +14,7 @@ module ShopifyCli
 
     attr_reader :db # :nodoc:
 
-    def initialize(path: File.join(ShopifyCli.cache_dir, ".db.pstore")) # :nodoc:
+    def initialize(path: File.join(ShopifyCLI.cache_dir, ".db.pstore")) # :nodoc:
       @db = PStore.new(path)
     end
 
@@ -25,7 +25,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   ShopifyCli::DB.keys
+    #   ShopifyCLI::DB.keys
     #
     def keys
       db.transaction(true) { db.roots }
@@ -42,7 +42,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   exists = ShopifyCli::DB.exists?('shopify_exchange_token')
+    #   exists = ShopifyCLI::DB.exists?('shopify_exchange_token')
     #
     def exists?(key)
       db.transaction(true) { db.root?(key) }
@@ -55,7 +55,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   ShopifyCli::DB.set(shopify_exchange_token: 'token', metric_consent: true)
+    #   ShopifyCLI::DB.set(shopify_exchange_token: 'token', metric_consent: true)
     #
     def set(**args)
       db.transaction do
@@ -80,7 +80,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   ShopifyCli::DB.get(:shopify_exchange_token)
+    #   ShopifyCLI::DB.get(:shopify_exchange_token)
     #
     def get(key)
       val = db.transaction(true) { db[key] }
@@ -95,7 +95,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   ShopifyCli::DB.del(:shopify_exchange_token)
+    #   ShopifyCLI::DB.del(:shopify_exchange_token)
     #
     def del(*args)
       db.transaction { args.each { |key| db.delete(key) } }
@@ -105,7 +105,7 @@ module ShopifyCli
     #
     # #### Usage
     #
-    #   ShopifyCli::DB.clear
+    #   ShopifyCLI::DB.clear
     #
     def clear
       del(*keys)

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   # The environment module provides an interface to get information from
   # the environment in which the CLI runs
   module Environment

--- a/lib/shopify_cli/feature.rb
+++ b/lib/shopify_cli/feature.rb
@@ -1,6 +1,6 @@
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::Feature contains the logic to hide and show features across the CLI
+  # ShopifyCLI::Feature contains the logic to hide and show features across the CLI
   # These features can be either commands or project types currently.
   #
   # Feature flags will persist between runs so if the flag is enabled or disabled,
@@ -9,7 +9,7 @@ module ShopifyCli
     SECTION = "features"
 
     ##
-    # ShopifyCli::Feature::Set is included on commands and projects to allow you to hide
+    # ShopifyCLI::Feature::Set is included on commands and projects to allow you to hide
     # and enable projects and commands based on feature flags.
     module Set
       ##
@@ -21,9 +21,9 @@ module ShopifyCli
       #
       # #### Example
       #
-      #    module ShopifyCli
+      #    module ShopifyCLI
       #      module Commands
-      #        class Config < ShopifyCli::Command
+      #        class Config < ShopifyCLI::Command
       #          hidden_feature(feature_set: :basic)
       #          ....
       #
@@ -41,7 +41,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #     ShopifyCli::Commands::Config.hidden?
+      #     ShopifyCLI::Commands::Config.hidden?
       #
       def hidden?
         enabled = (@hidden_feature_set || []).any? do |feature|
@@ -84,11 +84,11 @@ module ShopifyCli
       # * `is_enabled` - will be true if the feature has been enabled.
       def enabled?(feature)
         return false if feature.nil?
-        ShopifyCli::Config.get_bool(SECTION, feature.to_s)
+        ShopifyCLI::Config.get_bool(SECTION, feature.to_s)
       end
 
       def set(feature, value)
-        ShopifyCli::Config.set(SECTION, feature.to_s, value)
+        ShopifyCLI::Config.set(SECTION, feature.to_s, value)
       end
     end
   end

--- a/lib/shopify_cli/form.rb
+++ b/lib/shopify_cli/form.rb
@@ -1,6 +1,6 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class Form
     class << self
       def ask(ctx, args, flags)
@@ -12,7 +12,7 @@ module ShopifyCli
         begin
           form.ask
           form
-        rescue ShopifyCli::Abort => err
+        rescue ShopifyCLI::Abort => err
           ctx.puts(err.message)
           nil
         end

--- a/lib/shopify_cli/git.rb
+++ b/lib/shopify_cli/git.rb
@@ -1,6 +1,6 @@
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::Git wraps git functionality to make it easier to integrate will
+  # ShopifyCLI::Git wraps git functionality to make it easier to integrate will
   # git.
   class Git
     class << self
@@ -18,7 +18,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::Git.sha
+      #   ShopifyCLI::Git.sha
       #
       def sha(dir: Dir.pwd, ctx: Context.new)
         rev_parse("HEAD", dir: dir, ctx: ctx)
@@ -40,7 +40,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::Git.clone('git@github.com:shopify/test.git', 'test-app')
+      #   ShopifyCLI::Git.clone('git@github.com:shopify/test.git', 'test-app')
       #
       def clone(repository, dest, ctx: Context.new)
         if Dir.exist?(dest)
@@ -66,7 +66,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   branches = ShopifyCli::Git.branches(@ctx)
+      #   branches = ShopifyCLI::Git.branches(@ctx)
       #
       def branches(ctx)
         output, status = ctx.capture2e("git", "branch", "--list", "--format=%(refname:short)")
@@ -91,7 +91,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::Git.init(@ctx)
+      #   ShopifyCLI::Git.init(@ctx)
       #
       def init(ctx)
         output, status = ctx.capture2e("git", "status")

--- a/lib/shopify_cli/helpers.rb
+++ b/lib/shopify_cli/helpers.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   module Helpers
     autoload :Haikunator, "shopify_cli/helpers/haikunator"
   end

--- a/lib/shopify_cli/helpers/haikunator.rb
+++ b/lib/shopify_cli/helpers/haikunator.rb
@@ -23,7 +23,7 @@
 
 require "securerandom"
 
-module ShopifyCli
+module ShopifyCLI
   module Helpers
     module Haikunator
       class << self

--- a/lib/shopify_cli/heroku.rb
+++ b/lib/shopify_cli/heroku.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class Heroku
     DOWNLOAD_URLS = {
       linux: "https://cli-assets.heroku.com/heroku-linux-x64.tar.gz",
@@ -36,7 +36,7 @@ module ShopifyCli
     def download
       return if installed?
 
-      result = @ctx.system("curl", "-o", download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCli.cache_dir)
+      result = @ctx.system("curl", "-o", download_path, DOWNLOAD_URLS[@ctx.os], chdir: ShopifyCLI.cache_dir)
       @ctx.abort(@ctx.message("core.heroku.error.download")) unless result.success?
       @ctx.abort(@ctx.message("core.heroku.error.download")) unless File.exist?(download_path)
     end
@@ -47,7 +47,7 @@ module ShopifyCli
       result = if @ctx.windows?
         @ctx.system("\"#{download_path}\"")
       else
-        @ctx.system("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
+        @ctx.system("tar", "-xf", download_path, chdir: ShopifyCLI.cache_dir)
       end
       @ctx.abort(@ctx.message("core.heroku.error.install")) unless result.success?
 
@@ -74,7 +74,7 @@ module ShopifyCli
     end
 
     def download_path
-      File.join(ShopifyCli.cache_dir, download_filename)
+      File.join(ShopifyCLI.cache_dir, download_filename)
     end
 
     def git_remote
@@ -83,7 +83,7 @@ module ShopifyCli
     end
 
     def heroku_command
-      local_path = File.join(ShopifyCli.cache_dir, "heroku", "bin", "heroku").to_s
+      local_path = File.join(ShopifyCLI.cache_dir, "heroku", "bin", "heroku").to_s
       if File.exist?(local_path)
         local_path
       elsif @ctx.windows?

--- a/lib/shopify_cli/http_request.rb
+++ b/lib/shopify_cli/http_request.rb
@@ -1,7 +1,7 @@
 require "net/http"
 require "openssl"
 
-module ShopifyCli
+module ShopifyCLI
   class HttpRequest
     class << self
       def post(uri, body, headers)

--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -8,7 +8,7 @@ require "shopify_cli"
 require "uri"
 require "webrick"
 
-module ShopifyCli
+module ShopifyCLI
   class IdentityAuth
     include SmartProperties
 
@@ -49,7 +49,7 @@ module ShopifyCli
     ]
 
     property! :ctx
-    property :store, default: -> { ShopifyCli::DB.new }
+    property :store, default: -> { ShopifyCLI::DB.new }
     property :state_token, accepts: String, default: SecureRandom.hex(30)
     property :code_verifier, accepts: String, default: SecureRandom.hex(30)
 
@@ -70,7 +70,7 @@ module ShopifyCli
 
     def reauthenticate
       return if refresh_exchange_tokens || refresh_access_tokens
-      ctx.abort(ctx.message("core.identity_auth.error.reauthenticate", ShopifyCli::TOOL_NAME))
+      ctx.abort(ctx.message("core.identity_auth.error.reauthenticate", ShopifyCLI::TOOL_NAME))
     end
 
     def code_challenge
@@ -93,8 +93,8 @@ module ShopifyCli
     end
 
     def self.delete_tokens_and_keys
-      ShopifyCli::DB.del(*IDENTITY_ACCESS_TOKENS)
-      ShopifyCli::DB.del(*EXCHANGE_TOKENS)
+      ShopifyCLI::DB.del(*IDENTITY_ACCESS_TOKENS)
+      ShopifyCLI::DB.del(*EXCHANGE_TOKENS)
     end
 
     private
@@ -212,7 +212,7 @@ module ShopifyCli
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = Net::HTTP::Post.new(uri.path)
-      request["User-Agent"] = "Shopify CLI #{::ShopifyCli::VERSION}"
+      request["User-Agent"] = "Shopify CLI #{::ShopifyCLI::VERSION}"
       request.body = URI.encode_www_form(params)
       res = https.request(request)
       unless res.is_a?(Net::HTTPSuccess)
@@ -256,7 +256,7 @@ module ShopifyCli
 
     def scopes(additional_scopes = [])
       (["openid"] + additional_scopes).tap do |result|
-        result << "employee" if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        result << "employee" if ShopifyCLI::Shopifolk.acting_as_shopify_organization?
       end.join(" ")
     end
 

--- a/lib/shopify_cli/identity_auth/servlet.rb
+++ b/lib/shopify_cli/identity_auth/servlet.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class IdentityAuth
     class Servlet < WEBrick::HTTPServlet::AbstractServlet
       TEMPLATE = %{<!DOCTYPE html>

--- a/lib/shopify_cli/js_deps.rb
+++ b/lib/shopify_cli/js_deps.rb
@@ -1,17 +1,17 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::JsDeps ensures that all JavaScript dependencies are installed for projects.
+  # ShopifyCLI::JsDeps ensures that all JavaScript dependencies are installed for projects.
   #
   class JsDeps
     include SmartProperties
 
-    property! :ctx, accepts: ShopifyCli::Context
+    property! :ctx, accepts: ShopifyCLI::Context
     property! :system, accepts: JsSystem, default: -> { JsSystem.new(ctx: ctx) }
 
     ##
-    # Proxy to instance method ShopifyCli::JsDeps.new.install.
+    # Proxy to instance method ShopifyCLI::JsDeps.new.install.
     #
     # #### Parameters
     # - `ctx`: running context from your command
@@ -19,7 +19,7 @@ module ShopifyCli
     #
     # #### Example
     #
-    #   ShopifyCli::JsDeps.install(ctx)
+    #   ShopifyCLI::JsDeps.install(ctx)
     #
     def self.install(ctx, verbose = false)
       new(ctx: ctx).install(verbose)
@@ -34,7 +34,7 @@ module ShopifyCli
     # #### Example
     #
     #   # context is the running context for the command
-    #   ShopifyCli::JsDeps.new(context).install(true)
+    #   ShopifyCLI::JsDeps.new(context).install(true)
     #
     def install(verbose = false)
       title = ctx.message("core.js_deps.installing", @system.package_manager)
@@ -104,7 +104,7 @@ module ShopifyCli
         ctx.message("core.js_deps.error.invalid_package", File.read(File.join(path, "package.json"))),
         error: true
       )
-      raise ShopifyCli::AbortSilent
+      raise ShopifyCLI::AbortSilent
     end
   end
 end

--- a/lib/shopify_cli/js_system.rb
+++ b/lib/shopify_cli/js_system.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::JsSystem allows conditional system calls of npm or yarn commands.
+  # ShopifyCLI::JsSystem allows conditional system calls of npm or yarn commands.
   #
   class JsSystem
     include SmartProperties
@@ -12,21 +12,21 @@ module ShopifyCli
 
     class << self
       ##
-      # Proxy to instance method `ShopifyCli::JsSystem.new.yarn?`
+      # Proxy to instance method `ShopifyCLI::JsSystem.new.yarn?`
       #
       # #### Parameters
       # - `ctx`: running context from your command
       #
       # #### Example
       #
-      #   ShopifyCli::JsSystem.yarn?(ctx)
+      #   ShopifyCLI::JsSystem.yarn?(ctx)
       #
       def yarn?(ctx)
         JsSystem.new(ctx: ctx).yarn?
       end
 
       ##
-      # Proxy to instance method `ShopifyCli::JsSystem.new.call`
+      # Proxy to instance method `ShopifyCLI::JsSystem.new.call`
       #
       # #### Parameters
       # - `ctx`: running context from your command
@@ -35,21 +35,21 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::JsSystem.call(ctx, yarn: ['install', '--silent'], npm: ['install', '--no-audit'])
+      #   ShopifyCLI::JsSystem.call(ctx, yarn: ['install', '--silent'], npm: ['install', '--no-audit'])
       #
       def call(ctx, yarn:, npm:, capture_response: false)
         JsSystem.new(ctx: ctx).call(yarn: yarn, npm: npm, capture_response: capture_response)
       end
     end
 
-    property :ctx, accepts: ShopifyCli::Context
+    property :ctx, accepts: ShopifyCLI::Context
 
     ##
     # Returns the name of the JS package manager being used
     #
     # #### Example
     #
-    #   ShopifyCli::JsSystem.new(ctx: ctx).package_manager
+    #   ShopifyCLI::JsSystem.new(ctx: ctx).package_manager
     #
     def package_manager
       yarn? ? YARN_CORE_COMMAND : NPM_CORE_COMMAND
@@ -60,7 +60,7 @@ module ShopifyCli
     #
     # #### Example
     #
-    #   ShopifyCli::JsSystem.new(ctx: ctx).yarn?
+    #   ShopifyCLI::JsSystem.new(ctx: ctx).yarn?
     #
     def yarn?
       @has_yarn ||= begin
@@ -80,7 +80,7 @@ module ShopifyCli
     #
     # #### Example
     #
-    #   ShopifyCli::JsSystem.new(ctx: ctx).call(
+    #   ShopifyCLI::JsSystem.new(ctx: ctx).call(
     #     yarn: ['install', '--silent'],
     #     npm: ['install', '--no-audit'],
     #     capture_response: false

--- a/lib/shopify_cli/lazy_delegator.rb
+++ b/lib/shopify_cli/lazy_delegator.rb
@@ -1,6 +1,6 @@
 require "delegate"
 
-module ShopifyCli
+module ShopifyCLI
   ##
   # `LazyDelegator` defers initialization of its underlying delegatee until the
   # latter is accessed for the first time due to a method call that the
@@ -16,7 +16,7 @@ module ShopifyCli
   # LazyDelegator lends itself to being subclassed in scenarios where some
   # facts are known and others are costly to compute:
   #
-  #   class LazySpecificationHandler < ShopifyCli::LazyDelegator
+  #   class LazySpecificationHandler < ShopifyCLI::LazyDelegator
   #     attr_reader :identifier
   #
   #     def initialize(identifier, &initializer)

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Messages
     MESSAGES = {
       apps: {

--- a/lib/shopify_cli/method_object.rb
+++ b/lib/shopify_cli/method_object.rb
@@ -1,9 +1,9 @@
-module ShopifyCli
+module ShopifyCLI
   ##
   # The `MethodObject` mixin can be included in any class that implements `call`
   # to ensure that
   #
-  # * `call` will always return a `ShopifyCli::Result` by prepending a module
+  # * `call` will always return a `ShopifyCLI::Result` by prepending a module
   #   that takes care of the result wrapping and
   # * a `to_proc` method that allows instances of this class to be passed as a
   #   block.
@@ -42,8 +42,8 @@ module ShopifyCli
   #   constructed using the `&` operator,
   # * error handling is deferred until the result is unwrapped.
   #
-  # Please see the section for `ShopifyCli::Result`,
-  # `ShopifyCli::Result::Success`, and `ShopifyCli::Result::Failure` for more
+  # Please see the section for `ShopifyCLI::Result`,
+  # `ShopifyCLI::Result::Success`, and `ShopifyCLI::Result::Failure` for more
   # information on the API of result objects.
   #
   module MethodObject

--- a/lib/shopify_cli/options.rb
+++ b/lib/shopify_cli/options.rb
@@ -2,7 +2,7 @@
 require "shopify_cli"
 require "optparse"
 
-module ShopifyCli
+module ShopifyCLI
   class Options
     include SmartProperties
 

--- a/lib/shopify_cli/packager.rb
+++ b/lib/shopify_cli/packager.rb
@@ -1,7 +1,7 @@
-module ShopifyCli
+module ShopifyCLI
   class Packager
-    PACKAGING_DIR = File.join(ShopifyCli::ROOT, "packaging")
-    BUILDS_DIR = File.join(PACKAGING_DIR, "builds", ShopifyCli::VERSION)
+    PACKAGING_DIR = File.join(ShopifyCLI::ROOT, "packaging")
+    BUILDS_DIR = File.join(PACKAGING_DIR, "builds", ShopifyCLI::VERSION)
 
     def initialize
       FileUtils.mkdir_p(BUILDS_DIR)
@@ -24,7 +24,7 @@ module ShopifyCli
         file_path = File.join(debian_dir, file)
 
         file_contents = File.read(File.join(root_dir, "#{file}.base"))
-        file_contents = file_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
+        file_contents = file_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCLI::VERSION)
         File.open(file_path, "w", 0775) { |f| f.write(file_contents) }
       end
 
@@ -33,7 +33,7 @@ module ShopifyCli
       raise "Failed to build package" unless system("dpkg-deb", "-b", "shopify-cli")
 
       output_path = File.join(root_dir, "shopify-cli.deb")
-      final_path = File.join(BUILDS_DIR, "shopify-cli-#{ShopifyCli::VERSION}.deb")
+      final_path = File.join(BUILDS_DIR, "shopify-cli-#{ShopifyCLI::VERSION}.deb")
 
       puts "Moving generated package: \n  From: #{output_path}\n  To: #{final_path}\n\n"
       FileUtils.mv(output_path, final_path)
@@ -53,7 +53,7 @@ module ShopifyCli
       File.delete(spec_path) if File.exist?(spec_path)
 
       spec_contents = File.read(File.join(root_dir, "shopify-cli.spec.base"))
-      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
+      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCLI::VERSION)
       File.write(spec_path, spec_contents)
 
       puts "Building package…"
@@ -76,12 +76,12 @@ module ShopifyCli
       File.delete(build_path) if File.exist?(build_path)
 
       spec_contents = File.read(File.join(root_dir, "shopify-cli.base.rb"))
-      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCli::VERSION)
+      spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCLI::VERSION)
 
       puts "Grabbing sha256 checksum from Rubygems.org"
       require "digest/sha2"
       require "open-uri"
-      gem_checksum = open("https://rubygems.org/downloads/shopify-cli-#{ShopifyCli::VERSION}.gem") do |io|
+      gem_checksum = open("https://rubygems.org/downloads/shopify-cli-#{ShopifyCLI::VERSION}.gem") do |io|
         Digest::SHA256.new.hexdigest(io.read)
       end
 

--- a/lib/shopify_cli/partners_api.rb
+++ b/lib/shopify_cli/partners_api.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::PartnersAPI provides easy access to the partners dashboard CLI
+  # ShopifyCLI::PartnersAPI provides easy access to the partners dashboard CLI
   # schema.
   #
   class PartnersAPI < API
@@ -21,10 +21,10 @@ module ShopifyCli
       #
       # #### Raises
       #
-      # * http 404 will raise a ShopifyCli::API::APIRequestNotFoundError
-      # * http 400..499 will raise a ShopifyCli::API::APIRequestClientError
-      # * http 500..599 will raise a ShopifyCli::API::APIRequestServerError
-      # * All other codes will raise ShopifyCli::API::APIRequestUnexpectedError
+      # * http 404 will raise a ShopifyCLI::API::APIRequestNotFoundError
+      # * http 400..499 will raise a ShopifyCLI::API::APIRequestClientError
+      # * http 500..599 will raise a ShopifyCLI::API::APIRequestServerError
+      # * All other codes will raise ShopifyCLI::API::APIRequestUnexpectedError
       #
       # #### Returns
       #
@@ -32,13 +32,13 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   ShopifyCli::PartnersAPI.query(@ctx, 'all_organizations')
+      #   ShopifyCLI::PartnersAPI.query(@ctx, 'all_organizations')
       #
       def query(ctx, query_name, **variables)
         CLI::Kit::Util.begin do
           api_client(ctx).query(query_name, variables: variables)
         end.retry_after(API::APIRequestUnauthorizedError, retries: 1) do
-          ShopifyCli::IdentityAuth.new(ctx: ctx).reauthenticate
+          ShopifyCLI::IdentityAuth.new(ctx: ctx).reauthenticate
         end
       rescue API::APIRequestUnauthorizedError => e
         if (request_info = auth_failure_info(ctx, e))
@@ -46,11 +46,11 @@ module ShopifyCli
         end
         ctx.abort(ctx.message("core.api.error.failed_auth"))
       rescue API::APIRequestNotFoundError
-        ctx.puts(ctx.message("core.partners_api.error.account_not_found", ShopifyCli::TOOL_NAME))
+        ctx.puts(ctx.message("core.partners_api.error.account_not_found", ShopifyCLI::TOOL_NAME))
       end
 
       def partners_url_for(organization_id, api_client_id)
-        if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        if ShopifyCLI::Shopifolk.acting_as_shopify_organization?
           organization_id = "internal"
         end
         "https://#{Environment.partners_domain}/#{organization_id}/apps/#{api_client_id}"
@@ -67,9 +67,9 @@ module ShopifyCli
       end
 
       def access_token(ctx)
-        ShopifyCli::DB.get(:partners_exchange_token) do
+        ShopifyCLI::DB.get(:partners_exchange_token) do
           IdentityAuth.new(ctx: ctx).authenticate
-          ShopifyCli::DB.get(:partners_exchange_token)
+          ShopifyCLI::DB.get(:partners_exchange_token)
         end
       end
 

--- a/lib/shopify_cli/partners_api/organizations.rb
+++ b/lib/shopify_cli/partners_api/organizations.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class PartnersAPI
     class Organizations
       class << self

--- a/lib/shopify_cli/process_supervision.rb
+++ b/lib/shopify_cli/process_supervision.rb
@@ -1,6 +1,6 @@
 require "fileutils"
 
-module ShopifyCli
+module ShopifyCLI
   ##
   # ProcessSupervision wraps a running process spawned by `exec` and keeps track
   # if its `pid` and keeps a log file for it as well
@@ -19,7 +19,7 @@ module ShopifyCli
     class << self
       def run_dir
         # is the directory where the pid and logfile are kept
-        File.join(ShopifyCli.cache_dir, "sv")
+        File.join(ShopifyCLI.cache_dir, "sv")
       end
 
       ##
@@ -36,7 +36,7 @@ module ShopifyCli
       #   will be nil if the process is not running.
       #
       def for_ident(identifier)
-        pid, time = File.read(File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")).split(":")
+        pid, time = File.read(File.join(ShopifyCLI::ProcessSupervision.run_dir, "#{identifier}.pid")).split(":")
         new(identifier, pid: Integer(pid), time: time)
       rescue Errno::ENOENT
         nil
@@ -132,9 +132,9 @@ module ShopifyCli
       @identifier = identifier
       @pid = pid
       @time = time
-      FileUtils.mkdir_p(ShopifyCli::ProcessSupervision.run_dir)
-      @pid_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.pid")
-      @log_path = File.join(ShopifyCli::ProcessSupervision.run_dir, "#{identifier}.log")
+      FileUtils.mkdir_p(ShopifyCLI::ProcessSupervision.run_dir)
+      @pid_path = File.join(ShopifyCLI::ProcessSupervision.run_dir, "#{identifier}.pid")
+      @log_path = File.join(ShopifyCLI::ProcessSupervision.run_dir, "#{identifier}.log")
     end
 
     ##

--- a/lib/shopify_cli/project.rb
+++ b/lib/shopify_cli/project.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::Project captures the current project that the user is working on.
+  # ShopifyCLI::Project captures the current project that the user is working on.
   # This class can be used to fetch and save project environment as well as the
   # project config `.shopify-cli.yml`.
   #
@@ -25,13 +25,13 @@ module ShopifyCli
       #
       # #### Raises
       #
-      # * `ShopifyCli::Abort` - If the cli is not currently in a project directory
+      # * `ShopifyCLI::Abort` - If the cli is not currently in a project directory
       #   then this will be raised with a message implying that the user is not in
       #   a project directory.
       #
       # #### Example
       #
-      #   project = ShopifyCli::Project.current
+      #   project = ShopifyCLI::Project.current
       #
       def current(force_reload: false)
         clear if force_reload
@@ -60,7 +60,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   type = ShopifyCli::Project.current_project_type
+      #   type = ShopifyCLI::Project.current_project_type
       #
       def current_project_type
         return unless has_current?
@@ -81,7 +81,7 @@ module ShopifyCli
       #
       # #### Example
       #
-      #   type = ShopifyCli::Project.current_project_type
+      #   type = ShopifyCLI::Project.current_project_type
       #
       def write(ctx, project_type:, organization_id:, **identifiers)
         require "yaml" # takes 20ms, so deferred as late as possible.
@@ -113,7 +113,7 @@ module ShopifyCli
       def at(dir)
         proj_dir = directory(dir)
         unless proj_dir
-          raise(ShopifyCli::Abort, Context.message("core.project.error.not_in_project"))
+          raise(ShopifyCLI::Abort, Context.message("core.project.error.not_in_project"))
         end
         @at ||= Hash.new { |h, k| h[k] = new(directory: k) }
         @at[proj_dir]
@@ -136,11 +136,11 @@ module ShopifyCli
     #
     # #### Returns
     #
-    # * `env` - An instance of a ShopifyCli::Resources::EnvFile
+    # * `env` - An instance of a ShopifyCLI::Resources::EnvFile
     #
     # #### Example
     #
-    #   ShopifyCli::Project.current.env
+    #   ShopifyCLI::Project.current.env
     #
     def env
       @env ||= begin
@@ -159,18 +159,18 @@ module ShopifyCli
     #
     # #### Raises
     #
-    # * `ShopifyCli::Abort` - If the yml is invalid or poorly formatted
-    # * `ShopifyCli::Abort` - If the yml file does not exist
+    # * `ShopifyCLI::Abort` - If the yml is invalid or poorly formatted
+    # * `ShopifyCLI::Abort` - If the yml file does not exist
     #
     # #### Example
     #
-    #   ShopifyCli::Project.current.config
+    #   ShopifyCLI::Project.current.config
     #
     def config
       @config ||= begin
         config = load_yaml_file(".shopify-cli.yml")
         unless config.is_a?(Hash)
-          raise ShopifyCli::Abort, Context.message("core.yaml.error.not_hash", ".shopify-cli.yml")
+          raise ShopifyCLI::Abort, Context.message("core.yaml.error.not_hash", ".shopify-cli.yml")
         end
 
         # The app_type key was deprecated in favour of project_type, so replace it
@@ -191,12 +191,12 @@ module ShopifyCli
       begin
         YAML.load_file(f)
       rescue Psych::SyntaxError => e
-        raise(ShopifyCli::Abort, Context.message("core.yaml.error.invalid", relative_path, e.message))
+        raise(ShopifyCLI::Abort, Context.message("core.yaml.error.invalid", relative_path, e.message))
       # rescue Errno::EACCES => e
       # TODO
       #   Dev::Helpers::EaccesHandler.diagnose_and_raise(f, e, mode: :read)
       rescue Errno::ENOENT
-        raise ShopifyCli::Abort, Context.message("core.yaml.error.not_found", f)
+        raise ShopifyCLI::Abort, Context.message("core.yaml.error.not_found", f)
       end
     end
   end

--- a/lib/shopify_cli/project_commands.rb
+++ b/lib/shopify_cli/project_commands.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class ProjectCommands < Command
     def call(*)
       @ctx.puts(self.class.help)
@@ -6,9 +6,9 @@ module ShopifyCli
 
     def self.help
       project_type = name.split("::")[0].downcase
-      ShopifyCli::Context.message(
+      ShopifyCLI::Context.message(
         "#{project_type}.help",
-        ShopifyCli::TOOL_NAME,
+        ShopifyCLI::TOOL_NAME,
         subcommand_registry.command_names.join(" | ")
       )
     end

--- a/lib/shopify_cli/project_type.rb
+++ b/lib/shopify_cli/project_type.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class ProjectType
     extend Feature::Set
 
@@ -20,7 +20,7 @@ module ShopifyCli
       end
 
       def load_type(current_type, shallow = false)
-        filepath = File.join(ShopifyCli::ROOT, "lib", "project_types", current_type.to_s, "cli.rb")
+        filepath = File.join(ShopifyCLI::ROOT, "lib", "project_types", current_type.to_s, "cli.rb")
         return unless File.exist?(filepath)
         @shallow_load = shallow
         @current_type = current_type
@@ -31,7 +31,7 @@ module ShopifyCli
       end
 
       def load_all
-        Dir.glob(File.join(ShopifyCli::ROOT, "lib", "project_types", "*", "cli.rb")).map do |filepath|
+        Dir.glob(File.join(ShopifyCLI::ROOT, "lib", "project_types", "*", "cli.rb")).map do |filepath|
           load_type(filepath.split(File::Separator)[-2].to_sym, true)
         end
       end
@@ -41,7 +41,7 @@ module ShopifyCli
       end
 
       def project_filepath(path)
-        File.join(ShopifyCli::PROJECT_TYPES_DIR, project_type.to_s, path)
+        File.join(ShopifyCLI::PROJECT_TYPES_DIR, project_type.to_s, path)
       end
 
       def title(name)
@@ -50,7 +50,7 @@ module ShopifyCli
 
       def register_task(task, name)
         return if project_load_shallow
-        ShopifyCli::Tasks.register(task, name)
+        ShopifyCLI::Tasks.register(task, name)
       end
 
       def register_messages(messages)

--- a/lib/shopify_cli/resolve_constant.rb
+++ b/lib/shopify_cli/resolve_constant.rb
@@ -4,13 +4,13 @@
 # are resolved relative to `Kernal`, but the top-level namespace is
 # configurable:
 #
-#    ShopifyCli::Resolve.call(:object).value # => Object
-#    ShopifyCli::Resolve.call('minitest/test').value # => MiniTest::Test
-#    ShopifyCli::Resolve.call(:test, namespace: MiniTest) # => MiniTest::Test
+#    ShopifyCLI::Resolve.call(:object).value # => Object
+#    ShopifyCLI::Resolve.call('minitest/test').value # => MiniTest::Test
+#    ShopifyCLI::Resolve.call(:test, namespace: MiniTest) # => MiniTest::Test
 #
-module ShopifyCli
+module ShopifyCLI
   class ResolveConstant
-    include ShopifyCli::MethodObject
+    include ShopifyCLI::MethodObject
     property! :namespace, accepts: ->(ns) { ns.respond_to?(:const_get) }, default: -> { Kernel }
 
     def call(name)

--- a/lib/shopify_cli/resources.rb
+++ b/lib/shopify_cli/resources.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   module Resources
     autoload :EnvFile, "shopify_cli/resources/env_file"
   end

--- a/lib/shopify_cli/resources/env_file.rb
+++ b/lib/shopify_cli/resources/env_file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Resources
     class EnvFile
       include SmartProperties

--- a/lib/shopify_cli/result.rb
+++ b/lib/shopify_cli/result.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   ##
   # This module defines two containers for wrapping the result of an action. One
   # for signifying the successful execution of an action and one for signifying
@@ -261,8 +261,8 @@ module ShopifyCli
       end
 
       ##
-      # raises an `ShopifyCli::Result::UnexpectedError` as a
-      # `ShopifyCli::Result::Failure` does not carry a success value.
+      # raises an `ShopifyCLI::Result::UnexpectedError` as a
+      # `ShopifyCLI::Result::Failure` does not carry a success value.
       #
       def value
         raise UnexpectedFailure
@@ -342,7 +342,7 @@ module ShopifyCli
     end
 
     ##
-    # wraps the given value into a `ShopifyCli::Result::Success` container
+    # wraps the given value into a `ShopifyCLI::Result::Success` container
     #
     # #### Parameters
     #
@@ -353,7 +353,7 @@ module ShopifyCli
     end
 
     ##
-    # wraps the given value into a `ShopifyCli::Result::Failure` container
+    # wraps the given value into a `ShopifyCLI::Result::Failure` container
     #
     # #### Parameters
     #
@@ -367,8 +367,8 @@ module ShopifyCli
     # takes either a value or a block and chooses the appropriate result
     # container based on the type of the value or the type of the block's return
     # value. If the type is an exception, it is wrapped in a
-    # `ShopifyCli::Result::Failure` and otherwise in a
-    # `ShopifyCli::Result::Success`. If a block was provided instead of value, a
+    # `ShopifyCLI::Result::Failure` and otherwise in a
+    # `ShopifyCLI::Result::Success`. If a block was provided instead of value, a
     # `Proc` is returned and the result wrapping doesn't occur until the block
     # is invoked.
     #
@@ -384,12 +384,12 @@ module ShopifyCli
     #
     # #### Examples
     #
-    #   Result.wrap(1) # => ShopifyCli::Result::Success
-    #   Result.wrap(RuntimeError.new) # => ShopifyCli::Result::Failure
+    #   Result.wrap(1) # => ShopifyCLI::Result::Success
+    #   Result.wrap(RuntimeError.new) # => ShopifyCLI::Result::Failure
     #
     #   Result.wrap { 1 } # => Proc
-    #   Result.wrap { 1 }.call # => ShopifyCli::Result::Success
-    #   Result.wrap { raise }.call # => ShopifyCli::Result::Failure
+    #   Result.wrap { 1 }.call # => ShopifyCLI::Result::Success
+    #   Result.wrap { raise }.call # => ShopifyCLI::Result::Failure
     #
     #   Result.wrap { |s| s.upcase }.call("hello").tap do |result|
     #     result # => Result::Success

--- a/lib/shopify_cli/shopifolk.rb
+++ b/lib/shopify_cli/shopifolk.rb
@@ -1,6 +1,6 @@
-module ShopifyCli
+module ShopifyCLI
   ##
-  # ShopifyCli::Shopifolk contains the logic to determine if the user appears to be a Shopify staff
+  # ShopifyCLI::Shopifolk contains the logic to determine if the user appears to be a Shopify staff
   #
   # The Shopifolk Feature flag will persist between runs so if the flag is enabled or disabled,
   # it will still be in that same state until the next class invocation.
@@ -20,10 +20,10 @@ module ShopifyCli
       #
       # #### Example
       #
-      #     ShopifyCli::Shopifolk.check
+      #     ShopifyCLI::Shopifolk.check
       #
       def check
-        ShopifyCli::Shopifolk.new.shopifolk?
+        ShopifyCLI::Shopifolk.new.shopifolk?
       end
 
       def act_as_shopify_organization
@@ -52,10 +52,10 @@ module ShopifyCli
       return true if Feature.enabled?(FEATURE_NAME)
 
       if shopifolk_by_gcloud? && shopifolk_by_dev?
-        ShopifyCli::Feature.enable(FEATURE_NAME)
+        ShopifyCLI::Feature.enable(FEATURE_NAME)
         true
       else
-        ShopifyCli::Feature.disable(FEATURE_NAME)
+        ShopifyCLI::Feature.disable(FEATURE_NAME)
         false
       end
     end

--- a/lib/shopify_cli/sub_command.rb
+++ b/lib/shopify_cli/sub_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class SubCommand < Command
     class << self
       def call(args, command_name, parent_command)

--- a/lib/shopify_cli/task.rb
+++ b/lib/shopify_cli/task.rb
@@ -1,6 +1,6 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   class Task
     def self.call(*args, **kwargs)
       task = new

--- a/lib/shopify_cli/tasks.rb
+++ b/lib/shopify_cli/tasks.rb
@@ -1,6 +1,6 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class TaskRegistry
       def initialize

--- a/lib/shopify_cli/tasks/confirm_store.rb
+++ b/lib/shopify_cli/tasks/confirm_store.rb
@@ -1,11 +1,11 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class ConfirmStore < ShopifyCli::Task
+    class ConfirmStore < ShopifyCLI::Task
       def call(ctx)
         @ctx = ctx
-        store = ShopifyCli::AdminAPI.get_shop_or_abort(ctx)
+        store = ShopifyCLI::AdminAPI.get_shop_or_abort(ctx)
         if CLI::UI::Prompt.confirm(ctx.message("core.tasks.confirm_store.prompt", store), default: false)
           ctx.puts(ctx.message("core.tasks.confirm_store.confirmation", store))
         else

--- a/lib/shopify_cli/tasks/create_api_client.rb
+++ b/lib/shopify_cli/tasks/create_api_client.rb
@@ -1,13 +1,13 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class CreateApiClient < ShopifyCli::Task
+    class CreateApiClient < ShopifyCLI::Task
       VALID_APP_TYPES = %w(public custom)
       DEFAULT_APP_URL = "https://shopify.github.io/shopify-cli/help/start-app/"
 
       def call(ctx, org_id:, title:, type:)
-        resp = ShopifyCli::PartnersAPI.query(
+        resp = ShopifyCLI::PartnersAPI.query(
           ctx,
           "create_app",
           org: org_id.to_i,
@@ -31,7 +31,7 @@ module ShopifyCli
           ctx.abort(user_errors.map { |err| "#{err["field"]} #{err["message"]}" }.join(", "))
         end
 
-        ShopifyCli::Core::Monorail.metadata[:api_key] = resp.dig("data", "appCreate", "app", "apiKey")
+        ShopifyCLI::Core::Monorail.metadata[:api_key] = resp.dig("data", "appCreate", "app", "apiKey")
 
         resp.dig("data", "appCreate", "app")
       end

--- a/lib/shopify_cli/tasks/ensure_authenticated.rb
+++ b/lib/shopify_cli/tasks/ensure_authenticated.rb
@@ -1,12 +1,12 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class EnsureAuthenticated < ShopifyCli::Task
+    class EnsureAuthenticated < ShopifyCLI::Task
       def call(ctx)
         ctx.abort(
-          ctx.message("core.identity_auth.login_prompt", ShopifyCli::TOOL_NAME)
-        ) unless ShopifyCli::IdentityAuth::IDENTITY_ACCESS_TOKENS.all? { |key| ShopifyCli::DB.exists?(key) }
+          ctx.message("core.identity_auth.login_prompt", ShopifyCLI::TOOL_NAME)
+        ) unless ShopifyCLI::IdentityAuth::IDENTITY_ACCESS_TOKENS.all? { |key| ShopifyCLI::DB.exists?(key) }
       end
     end
   end

--- a/lib/shopify_cli/tasks/ensure_dev_store.rb
+++ b/lib/shopify_cli/tasks/ensure_dev_store.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class EnsureDevStore < ShopifyCli::Task
+    class EnsureDevStore < ShopifyCLI::Task
       def call(ctx)
         @ctx = ctx
         return ctx.abort(ctx.message(
@@ -12,7 +12,7 @@ module ShopifyCli
         return unless CLI::UI::Prompt.confirm(
           ctx.message("core.tasks.ensure_dev_store.convert_to_dev_store", project.env.shop)
         )
-        ShopifyCli::PartnersAPI.query(ctx, "convert_dev_to_test_store", input: {
+        ShopifyCLI::PartnersAPI.query(ctx, "convert_dev_to_test_store", input: {
           organizationID: shop["orgID"].to_i,
           shopId: shop["shopId"],
         })
@@ -22,13 +22,13 @@ module ShopifyCli
       private
 
       def project
-        @project ||= ShopifyCli::Project.current
+        @project ||= ShopifyCLI::Project.current
       end
 
       def shop
         @shop ||= begin
           current_domain = project.env.shop
-          ShopifyCli::PartnersAPI::Organizations.fetch_all(@ctx).map do |org|
+          ShopifyCLI::PartnersAPI::Organizations.fetch_all(@ctx).map do |org|
             org["stores"].find do |store|
               store["orgID"] = org["id"]
               store["shopDomain"] == current_domain

--- a/lib/shopify_cli/tasks/ensure_env.rb
+++ b/lib/shopify_cli/tasks/ensure_env.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class EnsureEnv < ShopifyCli::Task
+    class EnsureEnv < ShopifyCLI::Task
       def call(ctx, regenerate: false, required: [:api_key, :secret])
         @ctx = ctx
         env_data =
@@ -50,7 +50,7 @@ module ShopifyCli
             handler.option(@ctx.message("core.tasks.ensure_env.app_type.select_public")) { "public" }
             handler.option(@ctx.message("core.tasks.ensure_env.app_type.select_custom")) { "custom" }
           end
-          ShopifyCli::Tasks::CreateApiClient.call(@ctx, org_id: org_id, title: title, type: type)
+          ShopifyCLI::Tasks::CreateApiClient.call(@ctx, org_id: org_id, title: title, type: type)
         else
           CLI::UI::Prompt.ask(@ctx.message("core.tasks.ensure_env.app_select")) do |handler|
             apps.each { |app| handler.option(app["title"]) { app } }

--- a/lib/shopify_cli/tasks/ensure_loopback_url.rb
+++ b/lib/shopify_cli/tasks/ensure_loopback_url.rb
@@ -1,16 +1,16 @@
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class EnsureLoopbackURL < ShopifyCli::Task
+    class EnsureLoopbackURL < ShopifyCLI::Task
       def call(ctx)
         @ctx = ctx
         api_key = Project.current.env.api_key
-        result = ShopifyCli::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
+        result = ShopifyCLI::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
         loopback = IdentityAuth::REDIRECT_HOST
         app = result["data"]["app"]
         urls = app["redirectUrlWhitelist"]
         if urls.grep(/#{loopback}/).empty?
           with_loopback = urls.push(loopback)
-          ShopifyCli::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
+          ShopifyCLI::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
             redirectUrlWhitelist: with_loopback, apiKey: api_key
           })
         end

--- a/lib/shopify_cli/tasks/ensure_project_type.rb
+++ b/lib/shopify_cli/tasks/ensure_project_type.rb
@@ -1,10 +1,10 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class EnsureProjectType < ShopifyCli::Task
+    class EnsureProjectType < ShopifyCLI::Task
       def call(ctx, project_type)
-        return true if project_type.to_sym == ShopifyCli::Project.current_project_type
+        return true if project_type.to_sym == ShopifyCLI::Project.current_project_type
         ctx.abort(ctx.message("core.tasks.ensure_project_type.wrong_project_type", project_type))
       end
     end

--- a/lib/shopify_cli/tasks/select_org_and_shop.rb
+++ b/lib/shopify_cli/tasks/select_org_and_shop.rb
@@ -1,8 +1,8 @@
 require "shopify_cli"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class SelectOrgAndShop < ShopifyCli::Task
+    class SelectOrgAndShop < ShopifyCLI::Task
       attr_reader :ctx
 
       def call(ctx, organization_id: nil, shop_domain: nil)
@@ -12,7 +12,7 @@ module ShopifyCli
         unless Shopifolk.acting_as_shopify_organization?
           shop_domain ||= get_shop_domain(org)
         end
-        ShopifyCli::Core::Monorail.metadata[:organization_id] = org["id"].to_i
+        ShopifyCLI::Core::Monorail.metadata[:organization_id] = org["id"].to_i
         response(org["id"].to_i, shop_domain)
       end
 
@@ -25,20 +25,20 @@ module ShopifyCli
       end
 
       def organizations
-        @organizations ||= ShopifyCli::PartnersAPI::Organizations.fetch_all(ctx)
+        @organizations ||= ShopifyCLI::PartnersAPI::Organizations.fetch_all(ctx)
       end
 
       def get_organization(organization_id)
         @organization ||= if !organization_id.nil?
-          org = ShopifyCli::PartnersAPI::Organizations.fetch(ctx, id: organization_id)
+          org = ShopifyCLI::PartnersAPI::Organizations.fetch(ctx, id: organization_id)
           if org.nil?
-            ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCli::TOOL_NAME))
+            ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCLI::TOOL_NAME))
             ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.organization_not_found"))
           end
           org
         elsif organizations.count == 0
           if Shopifolk.acting_as_shopify_organization?
-            ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.shopifolk_notice", ShopifyCli::TOOL_NAME))
+            ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.shopifolk_notice", ShopifyCLI::TOOL_NAME))
           else
             ctx.abort(ctx.message("core.tasks.select_org_and_shop.error.no_organizations"))
           end
@@ -64,7 +64,7 @@ module ShopifyCli
         if valid_stores.count == 0
           ctx.puts(ctx.message("core.tasks.select_org_and_shop.error.no_development_stores"))
           ctx.puts(ctx.message("core.tasks.select_org_and_shop.create_store", organization["id"]))
-          ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCli::TOOL_NAME))
+          ctx.puts(ctx.message("core.tasks.select_org_and_shop.authentication_issue", ShopifyCLI::TOOL_NAME))
         elsif valid_stores.count == 1
           domain = valid_stores.first["shopDomain"]
           ctx.puts(ctx.message("core.tasks.select_org_and_shop.development_store", domain))

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -1,24 +1,24 @@
-module ShopifyCli
+module ShopifyCLI
   module Tasks
-    class UpdateDashboardURLS < ShopifyCli::Task
+    class UpdateDashboardURLS < ShopifyCLI::Task
       NGROK_REGEX = /https:\/\/([a-z0-9\-]+\.ngrok\.io)(.*)/
 
       def call(ctx, url:, callback_url:)
         @ctx = ctx
-        project = ShopifyCli::Project.current
+        project = ShopifyCLI::Project.current
         api_key = project.env.api_key
-        result = ShopifyCli::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
+        result = ShopifyCLI::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
         app = result["data"]["app"]
         consent = check_application_url(app["applicationUrl"], url)
         constructed_urls = construct_redirect_urls(app["redirectUrlWhitelist"], url, callback_url)
         return if url == app["applicationUrl"]
-        ShopifyCli::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
+        ShopifyCLI::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
           applicationUrl: consent ? url : app["applicationUrl"],
           redirectUrlWhitelist: constructed_urls, apiKey: api_key
         })
         @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.updated"))
       rescue
-        @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.update_error", ShopifyCli::TOOL_NAME))
+        @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.update_error", ShopifyCLI::TOOL_NAME))
         raise
       end
 

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -14,7 +14,7 @@ require_relative "dev_server/certificate_manager"
 
 require "pathname"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class << self
@@ -80,8 +80,8 @@ module ShopifyCli
           )
           watcher.stop
 
-        rescue ShopifyCli::API::APIRequestForbiddenError,
-               ShopifyCli::API::APIRequestUnauthorizedError
+        rescue ShopifyCLI::API::APIRequestForbiddenError,
+               ShopifyCLI::API::APIRequestUnauthorizedError
           @ctx.abort("You are not authorized to edit themes on #{theme.shop}.\n" \
                      "Make sure you are a user of that store, and allowed to edit themes.")
         end

--- a/lib/shopify_cli/theme/dev_server/certificate_manager.rb
+++ b/lib/shopify_cli/theme/dev_server/certificate_manager.rb
@@ -2,7 +2,7 @@
 
 require "openssl"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class CertificateManager
@@ -19,13 +19,13 @@ module ShopifyCli
         end
 
         def find_or_create_certificates!
-          @private_key = if (private_key_pem = ShopifyCli::DB.get(:ssl_private_key))
+          @private_key = if (private_key_pem = ShopifyCLI::DB.get(:ssl_private_key))
             OpenSSL::PKey::RSA.new(private_key_pem)
           else
             OpenSSL::PKey::RSA.new(2048)
           end
 
-          @certificate = if (certificate_pem = ShopifyCli::DB.get(:ssl_certificate))
+          @certificate = if (certificate_pem = ShopifyCLI::DB.get(:ssl_certificate))
             OpenSSL::X509::Certificate.new(certificate_pem)
           else
             x509_certificate = build_x509_certificate
@@ -35,8 +35,8 @@ module ShopifyCli
             x509_certificate
           end
 
-          ShopifyCli::DB.set(ssl_certificate: certificate.to_pem)
-          ShopifyCli::DB.set(ssl_private_key: private_key.to_pem)
+          ShopifyCLI::DB.set(ssl_certificate: certificate.to_pem)
+          ShopifyCLI::DB.set(ssl_private_key: private_key.to_pem)
         end
 
         private

--- a/lib/shopify_cli/theme/dev_server/header_hash.rb
+++ b/lib/shopify_cli/theme/dev_server/header_hash.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       # Based on Rack::HeaderHash

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class HotReload

--- a/lib/shopify_cli/theme/dev_server/local_assets.rb
+++ b/lib/shopify_cli/theme/dev_server/local_assets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class LocalAssets

--- a/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -3,7 +3,7 @@ require "net/http"
 require "stringio"
 require "time"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       HOP_BY_HOP_HEADERS = [
@@ -79,7 +79,7 @@ module ShopifyCli
         end
 
         def bearer_token
-          ShopifyCli::DB.get(:storefront_renderer_production_exchange_token) ||
+          ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token) ||
             raise(KeyError, "storefront_renderer_production_exchange_token missing")
         end
 

--- a/lib/shopify_cli/theme/dev_server/sse.rb
+++ b/lib/shopify_cli/theme/dev_server/sse.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "thread"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       # Server-Sent events implementation for Rack.

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -2,7 +2,7 @@
 require "listen"
 require "observer"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       # Watches for file changes and publish events to the theme

--- a/lib/shopify_cli/theme/dev_server/web_server.rb
+++ b/lib/shopify_cli/theme/dev_server/web_server.rb
@@ -3,7 +3,7 @@
 require "webrick"
 require "stringio"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       # WEBrick will sometimes cause a fatal deadlock error on shutdown.

--- a/lib/shopify_cli/theme/development_theme.rb
+++ b/lib/shopify_cli/theme/development_theme.rb
@@ -4,17 +4,17 @@ require_relative "theme"
 require "socket"
 require "securerandom"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     API_NAME_LIMIT = 50
 
     class DevelopmentTheme < Theme
       def id
-        ShopifyCli::DB.get(:development_theme_id)
+        ShopifyCLI::DB.get(:development_theme_id)
       end
 
       def name
-        existing_name = ShopifyCli::DB.get(:development_theme_name)
+        existing_name = ShopifyCLI::DB.get(:development_theme_name)
         # Up to version 2.3.0 (included) generated names stored locally
         # could have more than 50 characters and the API rejected them.
         # This code ensures we update the name for those users to ensure
@@ -36,27 +36,27 @@ module ShopifyCli
         else
           create
           @ctx.debug("Created temporary development theme: #{@id}")
-          ShopifyCli::DB.set(development_theme_id: @id)
+          ShopifyCLI::DB.set(development_theme_id: @id)
         end
       end
 
       def exists?
         return false unless id
 
-        ShopifyCli::AdminAPI.rest_request(
+        ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: shop,
           path: "themes/#{id}.json",
           api_version: "unstable",
         )
-      rescue ShopifyCli::API::APIRequestNotFoundError
+      rescue ShopifyCLI::API::APIRequestNotFoundError
         false
       end
 
       def delete
         super if exists?
-        ShopifyCli::DB.del(:development_theme_id) if ShopifyCli::DB.exists?(:development_theme_id)
-        ShopifyCli::DB.del(:development_theme_name) if ShopifyCli::DB.exists?(:development_theme_name)
+        ShopifyCLI::DB.del(:development_theme_id) if ShopifyCLI::DB.exists?(:development_theme_id)
+        ShopifyCLI::DB.del(:development_theme_name) if ShopifyCLI::DB.exists?(:development_theme_name)
       end
 
       def self.delete(ctx)
@@ -74,7 +74,7 @@ module ShopifyCli
         identifier = "#{hash}-#{hostname[0, hostname_character_limit]}"
         theme_name = "Development (#{identifier})"
 
-        ShopifyCli::DB.set(development_theme_name: theme_name)
+        ShopifyCLI::DB.set(development_theme_name: theme_name)
 
         theme_name
       end

--- a/lib/shopify_cli/theme/file.rb
+++ b/lib/shopify_cli/theme/file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "mime_type"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class File < Struct.new(:path)
       attr_reader :relative_path

--- a/lib/shopify_cli/theme/ignore_filter.rb
+++ b/lib/shopify_cli/theme/ignore_filter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class IgnoreFilter
       FILE = ".shopifyignore"

--- a/lib/shopify_cli/theme/mime_type.rb
+++ b/lib/shopify_cli/theme/mime_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "webrick"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class MimeType < Struct.new(:name)
       MIME_TYPES = WEBrick::HTTPUtils::DefaultMimeTypes.merge(

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -3,7 +3,7 @@ require "thread"
 require "json"
 require "base64"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class Syncer
       class Operation < Struct.new(:method, :file)
@@ -80,7 +80,7 @@ module ShopifyCli
       end
 
       def fetch_checksums!
-        _status, response = ShopifyCli::AdminAPI.rest_request(
+        _status, response = ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -211,7 +211,7 @@ module ShopifyCli
           used, total = limit.split("/").map(&:to_i)
           backoff_if_near_limit!(used, total)
         end
-      rescue ShopifyCli::API::APIRequestError => e
+      rescue ShopifyCLI::API::APIRequestError => e
         report_error(
           "{{red:ERROR}} {{blue:#{operation}}}:\n  " +
           parse_api_errors(e).join("\n  ")
@@ -228,7 +228,7 @@ module ShopifyCli
           asset[:attachment] = Base64.encode64(file.read)
         end
 
-        _status, body, response = ShopifyCli::AdminAPI.rest_request(
+        _status, body, response = ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -243,7 +243,7 @@ module ShopifyCli
       end
 
       def get(file)
-        _status, body, response = ShopifyCli::AdminAPI.rest_request(
+        _status, body, response = ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -265,7 +265,7 @@ module ShopifyCli
       end
 
       def delete(file)
-        _status, _body, response = ShopifyCli::AdminAPI.rest_request(
+        _status, _body, response = ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -4,7 +4,7 @@ require_relative "file"
 require "pathname"
 require "time"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class InvalidThemeRole < StandardError; end
 
@@ -101,7 +101,7 @@ module ShopifyCli
       def create
         raise InvalidThemeRole, "Can't create live theme. Use publish." if live?
 
-        _status, body = ShopifyCli::AdminAPI.rest_request(
+        _status, body = ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: shop,
           path: "themes.json",
@@ -144,11 +144,11 @@ module ShopifyCli
       end
 
       def current_development?
-        development? && id == ShopifyCli::DB.get(:development_theme_id)
+        development? && id == ShopifyCLI::DB.get(:development_theme_id)
       end
 
       def foreign_development?
-        development? && id != ShopifyCli::DB.get(:development_theme_id)
+        development? && id != ShopifyCLI::DB.get(:development_theme_id)
       end
 
       def to_h

--- a/lib/shopify_cli/transform_data_structure.rb
+++ b/lib/shopify_cli/transform_data_structure.rb
@@ -1,5 +1,5 @@
 
-module ShopifyCli
+module ShopifyCLI
   ##
   # `TransformDataStructure` helps to standardize data structure access. It
   # traverses nested data structures and can convert
@@ -22,13 +22,13 @@ module ShopifyCli
   # Since `TransformDataStructure` is a method object, it can easily be chained:
   #
   #    require 'open-uri'
-  #    ShopifyCli::Result
+  #    ShopifyCLI::Result
   #      .call { open("https://jsonplaceholder.typicode.com/todos/1") }
   #      .map(&TransformDataStructure.new(symbolize_keys: true, underscore_keys: true))
   #      .value # => { id: 1, user_id: 1, ... }
   #
   class TransformDataStructure
-    include ShopifyCli::MethodObject
+    include ShopifyCLI::MethodObject
 
     class << self
       private
@@ -53,7 +53,7 @@ module ShopifyCli
           result[transform_key(key)] = call(value).value
         end
       else
-        ShopifyCli::Result.success(object)
+        ShopifyCLI::Result.success(object)
       end
     end
 

--- a/lib/shopify_cli/tunnel.rb
+++ b/lib/shopify_cli/tunnel.rb
@@ -4,7 +4,7 @@ require "shopify_cli"
 require "forwardable"
 require "uri"
 
-module ShopifyCli
+module ShopifyCLI
   ##
   # Wraps around ngrok functionality to allow you to spawn a ngrok proccess in the
   # background and stop the process when you need to. It also allows control over
@@ -39,8 +39,8 @@ module ShopifyCli
     # * `ctx` - running context from your command
     #
     def stop(ctx)
-      if ShopifyCli::ProcessSupervision.running?(:ngrok)
-        if ShopifyCli::ProcessSupervision.stop(:ngrok)
+      if ShopifyCLI::ProcessSupervision.running?(:ngrok)
+        if ShopifyCLI::ProcessSupervision.stop(:ngrok)
           ctx.puts(ctx.message("core.tunnel.stopped"))
         else
           ctx.abort(ctx.message("core.tunnel.error.stop"))
@@ -75,7 +75,7 @@ module ShopifyCli
         end
         ctx.puts(ctx.message("core.tunnel.start", url))
         ctx.puts(ctx.message("core.tunnel.will_timeout", seconds_to_hm(seconds_remaining)))
-        ctx.puts(ctx.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
+        ctx.puts(ctx.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
       end
       url
     end
@@ -91,7 +91,7 @@ module ShopifyCli
     #
     def auth(ctx, token)
       install(ctx)
-      ctx.system(File.join(ShopifyCli.cache_dir, "ngrok"), "authtoken", token)
+      ctx.system(File.join(ShopifyCLI.cache_dir, "ngrok"), "authtoken", token)
     end
 
     ##
@@ -145,28 +145,28 @@ module ShopifyCli
 
     def install(ctx)
       ngrok = "ngrok#{ctx.executable_file_extension}"
-      return if File.exist?(File.join(ShopifyCli.cache_dir, ngrok))
+      return if File.exist?(File.join(ShopifyCLI.cache_dir, ngrok))
       check_prereq_command(ctx, "curl")
       check_prereq_command(ctx, ctx.linux? ? "unzip" : "tar")
       spinner = CLI::UI::SpinGroup.new
       spinner.add(ctx.message("core.tunnel.installing")) do
-        zip_dest = File.join(ShopifyCli.cache_dir, "ngrok.zip")
+        zip_dest = File.join(ShopifyCLI.cache_dir, "ngrok.zip")
         unless File.exist?(zip_dest)
-          ctx.system("curl", "-o", zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCli.cache_dir)
+          ctx.system("curl", "-o", zip_dest, DOWNLOAD_URLS[ctx.os], chdir: ShopifyCLI.cache_dir)
         end
         args = if ctx.linux?
           %W(unzip -u #{zip_dest})
         else
           %W(tar -xf #{zip_dest})
         end
-        ctx.system(*args, chdir: ShopifyCli.cache_dir)
+        ctx.system(*args, chdir: ShopifyCLI.cache_dir)
         ctx.rm(zip_dest)
       end
       spinner.wait
 
       # final check to see if ngrok is accessible
-      unless File.exist?(File.join(ShopifyCli.cache_dir, ngrok))
-        ctx.abort(ctx.message("core.tunnel.error.ngrok", ngrok, ShopifyCli.cache_dir))
+      unless File.exist?(File.join(ShopifyCLI.cache_dir, ngrok))
+        ctx.abort(ctx.message("core.tunnel.error.ngrok", ngrok, ShopifyCLI.cache_dir))
       end
     end
 
@@ -178,7 +178,7 @@ module ShopifyCli
     end
 
     def ngrok_command(port)
-      "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug #{port}"
+      "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug #{port}"
     end
 
     def seconds_to_hm(seconds)
@@ -186,14 +186,14 @@ module ShopifyCli
     end
 
     def start_ngrok(ctx, port)
-      process = ShopifyCli::ProcessSupervision.start(:ngrok, ngrok_command(port))
+      process = ShopifyCLI::ProcessSupervision.start(:ngrok, ngrok_command(port))
       log = fetch_url(ctx, process.log_path)
       seconds_remaining = (process.time.to_i + log.timeout) - Time.now.to_i
       [log.url, log.account, seconds_remaining]
     end
 
     def restart_ngrok(ctx, port)
-      unless ShopifyCli::ProcessSupervision.stop(:ngrok)
+      unless ShopifyCLI::ProcessSupervision.stop(:ngrok)
         ctx.abort(ctx.message("core.tunnel.error.stop"))
       end
       start_ngrok(ctx, port)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
-module ShopifyCli
+module ShopifyCLI
   VERSION = "2.4.0"
 end

--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -6,7 +6,7 @@
 require "formula"
 require "fileutils"
 
-class ShopifyCli < Formula
+class ShopifyCLI < Formula
   module RubyBin
     def ruby_bin
       Formula["ruby"].opt_bin

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -2,7 +2,7 @@ require_relative "lib/shopify_cli/version"
 
 Gem::Specification.new do |spec|
   spec.name = "shopify-cli"
-  spec.version = ShopifyCli::VERSION
+  spec.version = ShopifyCLI::VERSION
   spec.authors = ["Shopify"]
   spec.email = ["dev-tools-education@shopify.com"]
   spec.license = "MIT"

--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -7,7 +7,7 @@ module Minitest
 
   class Test
     FIXTURE_DIR = File.expand_path("fixtures", File.dirname(__FILE__))
-    CONFIG_FILE = CLI::Kit::Config.new(tool_name: ShopifyCli::TOOL_NAME).file
+    CONFIG_FILE = CLI::Kit::Config.new(tool_name: ShopifyCLI::TOOL_NAME).file
 
     include TestHelpers::Project
 
@@ -17,7 +17,7 @@ module Minitest
         @config_sha_before = Digest::SHA256.hexdigest(File.read(CONFIG_FILE))
       end
       project_context("project")
-      ::ShopifyCli::Project.clear
+      ::ShopifyCLI::Project.clear
       super
     end
 
@@ -53,7 +53,7 @@ module Minitest
       stub_new_version_check
 
       new_cmd = split_cmd ? cmd.split : cmd
-      ShopifyCli::Core::EntryPoint.call(new_cmd, @context)
+      ShopifyCLI::Core::EntryPoint.call(new_cmd, @context)
     end
 
     def capture_io(&block)
@@ -96,18 +96,18 @@ module Minitest
     private
 
     def stub_prompt_for_cli_updates
-      ShopifyCli::Config.stubs(:get_section).with("autoupdate").returns("enabled" => "true")
+      ShopifyCLI::Config.stubs(:get_section).with("autoupdate").returns("enabled" => "true")
     end
 
     def stub_new_version_check
-      stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
+      stub_request(:get, ShopifyCLI::Context::GEM_LATEST_URI)
         .with(headers: {
           "Accept" => "*/*",
           "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
           "Host" => "rubygems.org",
           "User-Agent" => "Ruby",
         })
-        .to_return(status: 200, body: "{\"version\":\"#{ShopifyCli::VERSION}\"}", headers: {})
+        .to_return(status: 200, body: "{\"version\":\"#{ShopifyCLI::VERSION}\"}", headers: {})
     end
   end
 end

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -9,8 +9,8 @@ module Extension
       include TestHelpers::FakeUI
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::ProjectType.load_type(:extension)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
       end
 
       def test_is_a_hidden_command
@@ -23,7 +23,7 @@ module Extension
 
       def test_uses_js_system_to_call_yarn_or_npm_commands
         stub_project
-        ShopifyCli::JsSystem.any_instance
+        ShopifyCLI::JsSystem.any_instance
           .expects(:call)
           .with(yarn: Command::Build::YARN_BUILD_COMMAND, npm: Command::Build::NPM_BUILD_COMMAND)
           .returns(true)
@@ -34,7 +34,7 @@ module Extension
 
       def test_aborts_and_informs_the_user_when_build_fails
         stub_project
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(false)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(false)
         @context.expects(:abort).with(@context.message("build.build_failure_message"))
 
         run_build
@@ -43,8 +43,8 @@ module Extension
       def test_runs_new_flow_if_development_server_supported
         type = "checkout_ui_extension"
         stub_project(type)
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
+        ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
 
         extension_command = Tasks::RunExtensionCommand.new(type: type, command: "build")
         Extension::Tasks::RunExtensionCommand.expects(:new).returns(extension_command) do |mock|
@@ -78,7 +78,7 @@ module Extension
 
       def stub_project(type = "TEST")
         project = ExtensionTestHelpers.fake_extension_project(type_identifier: type)
-        ShopifyCli::Project.stubs(:current).returns(project)
+        ShopifyCLI::Project.stubs(:current).returns(project)
       end
 
       def extension

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -12,7 +12,7 @@ module Extension
         @name = "My Ext"
         @directory_name = "my_ext"
 
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         ExtensionTestHelpers.fake_extension_project(with_mocks: true)
         @specification_handler = ExtensionTestHelpers.test_specification_handler
@@ -20,7 +20,7 @@ module Extension
         @app = Models::App.new(title: "Fake", api_key: "1234", secret: "4567", business_name: "Fake Business")
         stub_get_app(api_key: "1234", app: @app)
 
-        ShopifyCli::Tasks::EnsureAuthenticated.stubs(:call)
+        ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
       end
 
       def test_prints_help
@@ -29,13 +29,13 @@ module Extension
       end
 
       def test_create_aborts_if_the_directory_already_exists
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
-        ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(false)
+        ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
 
         Dir.expects(:exist?).with(@directory_name).returns(true).once
         Models::SpecificationHandlers::Default.any_instance.expects(:create).never
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           run_create(%W(extension --name=#{@name} --type=#{@specification_handler.identifier}
                         --api-key=#{@app.api_key}))
         end
@@ -46,8 +46,8 @@ module Extension
       end
 
       def test_runs_type_create_and_writes_project_files
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
-        ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(false)
+        ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
 
         Dir.expects(:exist?).with(@directory_name).returns(false).once
         Models::SpecificationHandlers::Default
@@ -71,8 +71,8 @@ module Extension
       end
 
       def test_does_not_create_project_files_and_outputs_try_again_message_if_type_create_failed
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
-        ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(false)
+        ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
 
         Dir.expects(:exist?).with(@directory_name).returns(false).once
         Models::SpecificationHandlers::Default

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -7,7 +7,7 @@ module Extension
     class ExtensionCommandTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         @project = ExtensionTestHelpers.fake_extension_project(with_mocks: true)
         @command = Extension::Command::ExtensionCommand.new
       end
@@ -27,7 +27,7 @@ module Extension
         unknown_type = "unknown_type"
         ExtensionTestHelpers.fake_extension_project(with_mocks: true, type_identifier: unknown_type)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.specification_handler.features }
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) { @command.specification_handler.features }
 
         assert_message_output(io: io, expected_content: [
           @context.message("errors.unknown_type", unknown_type),

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -9,8 +9,8 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::ProjectType.load_type(:extension)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
         @project = ExtensionTestHelpers.fake_extension_project(with_mocks: true)
         @version = Models::Version.new(
           registration_id: 42,
@@ -29,7 +29,7 @@ module Extension
 
         Command::Register.any_instance.expects(:call).once
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         run_push
@@ -40,7 +40,7 @@ module Extension
 
         Command::Register.any_instance.expects(:call).never
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         run_push
@@ -48,7 +48,7 @@ module Extension
 
       def test_runs_build_command
         Command::Build.any_instance.expects(:call).once
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         run_push
@@ -57,7 +57,7 @@ module Extension
       def test_updates_the_extensions_draft_version
         specification_handler = ExtensionTestHelpers.test_specification_handler
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.expects(:call)
           .with(
             context: @context,
@@ -76,7 +76,7 @@ module Extension
         @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
         @version.location = "https://www.fakeurl.com"
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         io = capture_io { run_push }
@@ -94,7 +94,7 @@ module Extension
 
         @version.last_user_interaction_at = Time.parse(response_time)
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         io = capture_io { run_push }
@@ -111,7 +111,7 @@ module Extension
         ]
 
         Command::Build.any_instance.stubs(:call)
-        ShopifyCli::JsSystem.any_instance.stubs(:call).returns(true)
+        ShopifyCLI::JsSystem.any_instance.stubs(:call).returns(true)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         io = capture_io { run_push }

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -9,8 +9,8 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::ProjectType.load_type(:extension)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
         @project = ExtensionTestHelpers.fake_extension_project(with_mocks: true, registration_id: nil)
         @specification_handler = ExtensionTestHelpers.test_specification_handler
 
@@ -27,7 +27,7 @@ module Extension
         Tasks::CreateExtension.any_instance.expects(:call).never
         ExtensionProject.expects(:write_env_file).never
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) { run_register_command }
 
         assert_message_output(io: io, expected_content: @context.message("register.already_registered"))
       end
@@ -43,7 +43,7 @@ module Extension
           .returns(false)
           .once
 
-        io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { run_register_command }
+        io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) { run_register_command }
 
         assert_message_output(io: io, expected_content: [
           @context.message("register.confirm_abort"),

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -9,8 +9,8 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type("extension")
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::ProjectType.load_type("extension")
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
         ExtensionTestHelpers.fake_extension_project(with_mocks: true)
       end
 
@@ -26,11 +26,11 @@ module Extension
 
         Tasks::ChooseNextAvailablePort.expects(:call)
           .with(from: ::Extension::Command::Serve::DEFAULT_PORT)
-          .returns(ShopifyCli::Result.failure(ArgumentError))
+          .returns(ShopifyCLI::Result.failure(ArgumentError))
           .once
         serve.specification_handler.expects(:choose_port?).returns(true).once
 
-        error = assert_raises ShopifyCli::Abort do
+        error = assert_raises ShopifyCLI::Abort do
           serve.call([], "serve")
         end
 
@@ -49,10 +49,10 @@ module Extension
         serve = ::Extension::Command::Serve.new(@context)
         stub_specification_handler_options(serve, choose_port: true, establish_tunnel: true)
         Tasks::ChooseNextAvailablePort.expects(:call)
-          .returns(ShopifyCli::Result.success(Extension::Command::Serve::DEFAULT_PORT))
-        ShopifyCli::Tunnel.expects(:urls).returns(["https://shopify.ngrok.io"])
-        ShopifyCli::Tunnel.expects(:running_on?).returns(true)
-        ShopifyCli::Tunnel.expects(:start)
+          .returns(ShopifyCLI::Result.success(Extension::Command::Serve::DEFAULT_PORT))
+        ShopifyCLI::Tunnel.expects(:urls).returns(["https://shopify.ngrok.io"])
+        ShopifyCLI::Tunnel.expects(:running_on?).returns(true)
+        ShopifyCLI::Tunnel.expects(:start)
           .with(@context, port: Extension::Command::Serve::DEFAULT_PORT)
           .returns("ngrok.example.com")
           .once
@@ -65,9 +65,9 @@ module Extension
         serve = ::Extension::Command::Serve.new(@context)
         stub_specification_handler_options(serve, choose_port: true, establish_tunnel: true)
         Tasks::ChooseNextAvailablePort.expects(:call)
-          .returns(ShopifyCli::Result.success(Extension::Command::Serve::DEFAULT_PORT))
-        ShopifyCli::Tunnel.expects(:urls).returns([])
-        ShopifyCli::Tunnel.expects(:start)
+          .returns(ShopifyCLI::Result.success(Extension::Command::Serve::DEFAULT_PORT))
+        ShopifyCLI::Tunnel.expects(:urls).returns([])
+        ShopifyCLI::Tunnel.expects(:start)
           .with(@context, port: Extension::Command::Serve::DEFAULT_PORT)
           .returns("ngrok.example.com")
           .once
@@ -79,10 +79,10 @@ module Extension
       def test_serve_quits_if_tunnel_requested_but_tunnel_already_running_on_different_port
         serve = ::Extension::Command::Serve.new(@context)
         stub_specification_handler_options(serve, choose_port: true, establish_tunnel: true)
-        ShopifyCli::Tunnel.expects(:urls).returns(["https://shopify.ngrok.io"])
-        ShopifyCli::Tunnel.expects(:running_on?).returns(false)
+        ShopifyCLI::Tunnel.expects(:urls).returns(["https://shopify.ngrok.io"])
+        ShopifyCLI::Tunnel.expects(:running_on?).returns(false)
 
-        error = assert_raises ShopifyCli::Abort do
+        error = assert_raises ShopifyCLI::Abort do
           serve.call([], "serve")
         end
 
@@ -92,7 +92,7 @@ module Extension
       def test_tunnel_not_started_if_specification_handler_does_not_support_establish_tunnel
         serve = ::Extension::Command::Serve.new(@context)
         stub_specification_handler_options(serve)
-        ShopifyCli::Tunnel.expects(:start).never
+        ShopifyCLI::Tunnel.expects(:start).never
         serve.specification_handler.expects(:serve).once
         serve.call([], "serve")
       end

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -9,8 +9,8 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::ProjectType.load_type(:extension)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
       end
 
       def test_prints_help
@@ -31,19 +31,19 @@ module Extension
       def test_auth_runs_the_core_cli_tunnel_auth_if_token_is_present
         # skip("Need to revisit processing of sub-sub-commands")
         fake_token = "FAKE_TOKEN"
-        ShopifyCli::Tunnel.expects(:auth).with(@context, fake_token).once
+        ShopifyCLI::Tunnel.expects(:auth).with(@context, fake_token).once
 
         capture_io { run_tunnel(Extension::Command::Tunnel::AUTH_SUBCOMMAND, fake_token) }
       end
 
       def test_start_runs_with_the_default_port_if_no_port_provided
-        ShopifyCli::Tunnel.expects(:start).with(@context, port: Extension::Command::Tunnel::DEFAULT_PORT).once
+        ShopifyCLI::Tunnel.expects(:start).with(@context, port: Extension::Command::Tunnel::DEFAULT_PORT).once
 
         capture_io { run_tunnel(Extension::Command::Tunnel::START_SUBCOMMAND) }
       end
 
       def test_start_runs_with_the_requested_port_if_provided
-        ShopifyCli::Tunnel.expects(:start).with(@context, port: 9999).once
+        ShopifyCLI::Tunnel.expects(:start).with(@context, port: 9999).once
 
         capture_io { run_tunnel(Extension::Command::Tunnel::START_SUBCOMMAND, "--port=9999") }
       end
@@ -52,9 +52,9 @@ module Extension
         # skip("Need to revisit processing of sub-sub-commands")
         invalid_port = "NOT_PORT"
 
-        ShopifyCli::Tunnel.expects(:start).never
+        ShopifyCLI::Tunnel.expects(:start).never
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           run_tunnel(Extension::Command::Tunnel::START_SUBCOMMAND, "--port=#{invalid_port}")
         end
 
@@ -65,13 +65,13 @@ module Extension
 
       def test_stop_runs_the_core_cli_tunnel_stop
         # skip("Need to revisit processing of sub-sub-commands")
-        ShopifyCli::Tunnel.expects(:stop).with(@context).once
+        ShopifyCLI::Tunnel.expects(:stop).with(@context).once
 
         capture_io { run_tunnel(Extension::Command::Tunnel::STOP_SUBCOMMAND) }
       end
 
       def test_status_outputs_no_tunnel_running_if_tunnel_urls_returns_empty
-        ShopifyCli::Tunnel.expects(:urls).returns([]).once
+        ShopifyCLI::Tunnel.expects(:urls).returns([]).once
 
         io = capture_io { run_tunnel(Extension::Command::Tunnel::STATUS_SUBCOMMAND) }
 
@@ -81,7 +81,7 @@ module Extension
       def test_status_outputs_the_https_url_of_the_running_tunnel_url_if_returned_by_tunnel_urls
         fake_http_url = "http://12345.ngrok.io"
         fake_https_url = "https://12345.ngrok.io"
-        ShopifyCli::Tunnel.expects(:urls).returns([fake_http_url, fake_https_url]).once
+        ShopifyCLI::Tunnel.expects(:urls).returns([fake_http_url, fake_https_url]).once
 
         io = capture_io { run_tunnel(Extension::Command::Tunnel::STATUS_SUBCOMMAND) }
 
@@ -90,7 +90,7 @@ module Extension
 
       def test_status_outputs_the_http_url_of_the_running_tunnel_url_if_no_https_url_is_returned_by_tunnel_urls
         fake_http_url = "http://12345.ngrok.io"
-        ShopifyCli::Tunnel.expects(:urls).returns([fake_http_url]).once
+        ShopifyCLI::Tunnel.expects(:urls).returns([fake_http_url]).once
 
         io = capture_io { run_tunnel(Extension::Command::Tunnel::STATUS_SUBCOMMAND) }
 

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -8,7 +8,7 @@ module Extension
 
     def setup
       super
-      ShopifyCli::ProjectType.load_type(:extension)
+      ShopifyCLI::ProjectType.load_type(:extension)
 
       @specification_handler = ExtensionTestHelpers.test_specification_handler
       @type = @specification_handler.identifier
@@ -19,10 +19,10 @@ module Extension
     end
 
     def test_write_cli_file_create_shopify_cli_yml_file
-      ::ShopifyCli::Project.clear
+      ::ShopifyCLI::Project.clear
 
       assert File.exist?(".shopify-cli.yml")
-      assert_equal :extension, ShopifyCli::Project.current_project_type
+      assert_equal :extension, ShopifyCLI::Project.current_project_type
       assert_equal @specification_handler.identifier, ExtensionProject.current.specification_identifier
     end
 

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -54,8 +54,8 @@ module Extension
       )
 
       if with_mocks
-        ShopifyCli::Project.stubs(:current).returns(project)
-        ShopifyCli::Project.stubs(:has_current?).returns(true)
+        ShopifyCLI::Project.stubs(:current).returns(project)
+        ShopifyCLI::Project.stubs(:has_current?).returns(true)
         ExtensionProject.stubs(:current).returns(project)
         specifications = test_specifications
         Models::Specifications.stubs(:new).returns(specifications)

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -21,7 +21,7 @@ module Extension
       end
 
       def env
-        @env ||= ShopifyCli::Resources::EnvFile.new(
+        @env ||= ShopifyCLI::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
           shop: "my-test-shop.myshopify.com",

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -32,8 +32,8 @@ module Extension
           registration_uuid: @registration_uuid,
         )
 
-        ShopifyCli::Project.stubs(:current).returns(@project)
-        ShopifyCli::Project.stubs(:has_current?).returns(true)
+        ShopifyCLI::Project.stubs(:current).returns(@project)
+        ShopifyCLI::Project.stubs(:has_current?).returns(true)
         ExtensionProject.stubs(:current).returns(@project)
         specifications = DummySpecifications.build(
           identifier: type_identifier.downcase,

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -4,7 +4,7 @@ module Extension
   module ExtensionTestHelpers
     module TestExtensionSetup
       def setup
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         specifications = DummySpecifications.build(
           custom_handler_root: File.expand_path("../", __FILE__),

--- a/test/project_types/extension/features/argo_config_test.rb
+++ b/test/project_types/extension/features/argo_config_test.rb
@@ -8,7 +8,7 @@ module Extension
       def setup
         super
         File.stubs(:size?).returns(true)
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_parses_and_symbolizes_yaml_hash
@@ -25,13 +25,13 @@ module Extension
 
       def test_aborts_when_yaml_is_invalid
         YAML.stubs(:load_file).raises(Psych::SyntaxError.new(nil, 1, 1, nil, nil, nil))
-        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context) }
+        assert_raises(ShopifyCLI::Abort) { ArgoConfig.parse_yaml(@context) }
       end
 
       def test_aborts_when_yaml_is_not_a_hash
         YAML.stubs(:load_file).returns(false)
 
-        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context) }
+        assert_raises(ShopifyCLI::Abort) { ArgoConfig.parse_yaml(@context) }
       end
 
       def test_returns_empty_hash_when_file_not_found_or_empty
@@ -51,7 +51,7 @@ module Extension
 
         YAML.stubs(:load_file).returns({ "a" => 1, "c" => 1 })
 
-        assert_raises(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
+        assert_raises(ShopifyCLI::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
       end
 
       def test_does_not_abort_when_yaml_contains_no_unpermitted_keys
@@ -59,7 +59,7 @@ module Extension
 
         YAML.stubs(:load_file).returns({ "a" => 1, "b" => 1 })
 
-        assert_nothing_raised(ShopifyCli::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
+        assert_nothing_raised(ShopifyCLI::Abort) { ArgoConfig.parse_yaml(@context, permitted_keys) }
       end
     end
   end

--- a/test/project_types/extension/features/argo_dependencies_test.rb
+++ b/test/project_types/extension/features/argo_dependencies_test.rb
@@ -7,22 +7,22 @@ module Extension
     class ArgoTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_nothing_is_raised_if_node_version_meets_minimum_major_and_minor_versions
         mock_node_version("v10.11.12")
-        assert_nothing_raised(ShopifyCli::Abort) do
+        assert_nothing_raised(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 11).call(@context)
         end
 
         mock_node_version("v10.11.12")
-        assert_nothing_raised(ShopifyCli::Abort) do
+        assert_nothing_raised(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 9, min_minor: 11).call(@context)
         end
 
         mock_node_version("v10.11.12")
-        assert_nothing_raised(ShopifyCli::Abort) do
+        assert_nothing_raised(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 10).call(@context)
         end
       end
@@ -30,7 +30,7 @@ module Extension
       def test_if_node_version_command_fails_abort_with_missing_node_message
         mock_node_version("", success: false)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 11).call(@context)
         end
 
@@ -42,7 +42,7 @@ module Extension
       def test_if_node_exists_but_major_version_is_under_the_minimum_abort_with_message
         mock_node_version("v10.11.12")
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 11).call(@context)
         end
 
@@ -54,7 +54,7 @@ module Extension
       def test_if_major_version_is_the_minimum_version_abort_with_message_if_minor_version_is_under_the_minimum_version
         mock_node_version("v10.11.12")
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           ArgoDependencies.node_installed(min_major: 10, min_minor: 12).call(@context)
         end
 

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -8,7 +8,7 @@ module Extension
       include TestHelpers::FakeUI
 
       def setup
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         super
       end
 
@@ -45,8 +45,8 @@ module Extension
       end
 
       def test_forwards_resource_url
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCLI::Tasks::EnsureEnv.stubs(:call)
         ExtensionProject.stubs(:update_env_file)
         ExtensionProject.any_instance.expects(:resource_url).returns("/test").at_least_once
 
@@ -69,8 +69,8 @@ module Extension
       end
 
       def test_builds_resource_url_if_necessary
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCLI::Tasks::EnsureEnv.stubs(:call)
         ExtensionProject.expects(:update_env_file).with(
           has_entries(context: anything, resource_url: "/generated")
         )
@@ -89,8 +89,8 @@ module Extension
       end
 
       def test_resource_url_is_used_if_given
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCLI::Tasks::EnsureEnv.stubs(:call)
 
         js_system = mock
         js_system.expects(:call)
@@ -130,7 +130,7 @@ module Extension
       end
 
       def stub_ensure_env_check
-        ShopifyCli::Tasks::EnsureEnv.stubs(:call)
+        ShopifyCLI::Tasks::EnsureEnv.stubs(:call)
       end
 
       def stub_package_manager
@@ -141,7 +141,7 @@ module Extension
           ✨  Done in 0.40s.
         YARN
 
-        ShopifyCli::JsSystem
+        ShopifyCLI::JsSystem
           .new(ctx: @context)
           .tap { |js_system| js_system.stubs(call: [fake_list_result, nil, stub(success?: true)]) }
           .yield_self { |js_system| Tasks::FindNpmPackages.new(js_system: js_system) }

--- a/test/project_types/extension/features/argo_setup_step_test.rb
+++ b/test/project_types/extension/features/argo_setup_step_test.rb
@@ -7,11 +7,11 @@ module Extension
     class ArgoSetupStepsTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @identifier = "FAKE_ARGO_TYPE"
         @directory = "fake_directory"
-        @system = ShopifyCli::JsSystem.new(ctx: @context)
+        @system = ShopifyCLI::JsSystem.new(ctx: @context)
       end
 
       def test_always_successful_steps_return_true_no_matter_what_the_step_block_returns
@@ -26,11 +26,11 @@ module Extension
 
       def test_all_step_types_catch_shopify_cli_abort_exceptions_and_output_their_message_and_return_false
         always_successful_io = capture_io do
-          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCli::Abort, "always_successful error" })
+          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCLI::Abort, "always_successful error" })
         end
 
         default_io = capture_io do
-          refute call_step(ArgoSetupStep.default { raise ShopifyCli::Abort, "default_io error" })
+          refute call_step(ArgoSetupStep.default { raise ShopifyCLI::Abort, "default_io error" })
         end
 
         assert_message_output(io: always_successful_io, expected_content: "always_successful error")

--- a/test/project_types/extension/features/argo_setup_steps_test.rb
+++ b/test/project_types/extension/features/argo_setup_steps_test.rb
@@ -9,12 +9,12 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @git_template = "https://www.github.com/fake_template.git"
         @identifier = "FAKE_ARGO_TYPE"
         @directory = "fake_directory"
-        @system = ShopifyCli::JsSystem.new(ctx: @context)
+        @system = ShopifyCLI::JsSystem.new(ctx: @context)
       end
 
       def test_check_dependencies_loops_through_the_provided_dependencies
@@ -31,7 +31,7 @@ module Extension
       end
 
       def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
-        ShopifyCli::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
+        ShopifyCLI::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
 
         call_step(ArgoSetupSteps.clone_template(@git_template))
 
@@ -39,10 +39,10 @@ module Extension
       end
 
       def test_install_dependencies_calls_js_deps_to_install_dependencies_and_returns_the_install_result
-        ShopifyCli::JsDeps.any_instance.expects(:install).returns(true).once
+        ShopifyCLI::JsDeps.any_instance.expects(:install).returns(true).once
         assert call_step(ArgoSetupSteps.install_dependencies)
 
-        ShopifyCli::JsDeps.any_instance.expects(:install).returns(false).once
+        ShopifyCLI::JsDeps.any_instance.expects(:install).returns(false).once
         refute call_step(ArgoSetupSteps.install_dependencies)
       end
 

--- a/test/project_types/extension/features/argo_setup_test.rb
+++ b/test/project_types/extension/features/argo_setup_test.rb
@@ -8,7 +8,7 @@ module Extension
     class ArgoSetupTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @git_template = "https://www.github.com/fake_template.git"
         @initializer = ArgoSetup.new(git_template: @git_template)

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -10,7 +10,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @dummy_argo = ExtensionTestHelpers::DummyArgo.new(
           git_template: "dummy-template",
@@ -25,7 +25,7 @@ module Extension
       def test_config_aborts_with_error_if_script_file_doesnt_exist
         File.stubs(:exist?).returns(false)
         stub_run_yarn_install_and_run_yarn_run_script_methods
-        error = assert_raises ShopifyCli::Abort do
+        error = assert_raises ShopifyCLI::Abort do
           @dummy_argo.config(@context)
         end
 
@@ -38,7 +38,7 @@ module Extension
         Base64.stubs(:strict_encode64).raises(IOError)
 
         @dummy_argo.renderer_version = "0.0.1"
-        error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+        error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
         assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
@@ -49,7 +49,7 @@ module Extension
 
         @dummy_argo.renderer_version = "0.0.1"
 
-        error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+        error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
         assert_includes error.message, @context.message("features.argo.script_prepare_error")
       end
 
@@ -108,7 +108,7 @@ module Extension
         with_stubbed_script(@context, Argo::SCRIPT_PATH) do
           stub_run_yarn_install_and_run_yarn_run_script_methods
           Tasks::FindNpmPackages.expects(:exactly_one_of).raises(Extension::PackageResolutionFailed)
-          error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
           assert_includes error
             .message, @context.message(
               "features.argo.dependencies.argo_missing_renderer_package_error",
@@ -129,7 +129,7 @@ module Extension
           stub_run_yarn_install_and_run_yarn_run_script_methods
 
           error_message = "'#{@dummy_argo.renderer_package_name}' not found."
-          error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
           assert_includes error
             .message, @context.message(
               "features.argo.dependencies.argo_missing_renderer_package_error",
@@ -140,7 +140,7 @@ module Extension
 
       def test_runs_yarn_install_and_yarn_run_script_if_the_package_manager_is_yarn
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
+          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           Argo.any_instance.expects(:run_yarn_install).returns(true).once
           Argo.any_instance.expects(:run_yarn_run_script).returns(true).once
           @dummy_argo.renderer_version = "0.0.1"
@@ -151,7 +151,7 @@ module Extension
 
       def test_does_not_run_yarn_install_and_yarn_run_script_if_the_package_manager_is_npm
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("npm")
+          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("npm")
           Argo.any_instance.expects(:run_yarn_install).never
           Argo.any_instance.expects(:run_yarn_run_script).never
           @dummy_argo.renderer_version = "0.0.1"
@@ -162,9 +162,9 @@ module Extension
 
       def test_aborts_with_error_if_yarn_install_command_fails
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
-          ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
-          error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
+          ShopifyCLI::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
+          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
           assert_includes error.message,
             @context.message("features.argo.dependencies.yarn_install_error", @error_message)
         end
@@ -172,10 +172,10 @@ module Extension
 
       def test_aborts_with_error_if_yarn_run_script_command_fails
         with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
+          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
           Argo.any_instance.stubs(:run_yarn_install).returns(true)
-          ShopifyCli::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
-          error = assert_raises(ShopifyCli::Abort) { @dummy_argo.config(@context) }
+          ShopifyCLI::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
+          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
           assert_includes error.message,
             @context.message("features.argo.dependencies.yarn_run_script_error", @error_message)
         end
@@ -184,13 +184,13 @@ module Extension
       private
 
       def stub_run_yarn_install_and_run_yarn_run_script_methods
-        ShopifyCli::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
+        ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
         Argo.any_instance.stubs(:run_yarn_install).returns(true)
         Argo.any_instance.stubs(:run_yarn_run_script).returns(true)
       end
 
       def stub_package_manager(package_manager_output)
-        ShopifyCli::JsSystem
+        ShopifyCLI::JsSystem
           .new(ctx: @context)
           .tap { |js_system| js_system.stubs(call: [package_manager_output, nil, stub(success?: true)]) }
           .yield_self { |js_system| Tasks::FindNpmPackages.new(js_system: js_system) }

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -14,7 +14,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         @app = Models::App.new(title: "Fake", api_key: "1234", secret: "4567", business_name: "Fake Business")
         @extension_handler = ExtensionTestHelpers.test_specification_handler
       end

--- a/test/project_types/extension/forms/questions/ask_app_test.rb
+++ b/test/project_types/extension/forms/questions/ask_app_test.rb
@@ -11,7 +11,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_setup
@@ -38,7 +38,7 @@ module Extension
           AskApp.new(ctx: @context, api_key: api_key).call(OpenStruct.new).tap do |result|
             assert_predicate(result, :failure?)
             result.error.tap do |error|
-              assert_kind_of(ShopifyCli::Abort, error)
+              assert_kind_of(ShopifyCLI::Abort, error)
               assert_match(@context.message("create.invalid_api_key", api_key), error.message)
             end
           end
@@ -72,7 +72,7 @@ module Extension
           io = capture_io do
             AskApp.new(ctx: @context, prompt: ->(_) {}).call(OpenStruct.new).tap do |result|
               assert_predicate(result, :failure?)
-              assert_kind_of(ShopifyCli::AbortSilent, result.error)
+              assert_kind_of(ShopifyCLI::AbortSilent, result.error)
             end
           end
 

--- a/test/project_types/extension/forms/questions/ask_name_test.rb
+++ b/test/project_types/extension/forms/questions/ask_name_test.rb
@@ -8,7 +8,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_accepts_a_valid_name_as_property

--- a/test/project_types/extension/forms/questions/ask_template_test.rb
+++ b/test/project_types/extension/forms/questions/ask_template_test.rb
@@ -8,12 +8,12 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_does_not_prompt_for_template_when_not_required
-          ShopifyCli::Shopifolk.stubs(:check).returns(false)
-          ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
+          ShopifyCLI::Shopifolk.stubs(:check).returns(false)
+          ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
           project_details = OpenStruct.new(
             type: OpenStruct.new(
               identifier: "THEME_APP_EXTENSION",
@@ -26,8 +26,8 @@ module Extension
         end
 
         def test_prompts_for_template_when_required
-          ShopifyCli::Shopifolk.stubs(:check).returns(true)
-          ShopifyCli::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
+          ShopifyCLI::Shopifolk.stubs(:check).returns(true)
+          ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
           project_details = OpenStruct.new(
             type: OpenStruct.new(
               identifier: "CHECKOUT_UI_EXTENSION",

--- a/test/project_types/extension/forms/questions/ask_type_test.rb
+++ b/test/project_types/extension/forms/questions/ask_type_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_returns_if_the_given_extension_type_valid
@@ -55,7 +55,7 @@ module Extension
           AskType.new(ctx: context).call(project_details).tap do |result|
             assert_predicate(result, :failure?)
             result.error.tap do |error|
-              assert_kind_of(ShopifyCli::AbortSilent, error)
+              assert_kind_of(ShopifyCLI::AbortSilent, error)
             end
           end
         end

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -8,7 +8,7 @@ module Extension
       include ExtensionTestHelpers
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @fake_messages = {
           name: "Fake Type",
@@ -53,7 +53,7 @@ module Extension
       end
 
       def test_load_current_type_messages_returns_nil_if_there_is_no_current_project
-        ShopifyCli::Project.expects(:has_current?).returns(false).once
+        ShopifyCLI::Project.expects(:has_current?).returns(false).once
 
         assert_nil(Messages::MessageLoading.load_current_type_messages)
       end
@@ -61,8 +61,8 @@ module Extension
       def test_load_current_type_messages_calls_messages_for_type_with_type_if_there_is_a_current_project
         project = ExtensionTestHelpers.fake_extension_project(with_mocks: true)
 
-        ShopifyCli::Project.expects(:has_current?).returns(true).once
-        ShopifyCli::Project.stubs(:current).returns(project).once
+        ShopifyCLI::Project.expects(:has_current?).returns(true).once
+        ShopifyCLI::Project.stubs(:current).returns(project).once
         Messages::MessageLoading.expects(:messages_for_type).with(project.type).once
 
         Messages::MessageLoading.load_current_type_messages

--- a/test/project_types/extension/models/development_server_test.rb
+++ b/test/project_types/extension/models/development_server_test.rb
@@ -4,7 +4,7 @@ module Extension
   module Models
     class DevelopmentServerTest < MiniTest::Test
       def setup
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         super
       end
 

--- a/test/project_types/extension/models/lazy_specification_handler_test.rb
+++ b/test/project_types/extension/models/lazy_specification_handler_test.rb
@@ -4,7 +4,7 @@ module Extension
   module Models
     class LazySpecificationHandlerTest < MiniTest::Test
       def setup
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         super
       end
 

--- a/test/project_types/extension/models/npm_package_test.rb
+++ b/test/project_types/extension/models/npm_package_test.rb
@@ -5,7 +5,7 @@ module Extension
   module Models
     class NpmPackageTest < MiniTest::Test
       def setup
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         super
       end
 

--- a/test/project_types/extension/models/registration_test.rb
+++ b/test/project_types/extension/models/registration_test.rb
@@ -6,7 +6,7 @@ module Extension
     class RegistrationTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_valid_title_returns_true_for_valid_title

--- a/test/project_types/extension/models/server_config/development_entries_test.rb
+++ b/test/project_types/extension/models/server_config/development_entries_test.rb
@@ -6,7 +6,7 @@ module Extension
       class DevelopmentEntriesTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_entries_are_created_with_valid_attributes

--- a/test/project_types/extension/models/server_config/development_renderer_test.rb
+++ b/test/project_types/extension/models/server_config/development_renderer_test.rb
@@ -6,7 +6,7 @@ module Extension
       class DevelopmentRendererTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_extension_config_renderer_can_be_instantiated_with_valid_attributes

--- a/test/project_types/extension/models/server_config/development_test.rb
+++ b/test/project_types/extension/models/server_config/development_test.rb
@@ -6,7 +6,7 @@ module Extension
       class DevelopmentTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_server_config_development_can_be_instantiated_with_valid_attributes

--- a/test/project_types/extension/models/server_config/extension_test.rb
+++ b/test/project_types/extension/models/server_config/extension_test.rb
@@ -6,7 +6,7 @@ module Extension
       class ExtensionTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_extension_config_can_be_instantiated_with_valid_attributes

--- a/test/project_types/extension/models/server_config/root_test.rb
+++ b/test/project_types/extension/models/server_config/root_test.rb
@@ -7,7 +7,7 @@ module Extension
       class RootTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_root_is_created_with_valid_attributes

--- a/test/project_types/extension/models/server_config/user_test.rb
+++ b/test/project_types/extension/models/server_config/user_test.rb
@@ -6,7 +6,7 @@ module Extension
       class UserTest < MiniTest::Test
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_extension_config_user_can_be_instantiated_with_valid_attributes

--- a/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_post_purchase_test.rb
@@ -11,7 +11,7 @@ module Extension
         def setup
           super
           YAML.stubs(:load_file).returns({})
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig.stubs(:parse_yaml).returns({})
 

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -12,7 +12,7 @@ module Extension
         def setup
           super
           YAML.stubs(:load_file).returns({})
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig.stubs(:parse_yaml).returns({})
 

--- a/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
+++ b/test/project_types/extension/models/specification_handlers/product_subscription_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
           specifications = DummySpecifications.build(identifier: "subscription_management", surface: "admin")
 
           @identifier = "PRODUCT_SUBSCRIPTION"

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
           specifications = DummySpecifications.build(identifier: "theme_app_extension")
           @identifier = "THEME_APP_EXTENSION"
           @spec = specifications[@identifier]

--- a/test/project_types/extension/models/specification_test.rb
+++ b/test/project_types/extension/models/specification_test.rb
@@ -5,7 +5,7 @@ module Extension
     class SpecificationTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_can_be_instantiated_from_a_set_of_valid_attributes

--- a/test/project_types/extension/models/specifications_test.rb
+++ b/test/project_types/extension/models/specifications_test.rb
@@ -10,7 +10,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_only_requires_fetching_strategy_for_initialization

--- a/test/project_types/extension/models/validation_error_test.rb
+++ b/test/project_types/extension/models/validation_error_test.rb
@@ -6,7 +6,7 @@ module Extension
     class ValidationErrorTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @error = ValidationError.new(field: ["Hi"], message: "message")
       end

--- a/test/project_types/extension/tasks/configure_features_test.rb
+++ b/test/project_types/extension/tasks/configure_features_test.rb
@@ -3,7 +3,7 @@ module Extension
     class ConfigureFeaturesTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_configures_git_template

--- a/test/project_types/extension/tasks/converters/app_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/app_converter_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
 
           @api_key = "fake_key"
           @secret = "fake_secret"

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
 
           @registration_id = 42
           @registration_uuid = "123"
@@ -21,7 +21,7 @@ module Extension
         end
 
         def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
-          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
             Converters::RegistrationConverter.from_hash(@context, nil)
           end
 

--- a/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
         end
 
         def test_from_hash_returns_empty_array_if_errors_are_nil
@@ -18,7 +18,7 @@ module Extension
         end
 
         def test_from_hash_aborts_with_parse_error_if_errors_are_not_an_array_and_not_nil
-          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
             ValidationErrorConverter.from_array(@context, Object)
           end
 

--- a/test/project_types/extension/tasks/converters/version_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/version_converter_test.rb
@@ -10,7 +10,7 @@ module Extension
 
         def setup
           super
-          ShopifyCli::ProjectType.load_type(:extension)
+          ShopifyCLI::ProjectType.load_type(:extension)
 
           @api_key = "FAKE_API_KEY"
           @registration_id = 42
@@ -21,7 +21,7 @@ module Extension
         end
 
         def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
-          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
             Converters::VersionConverter.from_hash(@context, nil)
           end
 

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -11,7 +11,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @api_key = "FAKE_API_KEY"
         @fake_type = "TEST_EXTENSION"
@@ -48,7 +48,7 @@ module Extension
       def test_aborts_with_parse_error_if_no_created_registration_or_errors_are_returned
         stub_create_extension_failure(userErrors: [], **@input)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           Tasks::CreateExtension.call(
             context: @context,
             api_key: @api_key,
@@ -66,7 +66,7 @@ module Extension
         user_errors = [{ field: ["field"], UserErrors::MESSAGE_FIELD => "An error occurred on field" }]
         stub_create_extension_failure(userErrors: user_errors, **@input)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           Tasks::CreateExtension.call(
             context: @context,
             api_key: @api_key,

--- a/test/project_types/extension/tasks/fetch_specifications_test.rb
+++ b/test/project_types/extension/tasks/fetch_specifications_test.rb
@@ -11,7 +11,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_request

--- a/test/project_types/extension/tasks/find_npm_packages_test.rb
+++ b/test/project_types/extension/tasks/find_npm_packages_test.rb
@@ -5,7 +5,7 @@ module Extension
     class FindNpmPackagesTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_finds_single_package
@@ -157,7 +157,7 @@ module Extension
 
       def stub_js_system(output: yarn_output, &customize)
         customize ||= ->(system) { system }
-        ShopifyCli::JsSystem.new(ctx: @context).tap do |js_system|
+        ShopifyCLI::JsSystem.new(ctx: @context).tap do |js_system|
           success = mock(success?: true)
           customize
             .call(js_system.expects(:call))

--- a/test/project_types/extension/tasks/get_app_test.rb
+++ b/test/project_types/extension/tasks/get_app_test.rb
@@ -11,7 +11,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         setup_temp_project
         @app = Models::App.new(title: "App One", api_key: "1234", secret: "5678")
       end

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -10,7 +10,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
         @app = Models::App.new(title: "App One", api_key: "1234", secret: "5678")
       end
 

--- a/test/project_types/extension/tasks/get_product_test.rb
+++ b/test/project_types/extension/tasks/get_product_test.rb
@@ -8,14 +8,14 @@ module Extension
 
       def test_get_performs_api_request_and_parses_response
         response = mock
-        ShopifyCli::AdminAPI.stubs(:query).returns(response)
+        ShopifyCLI::AdminAPI.stubs(:query).returns(response)
         result = mock
         Converters::ProductConverter.expects(:from_hash).with(response).returns(result)
         assert_equal result, Tasks::GetProduct.call(@context, "shop.myshopify.com")
       end
 
       def test_performs_api_request_and_aborts_if_api_response_is_nil
-        ShopifyCli::AdminAPI.stubs(:query).returns(nil)
+        ShopifyCLI::AdminAPI.stubs(:query).returns(nil)
 
         error = assert_raises CLI::Kit::Abort do
           Tasks::GetProduct.call(@context, "shop.myshopify.com")

--- a/test/project_types/extension/tasks/run_extension_command_test.rb
+++ b/test/project_types/extension/tasks/run_extension_command_test.rb
@@ -6,7 +6,7 @@ module Extension
     class GoCreateExtensionTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
       end
 
       def test_go_create_extension_succeeds_with_no_errors

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -11,7 +11,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @api_key = "FAKE_API_KEY"
         @registration_id = 42
@@ -45,7 +45,7 @@ module Extension
       def test_aborts_with_parse_error_if_no_updated_version_or_errors_are_returned
         stub_update_draft_failure(errors: [], **@input)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           Tasks::UpdateDraft.call(
             context: @context,
             api_key: @api_key,
@@ -62,7 +62,7 @@ module Extension
         user_errors = [{ field: ["field"], UserErrors::MESSAGE_FIELD => "An error occurred on field" }]
         stub_update_draft_failure(errors: user_errors, **@input)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           Tasks::UpdateDraft.call(
             context: @context,
             api_key: @api_key,

--- a/test/project_types/extension/tasks/user_errors_test.rb
+++ b/test/project_types/extension/tasks/user_errors_test.rb
@@ -8,7 +8,7 @@ module Extension
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:extension)
+        ShopifyCLI::ProjectType.load_type(:extension)
 
         @test_user_errors = Object.new.extend(Tasks::UserErrors)
       end

--- a/test/project_types/node/commands/connect_test.rb
+++ b/test/project_types/node/commands/connect_test.rb
@@ -8,10 +8,10 @@ module Node
       include TestHelpers::FakeUI
 
       def test_can_connect
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
 
-        ShopifyCli::Project.stubs(:has_current?).returns(false)
-        ShopifyCli::Connect.any_instance.expects(:default_connect)
+        ShopifyCLI::Project.stubs(:has_current?).returns(false)
+        ShopifyCLI::Connect.any_instance.expects(:default_connect)
           .with("node")
           .returns("node-app")
         context.expects(:done)
@@ -21,11 +21,11 @@ module Node
       end
 
       def test_warns_if_in_production
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
 
         context.expects(:puts)
           .with(context.message("node.connect.production_warning"))
-        ShopifyCli::Connect.any_instance.expects(:default_connect)
+        ShopifyCLI::Connect.any_instance.expects(:default_connect)
           .with("node")
           .returns("node-app")
         context.expects(:done)

--- a/test/project_types/node/commands/create_test.rb
+++ b/test/project_types/node/commands/create_test.rb
@@ -24,7 +24,7 @@ module Node
 
       def setup
         super
-        ShopifyCli::Tasks::EnsureAuthenticated.stubs(:call)
+        ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
       end
 
       def test_prints_help_with_no_name_argument
@@ -34,7 +34,7 @@ module Node
 
       def test_check_node_installed
         @context.expects(:which).with("node").returns(nil)
-        assert_raises ShopifyCli::Abort, "node.create.error.node_required" do
+        assert_raises ShopifyCLI::Abort, "node.create.error.node_required" do
           perform_command
         end
       end
@@ -42,7 +42,7 @@ module Node
       def test_check_get_node_version
         @context.expects(:which).with("node").returns("/usr/bin/node")
         @context.expects(:capture2e).with("node", "-v").returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, "node.create.error.node_version_failure" do
+        assert_raises ShopifyCLI::Abort, "node.create.error.node_version_failure" do
           perform_command
         end
       end
@@ -51,7 +51,7 @@ module Node
         @context.expects(:which).with("node").returns("/usr/bin/node")
         @context.expects(:capture2e).with("node", "-v").returns(["8.0.0", mock(success?: true)])
         @context.expects(:which).with("npm").returns(nil)
-        assert_raises ShopifyCli::Abort, "node.create.error.npm_required" do
+        assert_raises ShopifyCLI::Abort, "node.create.error.npm_required" do
           perform_command
         end
       end
@@ -61,7 +61,7 @@ module Node
         @context.expects(:capture2e).with("node", "-v").returns(["8.0.0", mock(success?: true)])
         @context.expects(:which).with("npm").returns("/usr/bin/npm")
         @context.expects(:capture2e).with("npm", "-v").returns([nil, mock(success?: false)])
-        assert_raises ShopifyCli::Abort, "node.create.error.npm_version_failure" do
+        assert_raises ShopifyCLI::Abort, "node.create.error.npm_version_failure" do
           perform_command
         end
       end
@@ -73,14 +73,14 @@ module Node
         @context.expects(:capture2).with("npm config get @shopify:registry").returns(
           ["https://registry.yarnpkg.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
-        ShopifyCli::JsDeps.expects(:install)
-        ShopifyCli::Tasks::CreateApiClient.stubs(:call).returns({
+        ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+        ShopifyCLI::JsDeps.expects(:install)
+        ShopifyCLI::Tasks::CreateApiClient.stubs(:call).returns({
           "apiKey" => "ljdlkajfaljf",
           "apiSecretKeys" => [{ "secret": "kldjakljjkj" }],
           "id" => "12345678",
         })
-        ShopifyCli::Resources::EnvFile.stubs(:new).returns(stub(write: true))
+        ShopifyCLI::Resources::EnvFile.stubs(:new).returns(stub(write: true))
 
         perform_command
 
@@ -106,14 +106,14 @@ module Node
           chdir: @context.root + "/test-app"
         )
 
-        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
-        ShopifyCli::JsDeps.expects(:install)
-        ShopifyCli::Tasks::CreateApiClient.stubs(:call).returns({
+        ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+        ShopifyCLI::JsDeps.expects(:install)
+        ShopifyCLI::Tasks::CreateApiClient.stubs(:call).returns({
           "apiKey" => "ljdlkajfaljf",
           "apiSecretKeys" => [{ "secret": "kldjakljjkj" }],
           "id" => "12345678",
         })
-        ShopifyCli::Resources::EnvFile.stubs(:new).returns(stub(write: true))
+        ShopifyCLI::Resources::EnvFile.stubs(:new).returns(stub(write: true))
 
         perform_command
 
@@ -128,8 +128,8 @@ module Node
         @context.expects(:capture2).with("npm config get @shopify:registry").returns(
           ["https://registry.yarnpkg.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
-        ShopifyCli::JsDeps.expects(:install)
+        ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+        ShopifyCLI::JsDeps.expects(:install)
 
         stub_partner_req(
           "create_app",
@@ -137,7 +137,7 @@ module Node
             org: 42,
             title: "test-app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -173,7 +173,7 @@ module Node
         @context.expects(:capture2).with("npm config get @shopify:registry").returns(
           ["https://badregistry.com", nil]
         )
-        ShopifyCli::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+        ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
         @context.expects(:system).with(
           "npm",
           "--userconfig",
@@ -184,7 +184,7 @@ module Node
           "https://registry.yarnpkg.com",
           chdir: @context.root + "/test-app"
         )
-        ShopifyCli::JsDeps.expects(:install)
+        ShopifyCLI::JsDeps.expects(:install)
 
         stub_partner_req(
           "create_app",
@@ -192,7 +192,7 @@ module Node
             org: 42,
             title: "test-app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {

--- a/test/project_types/node/commands/deploy/heroku_test.rb
+++ b/test/project_types/node/commands/deploy/heroku_test.rb
@@ -11,8 +11,8 @@ module Node
         def setup
           super
           File.stubs(:exist?)
-          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "lib", "project_types", "node", "cli.rb")).returns(true)
-          ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
+          File.stubs(:exist?).with(File.join(ShopifyCLI::ROOT, "lib", "project_types", "node", "cli.rb")).returns(true)
+          ShopifyCLI::Context.any_instance.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
         end
 
@@ -33,7 +33,7 @@ module Node
           expects_heroku_installed(status: false)
           expects_heroku_download(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -43,7 +43,7 @@ module Node
           expects_heroku_download_exists(status: false)
           expects_heroku_download(status: true)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -68,7 +68,7 @@ module Node
           expects_heroku_installed(status: false, twice: true)
           expects_tar_heroku(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -76,7 +76,7 @@ module Node
         def test_call_raises_if_git_isnt_inited
           expects_git_init_heroku(status: false, commits: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -84,7 +84,7 @@ module Node
         def test_call_raises_if_git_is_inited_but_there_are_no_commits
           expects_git_init_heroku(status: true, commits: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -108,7 +108,7 @@ module Node
           expects_heroku_whoami(status: false)
           expects_heroku_login(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -148,7 +148,7 @@ module Node
             .with(@context.message("node.deploy.heroku.app.name"))
             .returns("app-name")
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -172,7 +172,7 @@ module Node
             .with(@context.message("node.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -199,7 +199,7 @@ module Node
         def test_call_raises_if_finding_branches_fails
           expects_git_branch(status: false, multiple: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -213,7 +213,7 @@ module Node
         def test_call_raises_if_deploy_to_heroku_fails
           expects_git_push_heroku(status: false, branch: "master:master")
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Node::Command::Deploy::Heroku.start(@context)
           end
         end

--- a/test/project_types/node/commands/deploy_test.rb
+++ b/test/project_types/node/commands/deploy_test.rb
@@ -6,7 +6,7 @@ module Node
     class DeployTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
+        ShopifyCLI::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
       end
 
       def test_without_arguments_calls_help

--- a/test/project_types/node/commands/serve_test.rb
+++ b/test/project_types/node/commands/serve_test.rb
@@ -9,15 +9,15 @@ module Node
       def setup
         super
         project_context("app_types", "node")
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
+        ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCLI::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
         @context.stubs(:system)
       end
 
       def test_server_command
-        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
+        ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
         @context.expects(:system).with(
           "npm run dev",
           env: {
@@ -33,9 +33,9 @@ module Node
       end
 
       def test_server_command_with_invalid_host_url
-        ShopifyCli::Tunnel.stubs(:start).returns("garbage://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call).never
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).never
+        ShopifyCLI::Tunnel.stubs(:start).returns("garbage://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).never
         @context.expects(:system).with(
           "npm run dev",
           env: {
@@ -48,15 +48,15 @@ module Node
           }
         ).never
 
-        assert_raises ShopifyCli::Abort do
+        assert_raises ShopifyCLI::Abort do
           run_cmd("node serve")
         end
       end
 
       def test_open_while_run
-        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
+        ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, "https://example.com"
         )
         @context.expects(:puts).with(
@@ -68,9 +68,9 @@ module Node
       end
 
       def test_update_env_with_host
-        ShopifyCli::Tunnel.expects(:start).never
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
+        ShopifyCLI::Tunnel.expects(:start).never
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, "https://example-foo.com"
         )
         run_cmd('node serve --host="https://example-foo.com"')

--- a/test/project_types/node/commands/tunnel_test.rb
+++ b/test/project_types/node/commands/tunnel_test.rb
@@ -6,26 +6,26 @@ module Node
     class TunnelTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
+        ShopifyCLI::Tasks::EnsureProjectType.expects(:call).with(@context, :node)
       end
 
       def test_auth
-        ShopifyCli::Tunnel.any_instance.expects(:auth)
+        ShopifyCLI::Tunnel.any_instance.expects(:auth)
         run_cmd("node tunnel auth adfhauf98q7rtqhfkajf")
       end
 
       def test_auth_no_token
-        ShopifyCli::Tunnel.any_instance.expects(:auth).never
+        ShopifyCLI::Tunnel.any_instance.expects(:auth).never
         run_cmd("node tunnel auth")
       end
 
       def test_start
-        ShopifyCli::Tunnel.any_instance.expects(:start)
+        ShopifyCLI::Tunnel.any_instance.expects(:start)
         run_cmd("node tunnel start")
       end
 
       def test_stop
-        ShopifyCli::Tunnel.any_instance.expects(:stop)
+        ShopifyCLI::Tunnel.any_instance.expects(:stop)
         run_cmd("node tunnel stop")
       end
     end

--- a/test/project_types/node/forms/create_test.rb
+++ b/test/project_types/node/forms/create_test.rb
@@ -8,7 +8,7 @@ module Node
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:node)
+        ShopifyCLI::ProjectType.load_type(:node)
       end
 
       def test_returns_all_defined_attributes_if_valid

--- a/test/project_types/node/test_helper.rb
+++ b/test/project_types/node/test_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require "test_helper"
 
-ShopifyCli::ProjectType.load_type(:node)
+ShopifyCLI::ProjectType.load_type(:node)

--- a/test/project_types/rails/commands/connect_test.rb
+++ b/test/project_types/rails/commands/connect_test.rb
@@ -8,10 +8,10 @@ module Rails
       include TestHelpers::FakeUI
 
       def test_can_connect
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
 
-        ShopifyCli::Project.expects(:has_current?).returns(false)
-        ShopifyCli::Connect.any_instance.expects(:default_connect)
+        ShopifyCLI::Project.expects(:has_current?).returns(false)
+        ShopifyCLI::Connect.any_instance.expects(:default_connect)
           .with("rails")
           .returns("rails-app")
         context.expects(:done)
@@ -21,12 +21,12 @@ module Rails
       end
 
       def test_warns_if_in_production
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
 
-        ShopifyCli::Project.stubs(:current_project_type).returns(:rails)
+        ShopifyCLI::Project.stubs(:current_project_type).returns(:rails)
         context.expects(:puts)
           .with(context.message("rails.connect.production_warning"))
-        ShopifyCli::Connect.any_instance.expects(:default_connect)
+        ShopifyCLI::Connect.any_instance.expects(:default_connect)
           .with("rails")
           .returns("rails-app")
         context.expects(:done)

--- a/test/project_types/rails/commands/create_test.rb
+++ b/test/project_types/rails/commands/create_test.rb
@@ -24,8 +24,8 @@ module Rails
 
       def setup
         super
-        ShopifyCli::Tasks::EnsureAuthenticated.stubs(:call)
-        ShopifyCli::Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+        ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
+        ShopifyCLI::Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       end
 
       def test_prints_help_with_no_name_argument
@@ -35,12 +35,12 @@ module Rails
 
       def test_will_abort_if_bad_ruby
         Ruby.expects(:version).returns(Semantic::Version.new("2.3.7"))
-        assert_raises ShopifyCli::Abort do
+        assert_raises ShopifyCLI::Abort do
           perform_command
         end
 
         Ruby.expects(:version).returns(Semantic::Version.new("3.1.0"))
-        assert_raises ShopifyCli::Abort do
+        assert_raises ShopifyCLI::Abort do
           perform_command
         end
       end
@@ -72,7 +72,7 @@ module Rails
             org: 42,
             title: "test-app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -124,7 +124,7 @@ module Rails
             org: 42,
             title: "test-app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -172,7 +172,7 @@ module Rails
             org: 42,
             title: "test-app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -205,7 +205,7 @@ module Rails
         Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
         Dir.stubs(:exist?).returns(true)
 
-        exception = assert_raises ShopifyCli::Abort do
+        exception = assert_raises ShopifyCLI::Abort do
           perform_command
         end
         assert_equal(
@@ -263,7 +263,7 @@ module Rails
 
         # The dir needs to exist to simulate the command working, but we don't want to fail on the pre-create check
         Dir.expects(:exist?).with(File.join(@context.root, "test-app")).returns(false)
-        Dir.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "test")).returns(true)
+        Dir.stubs(:exist?).with(File.join(ShopifyCLI::ROOT, "test")).returns(true)
       end
     end
   end

--- a/test/project_types/rails/commands/deploy/heroku_test.rb
+++ b/test/project_types/rails/commands/deploy/heroku_test.rb
@@ -11,7 +11,7 @@ module Rails
         def setup
           super
           File.stubs(:exist?)
-          File.stubs(:exist?).with(File.join(ShopifyCli::ROOT, "lib", "project_types", "rails", "cli.rb")).returns(true)
+          File.stubs(:exist?).with(File.join(ShopifyCLI::ROOT, "lib", "project_types", "rails", "cli.rb")).returns(true)
           @context.stubs(:os).returns(:mac)
           stub_successful_heroku_flow
         end
@@ -19,7 +19,7 @@ module Rails
         def test_call_raises_if_using_sqlite
           expects_heroku_db_validated(status: false, db: "sqlite")
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -27,7 +27,7 @@ module Rails
         def test_call_raises_if_cannot_validate_db
           expects_heroku_db_validated(status: false, db: nil)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -55,7 +55,7 @@ module Rails
           expects_heroku_installed(status: false)
           expects_heroku_download(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -65,7 +65,7 @@ module Rails
           expects_heroku_download_exists(status: false)
           expects_heroku_download(status: true)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -92,7 +92,7 @@ module Rails
           expects_heroku_installed(status: false, twice: true)
           expects_tar_heroku(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -100,7 +100,7 @@ module Rails
         def test_call_raises_if_git_isnt_inited
           expects_git_init_heroku(status: false, commits: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -108,7 +108,7 @@ module Rails
         def test_call_raises_if_git_is_inited_but_there_are_no_commits
           expects_git_init_heroku(status: true, commits: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -132,7 +132,7 @@ module Rails
           expects_heroku_whoami(status: false)
           expects_heroku_login(status: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -172,7 +172,7 @@ module Rails
             .with(@context.message("rails.deploy.heroku.app.name"))
             .returns("app-name")
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -196,7 +196,7 @@ module Rails
             .with(@context.message("rails.deploy.heroku.app.no_apps_found"))
             .returns(:new)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -223,7 +223,7 @@ module Rails
         def test_call_raises_if_finding_branches_fails
           expects_git_branch(status: false, multiple: false)
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end
@@ -237,7 +237,7 @@ module Rails
         def test_call_raises_if_deploy_to_heroku_fails
           expects_git_push_heroku(status: false, branch: "master:master")
 
-          assert_raises ShopifyCli::Abort do
+          assert_raises ShopifyCLI::Abort do
             Rails::Command::Deploy::Heroku.start(@context)
           end
         end

--- a/test/project_types/rails/commands/deploy_test.rb
+++ b/test/project_types/rails/commands/deploy_test.rb
@@ -6,7 +6,7 @@ module Rails
     class DeployTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Tasks::EnsureProjectType.expects(:call).with(@context, :rails)
+        ShopifyCLI::Tasks::EnsureProjectType.expects(:call).with(@context, :rails)
       end
 
       def test_without_arguments_calls_help

--- a/test/project_types/rails/commands/generate_test.rb
+++ b/test/project_types/rails/commands/generate_test.rb
@@ -6,7 +6,7 @@ module Rails
     class GenerateTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
       end
 
       def test_without_arguments_calls_help
@@ -18,9 +18,9 @@ module Rails
         failure = mock
         failure.stubs(:success?).returns(false)
         failure.stubs(:exitstatus).returns(1)
-        ShopifyCli::Context.any_instance.expects(:system).returns(failure)
+        ShopifyCLI::Context.any_instance.expects(:system).returns(failure)
 
-        assert_raises(ShopifyCli::Abort) do
+        assert_raises(ShopifyCLI::Abort) do
           Rails::Command::Generate.run_generate(["script"], "test-name", @context)
         end
       end

--- a/test/project_types/rails/commands/serve_test.rb
+++ b/test/project_types/rails/commands/serve_test.rb
@@ -9,15 +9,15 @@ module Rails
       def setup
         super
         project_context("app_types", "rails")
-        ShopifyCli::Tasks::EnsureDevStore.stubs(:call)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call)
+        ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
         @context.stubs(:system)
       end
 
       def test_server_command
-        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update)
+        ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
         @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")
         @context.stubs(:getenv).with("GEM_PATH").returns("/gem/path")
         @context.expects(:system).with(
@@ -35,9 +35,9 @@ module Rails
       end
 
       def test_server_command_with_invalid_host_url
-        ShopifyCli::Tunnel.stubs(:start).returns("garbage://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call).never
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).never
+        ShopifyCLI::Tunnel.stubs(:start).returns("garbage://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).never
         @context.expects(:system).with(
           "bin/rails server",
           env: {
@@ -49,15 +49,15 @@ module Rails
           }
         ).never
 
-        assert_raises ShopifyCli::Abort do
+        assert_raises ShopifyCLI::Abort do
           Rails::Command::Serve.new(@context).call
         end
       end
 
       def test_open_while_run
-        ShopifyCli::Tunnel.stubs(:start).returns("https://example.com")
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
+        ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, "https://example.com"
         )
         @context.expects(:puts).with(
@@ -69,9 +69,9 @@ module Rails
       end
 
       def test_update_env_with_host
-        ShopifyCli::Tunnel.expects(:start).never
-        ShopifyCli::Tasks::UpdateDashboardURLS.expects(:call)
-        ShopifyCli::Resources::EnvFile.any_instance.expects(:update).with(
+        ShopifyCLI::Tunnel.expects(:start).never
+        ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+        ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
           @context, :host, "https://example-foo.com"
         )
         command = Rails::Command::Serve.new(@context)

--- a/test/project_types/rails/commands/tunnel_test.rb
+++ b/test/project_types/rails/commands/tunnel_test.rb
@@ -6,26 +6,26 @@ module Rails
     class TunnelTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Tasks::EnsureProjectType.expects(:call).with(@context, :rails)
+        ShopifyCLI::Tasks::EnsureProjectType.expects(:call).with(@context, :rails)
       end
 
       def test_auth
-        ShopifyCli::Tunnel.any_instance.expects(:auth)
+        ShopifyCLI::Tunnel.any_instance.expects(:auth)
         run_cmd("rails tunnel auth adfhauf98q7rtqhfkajf")
       end
 
       def test_auth_no_token
-        ShopifyCli::Tunnel.any_instance.expects(:auth).never
+        ShopifyCLI::Tunnel.any_instance.expects(:auth).never
         run_cmd("rails tunnel auth")
       end
 
       def test_start
-        ShopifyCli::Tunnel.any_instance.expects(:start)
+        ShopifyCLI::Tunnel.any_instance.expects(:start)
         run_cmd("rails tunnel start")
       end
 
       def test_stop
-        ShopifyCli::Tunnel.any_instance.expects(:stop)
+        ShopifyCLI::Tunnel.any_instance.expects(:stop)
         run_cmd("rails tunnel stop")
       end
     end

--- a/test/project_types/rails/ruby_test.rb
+++ b/test/project_types/rails/ruby_test.rb
@@ -4,7 +4,7 @@ require "project_types/rails/test_helper"
 module Rails
   class RubyTest < MiniTest::Test
     def test_ruby_matches
-      context = ShopifyCli::Context.new(env: {})
+      context = ShopifyCLI::Context.new(env: {})
       context.expects(:capture2).with("ruby", "-v").returns(
         ["ruby 2.3.7p456 (2018-03-28 revision 63024) [universal.x86_64-darwin18]", nil]
       )

--- a/test/project_types/rails/test_helper.rb
+++ b/test/project_types/rails/test_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require "test_helper"
 
-ShopifyCli::ProjectType.load_type(:rails)
+ShopifyCLI::ProjectType.load_type(:rails)

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -11,7 +11,7 @@ module Script
 
       def setup
         super
-        ShopifyCli::Core::Monorail.stubs(:log).yields
+        ShopifyCLI::Core::Monorail.stubs(:log).yields
         @context = TestHelpers::FakeContext.new
         @language = "assemblyscript"
         @script_name = "name"
@@ -23,7 +23,7 @@ module Script
           script_name: @script_name
         )
         Layers::Application::ExtensionPoints.stubs(:languages).returns(%w(assemblyscript))
-        ShopifyCli::Tasks::EnsureAuthenticated.stubs(:call)
+        ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
       end
 
       def test_prints_help_with_no_name_argument
@@ -68,9 +68,9 @@ module Script
 
       def test_help
         Script::Layers::Application::ExtensionPoints.expects(:available_types).returns(%w(ep1 ep2))
-        ShopifyCli::Context
+        ShopifyCLI::Context
           .expects(:message)
-          .with("script.create.help", ShopifyCli::TOOL_NAME, "{{cyan:ep1}}, {{cyan:ep2}}")
+          .with("script.create.help", ShopifyCLI::TOOL_NAME, "{{cyan:ep1}}, {{cyan:ep2}}")
         Script::Command::Create.help
       end
 

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -11,7 +11,7 @@ module Script
         @api_key = "apikey"
         @uuid = "uuid"
         @force = true
-        @env = ShopifyCli::Resources::EnvFile.new(api_key: @api_key, secret: "shh", extra: { "UUID" => @uuid })
+        @env = ShopifyCLI::Resources::EnvFile.new(api_key: @api_key, secret: "shh", extra: { "UUID" => @uuid })
         @script_project_repo = TestHelpers::FakeScriptProjectRepository.new
         @script_project_repo.create(
           language: "assemblyscript",
@@ -20,7 +20,7 @@ module Script
           env: @env
         )
         Script::Layers::Infrastructure::ScriptProjectRepository.stubs(:new).returns(@script_project_repo)
-        ShopifyCli::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
       end
 
       def test_calls_push_script
@@ -34,9 +34,9 @@ module Script
       end
 
       def test_help
-        ShopifyCli::Context
+        ShopifyCLI::Context
           .expects(:message)
-          .with("script.push.help", ShopifyCli::TOOL_NAME)
+          .with("script.push.help", ShopifyCLI::TOOL_NAME)
         Script::Command::Push.help
       end
 

--- a/test/project_types/script/forms/create_test.rb
+++ b/test/project_types/script/forms/create_test.rb
@@ -9,7 +9,7 @@ module Script
 
       def setup
         super
-        ShopifyCli::ProjectType.load_type(:script)
+        ShopifyCLI::ProjectType.load_type(:script)
         @context = TestHelpers::FakeContext.new
       end
 

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -43,7 +43,7 @@ describe Script::Layers::Application::CreateScript do
 
   describe ".call" do
     subject do
-      ShopifyCli::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
+      ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
 
       Script::Layers::Application::CreateScript.call(
         ctx: context,

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -45,7 +45,7 @@ describe Script::Layers::Application::ExtensionPoints do
   describe ".available_types" do
     describe "when beta flag is disabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(false).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(false).at_least_once
       end
       it "should return an array of all ep types that are not deprecated or in beta" do
         assert_equal %w(discount), Script::Layers::Application::ExtensionPoints.available_types
@@ -54,7 +54,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe "when beta flag is enabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(true).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_extension_points).returns(true).at_least_once
       end
       it "should return an array of all ep types that are not deprecated or in beta" do
         assert_equal %w(discount tax_filter), Script::Layers::Application::ExtensionPoints.available_types
@@ -82,7 +82,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe "when beta language flag is enabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
       end
 
       it "should return all languages" do
@@ -92,7 +92,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe "when beta language flag is not enabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
       end
 
       it "should return only fully supported languages" do
@@ -116,7 +116,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe "when beta language flag is enabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
       end
 
       describe "when asking about supported language" do
@@ -154,7 +154,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
     describe "when beta language flag is not enabled" do
       before do
-        ShopifyCli::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
+        ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once
       end
 
       describe "when asking about supported language" do

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -19,7 +19,7 @@ describe Script::Layers::Application::PushScript do
       language: language,
       extension_point_type: extension_point_type,
       script_name: script_name,
-      env: ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: "shh")
+      env: ShopifyCLI::Resources::EnvFile.new(api_key: api_key, secret: "shh")
     )
   end
   let(:push_package_repository) { TestHelpers::FakePushPackageRepository.new }

--- a/test/project_types/script/layers/domain/metadata_test.rb
+++ b/test/project_types/script/layers/domain/metadata_test.rb
@@ -6,7 +6,7 @@ describe Script::Layers::Domain::Metadata do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
-  let(:ctx) { ShopifyCli::Context.new }
+  let(:ctx) { ShopifyCLI::Context.new }
 
   describe ".new" do
     subject { Script::Layers::Domain::Metadata.new(schema_major_version, schema_minor_version, use_msgpack) }

--- a/test/project_types/script/layers/domain/script_project_test.rb
+++ b/test/project_types/script/layers/domain/script_project_test.rb
@@ -4,7 +4,7 @@ require "project_types/script/test_helper"
 
 describe Script::Layers::Domain::ScriptProject do
   let(:id) { "id" }
-  let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh") }
+  let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: "1234", secret: "shh") }
   let(:extension_point_type) { "discount" }
   let(:script_name) { "foo_script" }
   let(:language) { "assemblyscript" }
@@ -37,7 +37,7 @@ describe Script::Layers::Domain::ScriptProject do
         "script_name" => script_name,
         "extension_point_type" => extension_point_type,
         "language" => language,
-      }, ShopifyCli::Core::Monorail.metadata)
+      }, ShopifyCLI::Core::Monorail.metadata)
     end
 
     describe "when all properties are present" do

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -33,7 +33,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
 
     subject do
-      ShopifyCli::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
+      ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
 
       instance.create(
         script_name: script_name,
@@ -113,8 +113,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
 
     before do
-      ShopifyCli::Project.stubs(:has_current?).returns(true)
-      ShopifyCli::Project.stubs(:current).returns(current_project)
+      ShopifyCLI::Project.stubs(:has_current?).returns(true)
+      ShopifyCLI::Project.stubs(:current).returns(current_project)
       ctx.write(script_json, script_json_content.to_json)
     end
 
@@ -130,10 +130,10 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       describe "when env has values" do
         let(:uuid) { "uuid" }
         let(:api_key) { "api_key" }
-        let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: "foo", extra: { "UUID" => uuid }) }
+        let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: api_key, secret: "foo", extra: { "UUID" => uuid }) }
 
         it "should provide access to the env values" do
-          ShopifyCli::Project.any_instance.expects(:env).returns(env).at_least_once
+          ShopifyCLI::Project.any_instance.expects(:env).returns(env).at_least_once
 
           assert_equal env, subject.env
           assert_equal uuid, subject.uuid
@@ -219,7 +219,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     let(:updated_uuid) { "updated_uuid" }
     let(:script_json) { "script.json" }
     let(:script_json_content) { { "version" => "1", "title" => script_name }.to_json }
-    let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "123", secret: "foo", extra: env_extra) }
+    let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: "123", secret: "foo", extra: env_extra) }
     let(:env_extra) { { "uuid" => "original_uuid", "something" => "else" } }
     let(:valid_config) do
       {
@@ -242,14 +242,14 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       ctx.mkdir_p(dir)
       ctx.chdir(dir)
 
-      ShopifyCli::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
+      ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
       instance.create(
         script_name: script_name,
         extension_point_type: extension_point_type,
         language: language
       )
       ctx.write(script_json, script_json_content)
-      ShopifyCli::Project.any_instance.expects(:env).returns(env).at_least_once
+      ShopifyCLI::Project.any_instance.expects(:env).returns(env).at_least_once
     end
 
     describe "when updating an immutable property" do
@@ -264,9 +264,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       end
 
       it "should do nothing" do
-        previous_config = ShopifyCli::Project.current.config
+        previous_config = ShopifyCLI::Project.current.config
         assert subject
-        updated_config = ShopifyCli::Project.current.config
+        updated_config = ShopifyCLI::Project.current.config
         assert_equal previous_config, updated_config
       end
     end
@@ -277,10 +277,10 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       end
 
       it "should update the property" do
-        previous_env = ShopifyCli::Project.current.env.to_h
+        previous_env = ShopifyCLI::Project.current.env.to_h
         assert subject
-        ShopifyCli::Project.clear
-        updated_env = ShopifyCli::Project.current.env.to_h
+        ShopifyCLI::Project.clear
+        updated_env = ShopifyCLI::Project.current.env.to_h
 
         assert_equal hash_except(previous_env, "UUID"), hash_except(updated_env, "UUID")
         refute_equal previous_env["UUID"], updated_env["UUID"]
@@ -307,8 +307,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
 
     before do
-      ShopifyCli::Project.stubs(:has_current?).returns(true)
-      ShopifyCli::Project.stubs(:current).returns(current_project)
+      ShopifyCLI::Project.stubs(:has_current?).returns(true)
+      ShopifyCLI::Project.stubs(:current).returns(current_project)
     end
 
     subject { instance.update_or_create_script_json(title: new_title, configuration_ui: new_configuration_ui) }

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -354,6 +354,6 @@ describe Script::Layers::Infrastructure::ScriptService do
   private
 
   def stub_load_query(name, body)
-    ShopifyCli::API.any_instance.stubs(:load_query).with(name).returns(body)
+    ShopifyCLI::API.any_instance.stubs(:load_query).with(name).returns(body)
   end
 end

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -117,6 +117,6 @@ describe Script::Layers::Infrastructure::ScriptUploader do
   private
 
   def stub_load_query(name, body)
-    ShopifyCli::API.any_instance.stubs(:load_query).with(name).returns(body)
+    ShopifyCLI::API.any_instance.stubs(:load_query).with(name).returns(body)
   end
 end

--- a/test/project_types/script/tasks/ensure_env_test.rb
+++ b/test/project_types/script/tasks/ensure_env_test.rb
@@ -21,8 +21,8 @@ describe Script::Tasks::EnsureEnv do
 
     before do
       context.output_captured = true
-      ShopifyCli::Shopifolk.stubs(:check).returns(is_shopifolk)
-      ShopifyCli::Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+      ShopifyCLI::Shopifolk.stubs(:check).returns(is_shopifolk)
+      ShopifyCLI::Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       Script::Layers::Infrastructure::ScriptProjectRepository.stubs(:new).returns(script_project_repository)
       script_project_repository.create(
         language: language,
@@ -33,12 +33,12 @@ describe Script::Tasks::EnsureEnv do
     end
 
     describe "when env already has all required fields" do
-      let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "api_key", secret: "shh", extra: { "UUID" => "uuid" }) }
+      let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: "api_key", secret: "shh", extra: { "UUID" => "uuid" }) }
 
       it "does nothing" do
         CLI::UI::Prompt.expects(:ask).never
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::PartnersAPI.expects(:query).never
+        ShopifyCLI::PartnersAPI.expects(:query).never
         Script::Layers::Infrastructure::ScriptService.any_instance.expects(:get_app_scripts).never
 
         refute subject
@@ -91,7 +91,7 @@ describe Script::Tasks::EnsureEnv do
         let(:selected_uuid) { nil }
 
         before do
-          ShopifyCli::PartnersAPI::Organizations
+          ShopifyCLI::PartnersAPI::Organizations
             .stubs(:fetch_with_app)
             .returns(orgs_with_apps)
           Script::Layers::Infrastructure::ScriptService
@@ -150,7 +150,7 @@ describe Script::Tasks::EnsureEnv do
           end
 
           it("should not call partners to query for apps") do
-            ShopifyCli::PartnersAPI.expects(:query).never
+            ShopifyCLI::PartnersAPI.expects(:query).never
             Script::Layers::Infrastructure::ScriptService.any_instance.expects(:get_app_scripts).returns([])
 
             subject
@@ -264,7 +264,7 @@ describe Script::Tasks::EnsureEnv do
       end
 
       describe "when missing uuid" do
-        let(:env) { ShopifyCli::Resources::EnvFile.new(api_key: "api_key", secret: "shh") }
+        let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: "api_key", secret: "shh") }
 
         it_prompts_user_and_update_env
       end

--- a/test/project_types/script/test_helper.rb
+++ b/test/project_types/script/test_helper.rb
@@ -1,4 +1,4 @@
 require "test_helper"
 require_relative "test_helpers"
 
-ShopifyCli::ProjectType.load_type(:script)
+ShopifyCLI::ProjectType.load_type(:script)

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -11,7 +11,7 @@ module TestHelpers
 
       @project = Script::Layers::Domain::ScriptProject.new(
         id: "/#{script_name}",
-        env: env || ShopifyCli::Resources::EnvFile.new(api_key: "1234", secret: "shh", extra: {}),
+        env: env || ShopifyCLI::Resources::EnvFile.new(api_key: "1234", secret: "shh", extra: {}),
         script_name: script_name,
         extension_point_type: extension_point_type,
         language: language,
@@ -32,7 +32,7 @@ module TestHelpers
     end
 
     def create_env(api_key:, secret:, uuid:)
-      @project.env = ShopifyCli::Resources::EnvFile.new(api_key: api_key, secret: secret, extra: { "UUID" => uuid })
+      @project.env = ShopifyCLI::Resources::EnvFile.new(api_key: api_key, secret: secret, extra: { "UUID" => uuid })
       @project
     end
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -26,7 +26,7 @@ describe Script::UI::ErrorHandler do
           $stderr.expects(:puts).with("\e[0;31m✗ Error\e[0m")
           $stderr.expects(:puts).with("\e[0m#{failed_op} #{cause_of_error} #{help_suggestion}")
         end
-        assert_raises(ShopifyCli::AbortSilent) do
+        assert_raises(ShopifyCLI::AbortSilent) do
           subject
         end
       end
@@ -42,7 +42,7 @@ describe Script::UI::ErrorHandler do
           $stderr.expects(:puts).with("\e[0;31m✗ Error\e[0m")
           $stderr.expects(:puts).with("\e[0m#{cause_of_error} #{help_suggestion}")
         end
-        assert_raises(ShopifyCli::AbortSilent) do
+        assert_raises(ShopifyCLI::AbortSilent) do
           subject
         end
       end
@@ -58,7 +58,7 @@ describe Script::UI::ErrorHandler do
           $stderr.expects(:puts).with("\e[0;31m✗ Error\e[0m")
           $stderr.expects(:puts).with("\e[0m#{failed_op} #{help_suggestion}")
         end
-        assert_raises(ShopifyCli::AbortSilent) do
+        assert_raises(ShopifyCLI::AbortSilent) do
           subject
         end
       end
@@ -74,7 +74,7 @@ describe Script::UI::ErrorHandler do
           $stderr.expects(:puts).with("\e[0;31m✗ Error\e[0m")
           $stderr.expects(:puts).with("\e[0m#{failed_op} #{cause_of_error}")
         end
-        assert_raises(ShopifyCli::AbortSilent) do
+        assert_raises(ShopifyCLI::AbortSilent) do
           subject
         end
       end
@@ -115,7 +115,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when Oauth::Error" do
-        let(:err) { ShopifyCli::IdentityAuth::Error.new }
+        let(:err) { ShopifyCLI::IdentityAuth::Error.new }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
@@ -207,7 +207,7 @@ describe Script::UI::ErrorHandler do
         it "should not display deprecated or beta APIs" do
           expected_types = %w(payment_methods shipping_methods)
           Script::Layers::Application::ExtensionPoints.expects(:available_types).returns(expected_types)
-          io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { subject }
+          io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) { subject }
           assert_match(expected_types.join(", "), io.join)
         end
       end

--- a/test/project_types/script/ui/printing_spinner_test.rb
+++ b/test/project_types/script/ui/printing_spinner_test.rb
@@ -71,7 +71,7 @@ describe Script::UI::PrintingSpinner do
   def ctx_expects_puts_with_encoding(*lines)
     spinner_text = "spinning.."
     encoded_input = lines.map { |line| "\e[1A\e[1G" + line + "\e[K" }.join("\e[1B\e[1G\n")
-    ShopifyCli::Context.any_instance.expects(:puts).with("#{encoded_input}\n#{spinner_text}")
+    ShopifyCLI::Context.any_instance.expects(:puts).with("#{encoded_input}\n#{spinner_text}")
     Script::UI::PrintingSpinner
       .const_get(:PrintingSpinnerContext)
       .any_instance

--- a/test/project_types/theme/commands/check_test.rb
+++ b/test/project_types/theme/commands/check_test.rb
@@ -8,14 +8,14 @@ module Theme
       include TestHelpers::FakeUI
 
       def test_command_runs_theme_check
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
         ThemeCheck::Cli.any_instance.expects(:run)
 
         Theme::Command::Check.new(context).call([])
       end
 
       def test_parse_options
-        context = ShopifyCli::Context.new
+        context = ShopifyCLI::Context.new
         ThemeCheck::Cli.any_instance.expects(:parse).with(["-l"])
 
         command = Theme::Command::Check.new(context)

--- a/test/project_types/theme/commands/delete_test.rb
+++ b/test/project_types/theme/commands/delete_test.rb
@@ -9,7 +9,7 @@ module Theme
       def setup
         super
 
-        @ctx = ShopifyCli::Context.new
+        @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Delete.new(@ctx)
 
         @config = mock("Config")
@@ -25,7 +25,7 @@ module Theme
       end
 
       def test_delete_theme_ids
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
@@ -38,13 +38,13 @@ module Theme
       end
 
       def test_delete_unexisting_theme_ids
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
         CLI::UI::Prompt.expects(:confirm).returns(true)
 
-        @theme.expects(:delete).raises(ShopifyCli::API::APIRequestNotFoundError)
+        @theme.expects(:delete).raises(ShopifyCLI::API::APIRequestNotFoundError)
         @ctx.expects(:puts)
         @ctx.expects(:done)
 
@@ -52,7 +52,7 @@ module Theme
       end
 
       def test_cant_delete_live_theme
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
@@ -65,7 +65,7 @@ module Theme
       end
 
       def test_delete_development_theme
-        ShopifyCli::Theme::DevelopmentTheme.expects(:new)
+        ShopifyCLI::Theme::DevelopmentTheme.expects(:new)
           .with(@ctx)
           .returns(@theme)
 
@@ -89,7 +89,7 @@ module Theme
       end
 
       def test_delete_select_aborting
-        CLI::UI::Prompt.expects(:ask).raises(ShopifyCli::Abort)
+        CLI::UI::Prompt.expects(:ask).raises(ShopifyCLI::Abort)
         @ctx.expects(:puts)
 
         @theme.expects(:delete).never

--- a/test/project_types/theme/commands/init_test.rb
+++ b/test/project_types/theme/commands/init_test.rb
@@ -9,25 +9,25 @@ module Theme
       def setup
         super
 
-        @ctx = ShopifyCli::Context.new
+        @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Init.new(@ctx)
       end
 
       def test_clones_repo
-        ShopifyCli::Git.expects(:clone).with(Theme::Command::Init::DEFAULT_CLONE_URL, "repo-name")
+        ShopifyCLI::Git.expects(:clone).with(Theme::Command::Init::DEFAULT_CLONE_URL, "repo-name")
 
         @command.call(["repo-name"], "init")
       end
 
       def test_ask_repo_name
-        ShopifyCli::Git.expects(:clone).with(Theme::Command::Init::DEFAULT_CLONE_URL, "repo-name")
+        ShopifyCLI::Git.expects(:clone).with(Theme::Command::Init::DEFAULT_CLONE_URL, "repo-name")
         CLI::UI::Prompt.expects(:ask).returns("repo-name")
 
         @command.call([], "init")
       end
 
       def test_repo_url_in_options
-        ShopifyCli::Git.expects(:clone).with("CLONE_URL", "repo-name")
+        ShopifyCLI::Git.expects(:clone).with("CLONE_URL", "repo-name")
 
         @command.options.flags[:clone_url] = "CLONE_URL"
         @command.call(["repo-name"], "init")

--- a/test/project_types/theme/commands/package_test.rb
+++ b/test/project_types/theme/commands/package_test.rb
@@ -12,7 +12,7 @@ module Theme
       end
 
       def test_package_theme
-        theme_root = File.join(ShopifyCli::ROOT, "test/fixtures/theme")
+        theme_root = File.join(ShopifyCLI::ROOT, "test/fixtures/theme")
         @context.expects(:system).with(
           "zip",
           "-r",

--- a/test/project_types/theme/commands/publish_test.rb
+++ b/test/project_types/theme/commands/publish_test.rb
@@ -9,7 +9,7 @@ module Theme
       def setup
         super
 
-        @ctx = ShopifyCli::Context.new
+        @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Publish.new(@ctx)
 
         @theme = stub(
@@ -24,7 +24,7 @@ module Theme
       end
 
       def test_publish
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
@@ -37,7 +37,7 @@ module Theme
       end
 
       def test_publish_without_confirmation
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
@@ -49,7 +49,7 @@ module Theme
       end
 
       def test_publish_force_with_option
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, id: 1234)
           .returns(@theme)
 
@@ -71,7 +71,7 @@ module Theme
       end
 
       def test_publish_select_aborting
-        CLI::UI::Prompt.expects(:ask).raises(ShopifyCli::Abort)
+        CLI::UI::Prompt.expects(:ask).raises(ShopifyCLI::Abort)
         @ctx.expects(:puts)
 
         @theme.expects(:publish).never

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -9,7 +9,7 @@ module Theme
       def setup
         super
 
-        @ctx = ShopifyCli::Context.new
+        @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Pull.new(@ctx)
 
         @theme = stub(
@@ -23,13 +23,13 @@ module Theme
       end
 
       def test_pull_theme
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -44,13 +44,13 @@ module Theme
       end
 
       def test_pull_pass_nodelete_to_syncer
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -67,14 +67,14 @@ module Theme
       end
 
       def test_pull_with_ignores
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
         @ignore_filter.expects(:add_patterns).with(["config/*"])
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -96,9 +96,9 @@ module Theme
 
         @syncer.expects(:download_theme!).with(delete: true)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -9,7 +9,7 @@ module Theme
       def setup
         super
 
-        @ctx = ShopifyCli::Context.new
+        @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Push.new(@ctx)
 
         @theme = stub(
@@ -26,13 +26,13 @@ module Theme
       end
 
       def test_push_to_theme_id
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -47,7 +47,7 @@ module Theme
       end
 
       def test_push_to_live_theme
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
@@ -55,9 +55,9 @@ module Theme
 
         CLI::UI::Prompt.expects(:confirm).returns(true)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -72,7 +72,7 @@ module Theme
       end
 
       def test_allow_live
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
@@ -80,9 +80,9 @@ module Theme
 
         CLI::UI::Prompt.expects(:confirm).never
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -98,15 +98,15 @@ module Theme
       end
 
       def test_push_json
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
         @theme.expects(:to_h).returns({})
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -124,13 +124,13 @@ module Theme
       end
 
       def test_push_and_publish
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -147,14 +147,14 @@ module Theme
       end
 
       def test_push_with_ignores
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
         @ignore_filter.expects(:add_patterns).with(["config/*"])
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -170,15 +170,15 @@ module Theme
       end
 
       def test_push_to_development_theme
-        ShopifyCli::Theme::DevelopmentTheme.expects(:new)
+        ShopifyCLI::Theme::DevelopmentTheme.expects(:new)
           .with(@ctx, root: ".")
           .returns(@theme)
 
         @theme.expects(:ensure_exists!)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -194,7 +194,7 @@ module Theme
       end
 
       def test_push_to_unpublished_theme
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", name: "NAME", role: "unpublished")
           .returns(@theme)
 
@@ -202,9 +202,9 @@ module Theme
 
         @theme.expects(:create)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -220,13 +220,13 @@ module Theme
       end
 
       def test_push_pass_nodelete_to_syncer
-        ShopifyCli::Theme::Theme.expects(:new)
+        ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -248,9 +248,9 @@ module Theme
 
         @syncer.expects(:upload_theme!).with(delete: true)
 
-        ShopifyCli::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
-        ShopifyCli::Theme::Syncer.expects(:new)
+        ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
           .returns(@syncer)
 
@@ -261,10 +261,10 @@ module Theme
       end
 
       def test_push_select_aborting
-        CLI::UI::Prompt.expects(:ask).raises(ShopifyCli::Abort)
+        CLI::UI::Prompt.expects(:ask).raises(ShopifyCLI::Abort)
         @ctx.expects(:puts)
 
-        ShopifyCli::Theme::Syncer.expects(:new).never
+        ShopifyCLI::Theme::Syncer.expects(:new).never
 
         @command.call([], "push")
       end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -8,15 +8,15 @@ module Theme
       include TestHelpers::FakeUI
 
       def test_serve_command
-        context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", optionally({}))
+        context = ShopifyCLI::Context.new
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", optionally({}))
 
         Theme::Command::Serve.new(context).call
       end
 
       def test_can_specify_port
-        context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", port: 9293)
+        context = ShopifyCLI::Context.new
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", port: 9293)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:port] = 9293
@@ -24,8 +24,8 @@ module Theme
       end
 
       def test_can_specify_env
-        context = ShopifyCli::Context.new
-        ShopifyCli::Theme::DevServer.expects(:start).with(context, ".", env: "staging")
+        context = ShopifyCLI::Context.new
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", env: "staging")
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:env] = "staging"

--- a/test/project_types/theme/test_helper.rb
+++ b/test/project_types/theme/test_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require "test_helper"
 
-ShopifyCli::ProjectType.load_type(:theme)
+ShopifyCLI::ProjectType.load_type(:theme)

--- a/test/shopify-cli/admin_api/populate_resource_command_test.rb
+++ b/test/shopify-cli/admin_api/populate_resource_command_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class AdminAPI
     class PopulateResourceCommandTest < MiniTest::Test
       include TestHelpers::Project
@@ -8,13 +8,13 @@ module ShopifyCli
 
       def setup
         super
-        @resource = ShopifyCli::Commands::Populate::Product.new(@context)
-        ShopifyCli::AdminAPI.stubs(:new).returns(Object.new)
+        @resource = ShopifyCLI::Commands::Populate::Product.new(@context)
+        ShopifyCLI::AdminAPI.stubs(:new).returns(Object.new)
       end
 
       def test_with_schema_args_overrides_input
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-        ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+        ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
         CLI::UI::Prompt.expects(:confirm)
           .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.io"), default: false)
           .returns(true)
@@ -27,30 +27,30 @@ module ShopifyCli
       end
 
       def test_if_no_shop
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(false)
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(false)
         @resource.expects(:run_mutation).never
-        exception = assert_raises ShopifyCli::Abort do
+        exception = assert_raises ShopifyCLI::Abort do
           @resource.call([], nil)
         end
         assert_equal(
-          "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME),
+          "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME),
           exception.message
         )
       end
 
       def test_populate_runs_mutation_default_number_of_times
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-        ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+        ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
         CLI::UI::Prompt.expects(:confirm)
           .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.io"), default: false)
           .returns(true)
-        @resource.expects(:run_mutation).times(ShopifyCli::Commands::Populate::Product::DEFAULT_COUNT)
+        @resource.expects(:run_mutation).times(ShopifyCLI::Commands::Populate::Product::DEFAULT_COUNT)
         @resource.call([], nil)
       end
 
       def test_populate_runs_mutation_count_number_of_times
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-        ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+        ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").twice
         CLI::UI::Prompt.expects(:confirm)
           .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.io"), default: false)
           .returns(true)
@@ -59,8 +59,8 @@ module ShopifyCli
       end
 
       def test_populate_does_not_ask_confirmation_if_skip_shop_confirmation
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).once
-        ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").once
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).once
+        ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.io").once
         CLI::UI::Prompt.expects(:confirm)
           .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.io"), default: false)
           .never

--- a/test/shopify-cli/admin_api/schema_test.rb
+++ b/test/shopify-cli/admin_api/schema_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class AdminAPI
     class SchemaTest < MiniTest::Test
       include TestHelpers::Project
 
       def setup
         super
-        json_data = File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))
+        json_data = File.read(File.join(ShopifyCLI::ROOT, "test/fixtures/shopify_schema.json"))
         @test_obj = AdminAPI::Schema[JSON.parse(json_data)]
         @enum = {
           "kind" => "ENUM",
@@ -17,20 +17,20 @@ module ShopifyCli
       end
 
       def test_gets_schema
-        ShopifyCli::DB.expects(:exists?).with(:shopify_admin_schema).returns(false)
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true)
-        ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com")
-        ShopifyCli::DB.expects(:set).with(shopify_admin_schema: "{\"foo\":\"baz\"}")
-        ShopifyCli::DB.expects(:get).with(:shopify_admin_schema).returns("{\"foo\":\"baz\"}")
-        ShopifyCli::AdminAPI.expects(:query)
+        ShopifyCLI::DB.expects(:exists?).with(:shopify_admin_schema).returns(false)
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com")
+        ShopifyCLI::DB.expects(:set).with(shopify_admin_schema: "{\"foo\":\"baz\"}")
+        ShopifyCLI::DB.expects(:get).with(:shopify_admin_schema).returns("{\"foo\":\"baz\"}")
+        ShopifyCLI::AdminAPI.expects(:query)
           .with(@context, "admin_introspection", shop: "my-test-shop.myshopify.com")
           .returns(foo: "baz")
         assert_equal({ "foo" => "baz" }, AdminAPI::Schema.get(@context))
       end
 
       def test_gets_schema_if_already_downloaded
-        ShopifyCli::DB.expects(:exists?).returns(true)
-        ShopifyCli::DB.expects(:get).with(:shopify_admin_schema).returns("{\"foo\":\"baz\"}")
+        ShopifyCLI::DB.expects(:exists?).returns(true)
+        ShopifyCLI::DB.expects(:get).with(:shopify_admin_schema).returns("{\"foo\":\"baz\"}")
         assert_equal({ "foo" => "baz" }, AdminAPI::Schema.get(@context))
       end
 

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class AdminAPITest < MiniTest::Test
     include TestHelpers::Project
 
@@ -15,7 +15,7 @@ module ShopifyCli
         .with("api_versions")
         .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "api/versions.json"))))
 
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -27,7 +27,7 @@ module ShopifyCli
     end
 
     def test_query_calls_admin_api
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123")
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123")
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -62,7 +62,7 @@ module ShopifyCli
     end
 
     def test_query_can_reauth
-      ShopifyCli::DB.stubs(:get).with(:shopify_exchange_token).returns("token123").then.returns("token456")
+      ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("token123").then.returns("token456")
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -78,7 +78,7 @@ module ShopifyCli
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError)
 
       @identity_auth_client = mock
-      ShopifyCli::IdentityAuth
+      ShopifyCLI::IdentityAuth
         .expects(:new)
         .with(ctx: @context)
         .returns(@identity_auth_client)
@@ -92,7 +92,7 @@ module ShopifyCli
     end
 
     def test_rest_request_can_reauth
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -105,7 +105,7 @@ module ShopifyCli
       api_stub.expects(:request).raises(API::APIRequestUnauthorizedError)
 
       @identity_auth_client = mock
-      ShopifyCli::IdentityAuth
+      ShopifyCLI::IdentityAuth
         .expects(:new)
         .with(ctx: @context)
         .returns(@identity_auth_client)
@@ -123,7 +123,7 @@ module ShopifyCli
     end
 
     def test_query_calls_admin_api_with_different_shop
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123")
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123")
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -137,7 +137,7 @@ module ShopifyCli
     end
 
     def test_query_fails_gracefully_when_unable_to_authenticate
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
       api_stub = stub
       AdminAPI.expects(:new).with(
         ctx: @context,
@@ -147,10 +147,10 @@ module ShopifyCli
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError).twice
 
       @identity_auth_client = mock
-      ShopifyCli::IdentityAuth.expects(:new).returns(@identity_auth_client)
+      ShopifyCLI::IdentityAuth.expects(:new).returns(@identity_auth_client)
       @identity_auth_client.expects(:reauthenticate)
 
-      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
         AdminAPI.query(@context, "query", shop: "shop.myshopify.com", api_version: "2019-04")
       end
       assert_message_output(
@@ -171,15 +171,15 @@ module ShopifyCli
       unstable_stub.expects(:query)
         .with("api_versions")
         .raises(API::APIRequestForbiddenError)
-      ShopifyCli::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
+      ShopifyCLI::DB.expects(:get).with(:shopify_exchange_token).returns("token123").twice
 
-      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
         AdminAPI.query(@context, "query", shop: "my-test-shop.myshopify.com")
       end
       assert_message_output(
         io: io,
         expected_content: [
-          @context.message("core.api.error.forbidden", ShopifyCli::TOOL_NAME),
+          @context.message("core.api.error.forbidden", ShopifyCLI::TOOL_NAME),
         ]
       )
     end

--- a/test/shopify-cli/api_test.rb
+++ b/test/shopify-cli/api_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "shopify_cli/http_request"
 
-module ShopifyCli
+module ShopifyCLI
   class APITest < MiniTest::Test
     class TestAPI < API
       def call_load_query(query_name)
@@ -26,14 +26,14 @@ module ShopifyCli
         token: "faketoken",
         url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
       )
-      ShopifyCli.stubs(:sha).returns("abcde")
+      ShopifyCLI.stubs(:sha).returns("abcde")
       @context.stubs(:uname).returns("Mac")
     end
 
     def test_mutation_makes_request_to_shopify
       headers = {
-        "User-Agent" => "Shopify CLI; v=#{ShopifyCli::VERSION}",
-        "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCli::VERSION} sha=#{ShopifyCli.sha}",
+        "User-Agent" => "Shopify CLI; v=#{ShopifyCLI::VERSION}",
+        "Sec-CH-UA" => "Shopify CLI; v=#{ShopifyCLI::VERSION} sha=#{ShopifyCLI.sha}",
         "Sec-CH-UA-PLATFORM" => @context.os.to_s,
         "Auth" => "faketoken",
       }
@@ -41,7 +41,7 @@ module ShopifyCli
       variables = { var_name: "var_value" }
       body = JSON.dump(query: @mutation.tr("\n", ""), variables: variables)
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
       response = stub("response", code: "200", body: "{}")
       HttpRequest.expects(:post).with(uri, body, headers).returns(response)
@@ -50,7 +50,7 @@ module ShopifyCli
 
     def test_raises_error_with_invalid_url
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
       api = API.new(
         ctx: @context,
@@ -59,7 +59,7 @@ module ShopifyCli
         url: "https//https://invalidurl",
       )
 
-      assert_raises(ShopifyCli::Abort) do
+      assert_raises(ShopifyCLI::Abort) do
         api.query("api/mutation")
       end
     end
@@ -68,7 +68,7 @@ module ShopifyCli
       response = stub("response", code: "500", body: "{}")
       HttpRequest.expects(:post).returns(response).times(4)
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
       @context.expects(:puts).with(@context.message("core.api.error.internal_server_error"))
@@ -84,7 +84,7 @@ module ShopifyCli
       response = stub("response", code: "500", body: "{}")
       HttpRequest.expects(:post).returns(response).times(4)
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
       @context.expects(:debug).with(@context.message("core.api.error.internal_server_error_debug", "500\n{}"))
@@ -100,7 +100,7 @@ module ShopifyCli
       response = stub("response", code: "600", body: "{}")
       HttpRequest.expects(:post).returns(response)
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
 
       @context.expects(:puts).with(@context.message("core.api.error.internal_server_error"))
@@ -113,9 +113,9 @@ module ShopifyCli
 
     def test_load_query_can_load_project_type_queries
       new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
-      ShopifyCli::Project.expects(:current_project_type).returns(:fake)
+      ShopifyCLI::Project.expects(:current_project_type).returns(:fake)
 
-      expected_path = File.join(ShopifyCli::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
+      expected_path = File.join(ShopifyCLI::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
       File.expects(:exist?).with(expected_path).returns(true)
       File.expects(:read).with(expected_path).returns("content")
 
@@ -124,12 +124,12 @@ module ShopifyCli
 
     def test_load_query_will_fall_back_to_core_queries
       new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
-      ShopifyCli::Project.expects(:current_project_type).returns(:fake)
+      ShopifyCLI::Project.expects(:current_project_type).returns(:fake)
 
-      project_type_path = File.join(ShopifyCli::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
+      project_type_path = File.join(ShopifyCLI::ROOT, "lib", "project_types", "fake", "graphql", "my_query.graphql")
       File.expects(:exist?).with(project_type_path).returns(false)
 
-      expected_path = File.join(ShopifyCli::ROOT, "lib", "graphql", "my_query.graphql")
+      expected_path = File.join(ShopifyCLI::ROOT, "lib", "graphql", "my_query.graphql")
       File.expects(:read).with(expected_path).returns("content")
 
       assert_equal("content", new_api.call_load_query("my_query"))
@@ -137,8 +137,8 @@ module ShopifyCli
 
     def test_load_query_will_not_read_project_type_queries_if_not_in_project
       new_api = TestAPI.new(ctx: Context.new, token: "blah", url: "alsoblah")
-      ShopifyCli::Project.expects(:current_project_type).returns(nil)
-      expected_path = File.join(ShopifyCli::ROOT, "lib", "graphql", "my_query.graphql")
+      ShopifyCLI::Project.expects(:current_project_type).returns(nil)
+      expected_path = File.join(ShopifyCLI::ROOT, "lib", "graphql", "my_query.graphql")
       File.expects(:read).with(expected_path).returns("content")
       assert_equal("content", new_api.call_load_query("my_query"))
     end
@@ -146,7 +146,7 @@ module ShopifyCli
     def test_include_shopify_cli_header_if_acting_as_shopify_organization
       Shopifolk.act_as_shopify_organization
       File.stubs(:read)
-        .with(File.join(ShopifyCli::ROOT, "lib/graphql/api/mutation.graphql"))
+        .with(File.join(ShopifyCLI::ROOT, "lib/graphql/api/mutation.graphql"))
         .returns(@mutation)
       mutation = JSON.dump(query: @mutation.tr("\n", ""), variables: {})
       response = stub("response", code: "200", body: "{}")

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class CommandTest < MiniTest::Test
       def test_non_existant
         io = capture_io do
-          assert_raises(ShopifyCli::AbortSilent) do
+          assert_raises(ShopifyCLI::AbortSilent) do
             run_cmd("foobar")
           end
         end
@@ -26,7 +26,7 @@ module ShopifyCli
           run_cmd("populate customer --help")
         end
 
-        assert_match(CLI::UI.fmt(ShopifyCli::Commands::Populate::Customer.help), io.join)
+        assert_match(CLI::UI.fmt(ShopifyCLI::Commands::Populate::Customer.help), io.join)
       end
     end
   end

--- a/test/shopify-cli/commands/config_test.rb
+++ b/test/shopify-cli/commands/config_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class ConfigTest < MiniTest::Test
       include TestHelpers::FakeFS
@@ -9,58 +9,58 @@ module ShopifyCli
 
       def setup
         super
-        ShopifyCli::Core::Monorail.stubs(:log).yields
+        ShopifyCLI::Core::Monorail.stubs(:log).yields
       end
 
       def test_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Config.help)
         run_cmd("config help")
       end
 
       def test_feature_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Config::Feature.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Config::Feature.help)
         run_cmd("config feature --help")
       end
 
       def test_analytics_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Config::Analytics.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Config::Analytics.help)
         run_cmd("config analytics --help")
       end
 
       def test_no_arguments_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Config.help)
         run_cmd("config")
       end
 
       def test_no_feature_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Config.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Config.help)
         run_cmd("config feature")
       end
 
       def test_will_enable_a_feature_that_is_disabled
-        ShopifyCli::Feature.disable(TEST_FEATURE)
+        ShopifyCLI::Feature.disable(TEST_FEATURE)
         @context.expects(:puts).with(@context.message("core.config.feature.enabled", TEST_FEATURE))
         run_cmd("config feature #{TEST_FEATURE} --enable")
-        assert ShopifyCli::Feature.enabled?(TEST_FEATURE)
+        assert ShopifyCLI::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_disable_a_feature_that_is_enabled
-        ShopifyCli::Feature.enable(TEST_FEATURE)
+        ShopifyCLI::Feature.enable(TEST_FEATURE)
         @context.expects(:puts).with(@context.message("core.config.feature.disabled", TEST_FEATURE))
         run_cmd("config feature #{TEST_FEATURE} --disable")
-        refute ShopifyCli::Feature.enabled?(TEST_FEATURE)
+        refute ShopifyCLI::Feature.enabled?(TEST_FEATURE)
       end
 
       def test_will_enable_analytics_that_is_disabled
-        ShopifyCli::Config.set("analytics", "enabled", false)
+        ShopifyCLI::Config.set("analytics", "enabled", false)
         run_cmd("config analytics --enable")
-        assert ShopifyCli::Config.get_bool("analytics", "enabled")
+        assert ShopifyCLI::Config.get_bool("analytics", "enabled")
       end
 
       def test_will_disable_analytics_that_is_enabled
-        ShopifyCli::Config.set("analytics", "enabled", true)
+        ShopifyCLI::Config.set("analytics", "enabled", true)
         run_cmd("config analytics --disable")
-        refute ShopifyCli::Config.get_bool("analytics", "enabled")
+        refute ShopifyCLI::Config.get_bool("analytics", "enabled")
       end
     end
   end

--- a/test/shopify-cli/commands/help_test.rb
+++ b/test/shopify-cli/commands/help_test.rb
@@ -2,20 +2,20 @@ require "test_helper"
 
 module Rails
   module Commands
-    class Fake < ShopifyCli::Command
+    class Fake < ShopifyCLI::Command
     end
   end
 end
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
-    class FakeCommand < ShopifyCli::ProjectCommands
+    class FakeCommand < ShopifyCLI::ProjectCommands
     end
 
     class HelpTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Commands.register(:FakeCommand, "fake", "fake_path", true)
+        ShopifyCLI::Commands.register(:FakeCommand, "fake", "fake_path", true)
       end
 
       def test_default_behavior_lists_tasks

--- a/test/shopify-cli/commands/login_test.rb
+++ b/test/shopify-cli/commands/login_test.rb
@@ -1,66 +1,66 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class LoginTest < MiniTest::Test
       def setup
         super
         stub_shopify_org_confirmation
-        ShopifyCli::Shopifolk.stubs(:check).returns(false)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(false)
         stub_request(:head, "https://testshop.myshopify.io/admin")
           .to_return(status: 200)
         @stub_org = {
           "id" => "1234567",
           "businessName" => "Test partner org",
         }
-        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_all).with(@context).returns([@stub_org])
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_all).with(@context).returns([@stub_org])
       end
 
       def test_call_login_non_shopifolk
-        ShopifyCli::DB.expects(:set).with(shop: anything).never
+        ShopifyCLI::DB.expects(:set).with(shop: anything).never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::DB.expects(:set).with(organization_id: 1234567).once
+        ShopifyCLI::DB.expects(:set).with(organization_id: 1234567).once
         Whoami.expects(:call).with([], "whoami")
 
         run_cmd("login")
       end
 
       def test_call_login_non_shopifolk_not_a_partner
-        ShopifyCli::DB.expects(:set).with(shop: anything).never
+        ShopifyCLI::DB.expects(:set).with(shop: anything).never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::PartnersAPI::Organizations.stubs(:fetch_all).with(@context).returns([])
-        ShopifyCli::DB.expects(:set).with(organization_id: anything).never
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_all).with(@context).returns([])
+        ShopifyCLI::DB.expects(:set).with(organization_id: anything).never
         Whoami.expects(:call).with([], "whoami")
 
         run_cmd("login")
       end
 
       def test_call_login_shopifolk_not_acting_as_shopify
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
-        ShopifyCli::Shopifolk.expects(:reset).once
-        ShopifyCli::DB.expects(:set).with(shop: anything).never
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
+        ShopifyCLI::Shopifolk.expects(:reset).once
+        ShopifyCLI::DB.expects(:set).with(shop: anything).never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
+        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
         Whoami.expects(:call).with([], "whoami")
 
         run_cmd("login")
       end
 
       def test_call_login_shopifolk_acting_as_shopify
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
         stub_shopify_org_confirmation(response: true)
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).once
-        ShopifyCli::DB.expects(:set).with(shop: anything).never
-        ShopifyCli::DB.expects(:set).with(organization_id: 1234567).once
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).once
+        ShopifyCLI::DB.expects(:set).with(shop: anything).never
+        ShopifyCLI::DB.expects(:set).with(organization_id: 1234567).once
         Whoami.expects(:call).with([], "whoami")
 
         auth = mock
@@ -71,30 +71,30 @@ module ShopifyCli
       end
 
       def test_call_login_with_store_flag_doesnt_ask_acting_as_shopify
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).never
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
+        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
         Whoami.expects(:call).with([], "whoami")
 
         run_cmd("login --store=testshop.myshopify.io")
       end
 
       def test_call_login_with_shop_flag_doesnt_ask_acting_as_shopify
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
-        ShopifyCli::Shopifolk.stubs(:check).returns(true)
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).never
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
+        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
         Whoami.expects(:call).with([], "whoami")
 
         run_cmd("login --shop=testshop.myshopify.io")
@@ -102,9 +102,9 @@ module ShopifyCli
 
       def test_call_login_with_store_and_password_flag
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).never
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io")
-        ShopifyCli::DB.expects(:set).with(shopify_exchange_token: "muffin")
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
+        ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
 
         @context.expects(:ci?).returns(true)
@@ -114,9 +114,9 @@ module ShopifyCli
 
       def test_call_login_with_shop_and_password_flag
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).never
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io")
-        ShopifyCli::DB.expects(:set).with(shopify_exchange_token: "muffin")
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
+        ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
 
         @context.expects(:ci?).returns(true)
@@ -126,14 +126,14 @@ module ShopifyCli
 
       def test_cant_call_login_with_password_flag_not_on_ci
         CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).never
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io")
-        ShopifyCli::DB.expects(:set).with(shopify_exchange_token: "muffin").never
+        ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).never
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
+        ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin").never
 
         auth = mock
         auth.expects(:authenticate)
         IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCli::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
+        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
         Whoami.expects(:call).with([], "whoami")
 
         @context.expects(:ci?).returns(false)
@@ -143,9 +143,9 @@ module ShopifyCli
 
       def test_call_login_with_shop_and_password_env_vars
         CLI::UI::Prompt.expects(:ask).never
-        ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true).never
-        ShopifyCli::DB.expects(:set).with(shop: "testshop.myshopify.io")
-        ShopifyCli::DB.expects(:set).with(shopify_exchange_token: "muffin")
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
+        ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
 
         @context.expects(:ci?).returns(true)
@@ -163,7 +163,7 @@ module ShopifyCli
 
         CLI::UI::Prompt.expects(:ask).never
 
-        exception = assert_raises ShopifyCli::Abort do
+        exception = assert_raises ShopifyCLI::Abort do
           run_cmd("login --shop=#{store}")
         end
         assert_equal(
@@ -173,7 +173,7 @@ module ShopifyCli
       end
 
       def test_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Login.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Login.help)
         run_cmd("help login")
       end
 
@@ -190,18 +190,18 @@ module ShopifyCli
           .to_return(status: 404)
 
         assert_equal("shoesbycolin.myshopify.com",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("https://shoesbycolin.com"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("https://shoesbycolin.com"))
         assert_equal("shoesbycolin.myshopify.com",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("shoesbycolin.com"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("shoesbycolin.com"))
         assert_equal("shoesbycolin.myshopify.com",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("https://shoesbycolin.com/admin"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("https://shoesbycolin.com/admin"))
         assert_equal("shoesbycolin.myshopify.com",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("shoesbycolin"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("shoesbycolin"))
         assert_equal("shoesbycolin.myshopify.com",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("http://shoesbycolin.myshopify.com/admin"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("http://shoesbycolin.myshopify.com/admin"))
         assert_equal("shoesbycolin.myshopify.io",
-          ShopifyCli::Commands::Login.shop_to_permanent_domain("http://shoesbycolin.myshopify.io/admin"))
-        assert_nil(ShopifyCli::Commands::Login.shop_to_permanent_domain("not-found"))
+          ShopifyCLI::Commands::Login.shop_to_permanent_domain("http://shoesbycolin.myshopify.io/admin"))
+        assert_nil(ShopifyCLI::Commands::Login.shop_to_permanent_domain("not-found"))
       end
 
       private

--- a/test/shopify-cli/commands/logout_test.rb
+++ b/test/shopify-cli/commands/logout_test.rb
@@ -1,35 +1,35 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class LogoutTest < MiniTest::Test
       def teardown
-        ShopifyCli::Shopifolk.expects(:reset).once
+        ShopifyCLI::Shopifolk.expects(:reset).once
         super
       end
 
       def test_call_deletes_db_keys_that_exist
-        ShopifyCli::DB.expects(:del).with(*ShopifyCli::IdentityAuth::IDENTITY_ACCESS_TOKENS)
-        ShopifyCli::DB.expects(:del).with(*ShopifyCli::IdentityAuth::EXCHANGE_TOKENS)
+        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::IDENTITY_ACCESS_TOKENS)
+        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::EXCHANGE_TOKENS)
 
-        ShopifyCli::DB.expects(:exists?).with(:shop).twice.returns(true)
-        ShopifyCli::DB.expects(:del).with(:shop).once
-        ShopifyCli::DB.expects(:exists?).with(:organization_id).once.returns(true)
-        ShopifyCli::DB.expects(:del).with(:organization_id).once
+        ShopifyCLI::DB.expects(:exists?).with(:shop).twice.returns(true)
+        ShopifyCLI::DB.expects(:del).with(:shop).once
+        ShopifyCLI::DB.expects(:exists?).with(:organization_id).once.returns(true)
+        ShopifyCLI::DB.expects(:del).with(:organization_id).once
 
-        ShopifyCli::Shopifolk.expects(:reset).once
+        ShopifyCLI::Shopifolk.expects(:reset).once
 
-        ShopifyCli::DB.expects(:exists?).with(:development_theme_id).returns(true)
-        ShopifyCli::DB.expects(:del).with(:development_theme_id).once
+        ShopifyCLI::DB.expects(:exists?).with(:development_theme_id).returns(true)
+        ShopifyCLI::DB.expects(:del).with(:development_theme_id).once
 
-        ShopifyCli::DB.expects(:exists?).with(:development_theme_name).returns(true)
-        ShopifyCli::DB.expects(:del).with(:development_theme_name).once
+        ShopifyCLI::DB.expects(:exists?).with(:development_theme_name).returns(true)
+        ShopifyCLI::DB.expects(:del).with(:development_theme_name).once
 
         run_cmd("logout")
       end
 
       def test_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Logout.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Logout.help)
         run_cmd("help logout")
       end
     end

--- a/test/shopify-cli/commands/populate/customer_test.rb
+++ b/test/shopify-cli/commands/populate/customer_test.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     module PopulateTests
       class CustomerTest < MiniTest::Test
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:name).returns(["first", "last"])
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-          ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
+          ShopifyCLI::Helpers::Haikunator.stubs(:name).returns(["first", "last"])
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+          ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
           CLI::UI::Prompt.expects(:confirm)
             .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.com"), default: false)
             .returns(true)
-          ShopifyCli::AdminAPI.expects(:query)
+          ShopifyCLI::AdminAPI.expects(:query)
             .with(@context, "create_customer", shop: "my-test-shop.myshopify.com", input: {
               firstName: "first",
               lastName: "last",
             })
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/customer_data.json"))))
-          ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
+          ShopifyCLI::API.expects(:gid_to_id).returns(12345678)
+          ShopifyCLI::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "first last added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/customers/12345678}}"
@@ -30,13 +30,13 @@ module ShopifyCli
         end
 
         def test_populate_if_no_shop
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(false)
-          ShopifyCli::AdminAPI.expects(:query).never
-          exception = assert_raises ShopifyCli::Abort do
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(false)
+          ShopifyCLI::AdminAPI.expects(:query).never
+          exception = assert_raises ShopifyCLI::Abort do
             run_cmd("populate customers")
           end
           assert_equal(
-            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME),
+            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME),
             exception.message
           )
         end

--- a/test/shopify-cli/commands/populate/draft_order_test.rb
+++ b/test/shopify-cli/commands/populate/draft_order_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     module PopulateTests
       class DraftOrderTest < MiniTest::Test
@@ -9,13 +9,13 @@ module ShopifyCli
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.stubs(:title).returns("fake order")
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-          ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
+          ShopifyCLI::Helpers::Haikunator.stubs(:title).returns("fake order")
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+          ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
           CLI::UI::Prompt.expects(:confirm)
             .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.com"), default: false)
             .returns(true)
-          ShopifyCli::AdminAPI.expects(:query)
+          ShopifyCLI::AdminAPI.expects(:query)
             .with(@context, "create_draft_order", shop: "my-test-shop.myshopify.com", input: {
               lineItems: [{
                 originalUnitPrice: "1.00",
@@ -25,8 +25,8 @@ module ShopifyCli
               }],
             })
             .returns(JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/draft_order_data.json"))))
-          ShopifyCli::API.expects(:gid_to_id).returns(12345678)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
+          ShopifyCLI::API.expects(:gid_to_id).returns(12345678)
+          ShopifyCLI::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           @context.expects(:done).with(
             "DraftOrder added to {{green:my-test-shop.myshopify.com}} at " \
             "{{underline:https://my-test-shop.myshopify.com/admin/draft_orders/12345678}}"
@@ -35,13 +35,13 @@ module ShopifyCli
         end
 
         def test_populate_if_no_shop
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(false)
-          ShopifyCli::AdminAPI.expects(:query).never
-          exception = assert_raises ShopifyCli::Abort do
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(false)
+          ShopifyCLI::AdminAPI.expects(:query).never
+          exception = assert_raises ShopifyCLI::Abort do
             run_cmd("populate draftorders")
           end
           assert_equal(
-            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME),
+            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME),
             exception.message
           )
         end

--- a/test/shopify-cli/commands/populate/product_test.rb
+++ b/test/shopify-cli/commands/populate/product_test.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     module PopulateTests
       class ProductTest < MiniTest::Test
         include TestHelpers::Schema
 
         def test_populate_calls_api_with_mutation
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake product")
-          ShopifyCli::Helpers::Haikunator.expects(:title).returns("fake producttwo")
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(true).twice
-          ShopifyCli::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
+          ShopifyCLI::Helpers::Haikunator.expects(:title).returns("fake product")
+          ShopifyCLI::Helpers::Haikunator.expects(:title).returns("fake producttwo")
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true).twice
+          ShopifyCLI::DB.expects(:get).with(:shop).returns("my-test-shop.myshopify.com").twice
           CLI::UI::Prompt.expects(:confirm)
             .with(@context.message("core.tasks.confirm_store.prompt", "my-test-shop.myshopify.com"), default: false)
             .returns(true)
-          ShopifyCli::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
+          ShopifyCLI::AdminAPI::PopulateResourceCommand.any_instance.stubs(:price).returns("1.00")
           return_data = JSON.parse(File.read(File.join(FIXTURE_DIR, "populate/product_data.json")))
-          ShopifyCli::AdminAPI.expects(:query)
+          ShopifyCLI::AdminAPI.expects(:query)
             .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
               'title': "fake product",
               variants: [{ price: "1.00" }],
             })
             .returns(return_data)
-          ShopifyCli::AdminAPI.expects(:query)
+          ShopifyCLI::AdminAPI.expects(:query)
             .with(@context, "create_product", shop: "my-test-shop.myshopify.com", input: {
               'title': "fake producttwo",
               variants: [{ price: "1.00" }],
             })
             .returns(return_data)
-          ShopifyCli::API.expects(:gid_to_id).returns(12345678).twice
+          ShopifyCLI::API.expects(:gid_to_id).returns(12345678).twice
           @context.expects(:done).with(
             "fake product added to {{green:my-test-shop.myshopify.com}} at" \
             " {{underline:https://my-test-shop.myshopify.com/admin/products/12345678}}"
@@ -38,13 +38,13 @@ module ShopifyCli
         end
 
         def test_populate_if_no_shop
-          ShopifyCli::DB.expects(:exists?).with(:shop).returns(false)
-          ShopifyCli::AdminAPI.expects(:query).never
-          exception = assert_raises ShopifyCli::Abort do
+          ShopifyCLI::DB.expects(:exists?).with(:shop).returns(false)
+          ShopifyCLI::AdminAPI.expects(:query).never
+          exception = assert_raises ShopifyCLI::Abort do
             run_cmd("populate products")
           end
           assert_equal(
-            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME),
+            "{{x}} " + @context.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME),
             exception.message
           )
         end

--- a/test/shopify-cli/commands/populate_test.rb
+++ b/test/shopify-cli/commands/populate_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class PopulateTest < MiniTest::Test
       def test_without_arguments_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Populate.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Populate.help)
         run_cmd("populate")
       end
 
@@ -14,7 +14,7 @@ module ShopifyCli
           run_cmd("populate foobar")
         end
 
-        assert_match(CLI::UI.fmt(ShopifyCli::Commands::Populate.help), io.join)
+        assert_match(CLI::UI.fmt(ShopifyCLI::Commands::Populate.help), io.join)
       end
     end
   end

--- a/test/shopify-cli/commands/store_test.rb
+++ b/test/shopify-cli/commands/store_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class StoreTest < MiniTest::Test
       def test_can_display_store
         shop = "testshop.myshopify.com"
-        ShopifyCli::AdminAPI.expects(:get_shop_or_abort).with(@context).returns(shop)
+        ShopifyCLI::AdminAPI.expects(:get_shop_or_abort).with(@context).returns(shop)
 
         @context.expects(:puts).with(@context.message("core.store.shop", shop))
 
@@ -13,7 +13,7 @@ module ShopifyCli
       end
 
       def test_help_argument_calls_help
-        @context.expects(:puts).with(ShopifyCli::Commands::Store.help)
+        @context.expects(:puts).with(ShopifyCLI::Commands::Store.help)
         run_cmd("help store")
       end
     end

--- a/test/shopify-cli/commands/switch_test.rb
+++ b/test/shopify-cli/commands/switch_test.rb
@@ -1,25 +1,25 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class SwitchTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::DB.stubs(:get).with(:acting_as_shopify_organization).returns(false)
+        ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(false)
       end
 
       def test_can_switch_store_no_org_id
         old_shop = "testshop1.myshopify.com"
         new_shop = "testshop2.myshopify.com"
-        ShopifyCli::DB.expects(:exists?).with(:shop).returns(true)
-        ShopifyCli::DB.expects(:get).with(:shop).returns(old_shop)
-        ShopifyCli::DB.expects(:get).with(:organization_id).returns(nil)
-        ShopifyCli::Tasks::SelectOrgAndShop.expects(:call).with(@context).returns(
+        ShopifyCLI::DB.expects(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB.expects(:get).with(:shop).returns(old_shop)
+        ShopifyCLI::DB.expects(:get).with(:organization_id).returns(nil)
+        ShopifyCLI::Tasks::SelectOrgAndShop.expects(:call).with(@context).returns(
           { organization_id: 123, shop_domain: new_shop }
         )
-        ShopifyCli::DB.expects(:set).with(shop: new_shop)
+        ShopifyCLI::DB.expects(:set).with(shop: new_shop)
         @identity_auth_client = mock
-        ShopifyCli::IdentityAuth
+        ShopifyCLI::IdentityAuth
           .expects(:new)
           .with(ctx: @context).returns(@identity_auth_client)
         @identity_auth_client
@@ -36,13 +36,13 @@ module ShopifyCli
 
       def test_can_switch_store_with_org_id
         new_shop = "testshop2.myshopify.com"
-        ShopifyCli::DB.expects(:get).with(:organization_id).returns("123")
-        ShopifyCli::Tasks::SelectOrgAndShop.expects(:call).with(@context, organization_id: "123").returns(
+        ShopifyCLI::DB.expects(:get).with(:organization_id).returns("123")
+        ShopifyCLI::Tasks::SelectOrgAndShop.expects(:call).with(@context, organization_id: "123").returns(
           { organization_id: 123, shop_domain: new_shop }
         )
-        ShopifyCli::DB.expects(:set).with(shop: new_shop)
+        ShopifyCLI::DB.expects(:set).with(shop: new_shop)
         @identity_auth_client = mock
-        ShopifyCli::IdentityAuth
+        ShopifyCLI::IdentityAuth
           .expects(:new)
           .with(ctx: @context).returns(@identity_auth_client)
         @identity_auth_client
@@ -60,11 +60,11 @@ module ShopifyCli
       def test_can_switch_store_with_store_flag
         new_shop = "testshop2.myshopify.com"
 
-        ShopifyCli::Commands::Login.expects(:validate_shop).with(new_shop).returns(new_shop)
-        ShopifyCli::DB.expects(:set).with(shop: new_shop)
+        ShopifyCLI::Commands::Login.expects(:validate_shop).with(new_shop).returns(new_shop)
+        ShopifyCLI::DB.expects(:set).with(shop: new_shop)
 
         @identity_auth_client = mock
-        ShopifyCli::IdentityAuth
+        ShopifyCLI::IdentityAuth
           .expects(:new)
           .with(ctx: @context).returns(@identity_auth_client)
         @identity_auth_client
@@ -82,11 +82,11 @@ module ShopifyCli
       def test_can_switch_store_with_shop_flag
         new_shop = "testshop2.myshopify.com"
 
-        ShopifyCli::Commands::Login.expects(:validate_shop).with(new_shop).returns(new_shop)
-        ShopifyCli::DB.expects(:set).with(shop: new_shop)
+        ShopifyCLI::Commands::Login.expects(:validate_shop).with(new_shop).returns(new_shop)
+        ShopifyCLI::DB.expects(:set).with(shop: new_shop)
 
         @identity_auth_client = mock
-        ShopifyCli::IdentityAuth
+        ShopifyCLI::IdentityAuth
           .expects(:new)
           .with(ctx: @context).returns(@identity_auth_client)
         @identity_auth_client
@@ -102,14 +102,14 @@ module ShopifyCli
       end
 
       def test_aborts_if_no_shop_no_org_id
-        ShopifyCli::DB.stubs(:exists?).returns(false)
-        ShopifyCli::DB.expects(:get).with(:organization_id).returns(nil)
+        ShopifyCLI::DB.stubs(:exists?).returns(false)
+        ShopifyCLI::DB.expects(:get).with(:organization_id).returns(nil)
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_cmd("switch") }
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) { run_cmd("switch") }
         assert_message_output(
           io: io,
           expected_content: [
-            @context.message("core.populate.error.no_shop", ShopifyCli::TOOL_NAME),
+            @context.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME),
           ]
         )
       end
@@ -119,15 +119,15 @@ module ShopifyCli
         assert_message_output(
           io: io,
           expected_content: [
-            ShopifyCli::Commands::Switch.help,
+            ShopifyCLI::Commands::Switch.help,
           ]
         )
       end
 
       def test_cant_switch_if_shopifolk
-        ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).once.returns(true)
-        ShopifyCli::DB.expects(:set).with(shop: anything).never
-        ShopifyCli::IdentityAuth.expects(:new).never
+        ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).once.returns(true)
+        ShopifyCLI::DB.expects(:set).with(shop: anything).never
+        ShopifyCLI::IdentityAuth.expects(:new).never
 
         io = capture_io { run_cmd("switch") }
 

--- a/test/shopify-cli/commands/whoami_test.rb
+++ b/test/shopify-cli/commands/whoami_test.rb
@@ -1,17 +1,17 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Commands
     class WhoamiTest < MiniTest::Test
       def test_no_shop_no_org_id
         stub_db_setup(shop: nil, organization_id: nil)
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).never
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).never
 
         io = capture_io { run_cmd("whoami") }
         assert_message_output(
           io: io,
           expected_content: [
-            @context.message("core.whoami.not_logged_in", ShopifyCli::TOOL_NAME),
+            @context.message("core.whoami.not_logged_in", ShopifyCLI::TOOL_NAME),
           ]
         )
       end
@@ -19,7 +19,7 @@ module ShopifyCli
       def test_yes_shop_no_org_id
         shop = "testshop2.myshopify.com"
         stub_db_setup(shop: shop, organization_id: nil)
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).never
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).never
 
         io = capture_io { run_cmd("whoami") }
         assert_message_output(
@@ -36,7 +36,7 @@ module ShopifyCli
           "businessName" => "test business name",
         }
         stub_db_setup(shop: nil, organization_id: test_org["id"])
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch)
           .with(@context, id: test_org["id"])
           .once
           .returns(test_org)
@@ -58,7 +58,7 @@ module ShopifyCli
         shop = "testshop2.myshopify.com"
 
         stub_db_setup(shop: shop, organization_id: test_org["id"])
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch)
           .with(@context, id: test_org["id"])
           .once
           .returns(test_org)
@@ -75,8 +75,8 @@ module ShopifyCli
       private
 
       def stub_db_setup(shop:, organization_id:)
-        ShopifyCli::DB.stubs(:get).with(:shop).returns(shop)
-        ShopifyCli::DB.stubs(:get).with(:organization_id).returns(organization_id)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns(shop)
+        ShopifyCLI::DB.stubs(:get).with(:organization_id).returns(organization_id)
       end
     end
   end

--- a/test/shopify-cli/connect_test.rb
+++ b/test/shopify-cli/connect_test.rb
@@ -1,30 +1,30 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class ConnectTest < MiniTest::Test
     include TestHelpers::Partners
 
     def test_runs_default_behaviour_if_no_connect_command
-      ShopifyCli::Project.stubs(:has_current?).returns(false)
-      ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
-      ShopifyCli::Project.expects(:write)
-      ShopifyCli::Connect.new(@context).default_connect("project_type")
+      ShopifyCLI::Project.stubs(:has_current?).returns(false)
+      ShopifyCLI::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
+      ShopifyCLI::Project.expects(:write)
+      ShopifyCLI::Connect.new(@context).default_connect("project_type")
     end
 
     def test_not_write_yml_when_current_project_exists_in_default
-      ShopifyCli::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
-      ShopifyCli::Project.expects(:write).never
-      ShopifyCli::Connect.new(@context).default_connect("project_type")
+      ShopifyCLI::Tasks::EnsureEnv.expects(:call).with(@context, regenerate: true).returns(org_response)
+      ShopifyCLI::Project.expects(:write).never
+      ShopifyCLI::Connect.new(@context).default_connect("project_type")
     end
 
     def test_outputs_warnings_if_already_connected_in_default
-      context = ShopifyCli::Context.new
+      context = ShopifyCLI::Context.new
 
       context.expects(:puts).with(context.message("core.connect.already_connected_warning"))
-      ShopifyCli::Tasks::EnsureEnv.expects(:call).with(context, regenerate: true).returns(org_response)
-      ShopifyCli::Project.expects(:write).never
+      ShopifyCLI::Tasks::EnsureEnv.expects(:call).with(context, regenerate: true).returns(org_response)
+      ShopifyCLI::Project.expects(:write).never
 
-      ShopifyCli::Connect.new(context).default_connect("project_type")
+      ShopifyCLI::Connect.new(context).default_connect("project_type")
     end
 
     private

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class ContextTest < MiniTest::Test
     include TestHelpers::FakeFS
 
@@ -110,10 +110,10 @@ module ShopifyCli
     end
 
     def test_check_for_new_version_if_no_config_section
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:get)
         .returns(false)
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:set)
         .once
       mock_rubygems_https_call(response_body: "{\"version\":\"99.99.99\"}")
@@ -122,22 +122,22 @@ module ShopifyCli
     end
 
     def test_no_check_for_new_version_if_config_section_and_interval_not_passed
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:get)
         .returns(Time.now.to_i - 3600)
       Net::HTTP
         .expects(:get_response)
-        .with(ShopifyCli::Context::GEM_LATEST_URI)
+        .with(ShopifyCLI::Context::GEM_LATEST_URI)
         .never
 
       refute(@ctx.new_version)
     end
 
     def test_check_for_new_version_if_config_section_and_interval_passed
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:get)
         .returns(Time.now.to_i - 86500)
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:set)
         .once
       mock_rubygems_https_call(response_body: "{\"version\":\"99.99.99\"}")
@@ -146,10 +146,10 @@ module ShopifyCli
     end
 
     def test_check_for_new_version_returns_nil_if_https_call_returns_garbage
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:get)
         .returns(Time.now.to_i - 86500)
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:set)
         .once
       mock_rubygems_https_call(response_body: "ad098q907b\n90979a*(&*^*%klhfadkh}")
@@ -158,15 +158,15 @@ module ShopifyCli
     end
 
     def test_check_for_new_version_returns_nil_if_https_call_times_out
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:get)
         .returns(Time.now.to_i - 86500)
-      ShopifyCli::Config
+      ShopifyCLI::Config
         .expects(:set)
         .once
       Net::HTTP
         .expects(:get_response)
-        .with(ShopifyCli::Context::GEM_LATEST_URI)
+        .with(ShopifyCLI::Context::GEM_LATEST_URI)
         .raises(Net::ReadTimeout)
 
       refute(@ctx.new_version)
@@ -175,7 +175,7 @@ module ShopifyCli
     private
 
     def mock_rubygems_https_call(response_body:)
-      stub_request(:get, ShopifyCli::Context::GEM_LATEST_URI)
+      stub_request(:get, ShopifyCLI::Context::GEM_LATEST_URI)
         .with(headers: {
           "Accept" => "*/*",
           "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",

--- a/test/shopify-cli/core/entry_point_test.rb
+++ b/test/shopify-cli/core/entry_point_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class EntryPointTest < MiniTest::Test
       include TestHelpers::Project
@@ -9,7 +9,7 @@ module ShopifyCli
         args = %w(help argone argtwo)
 
         Core::Executor.any_instance.expects(:call).with(
-          ShopifyCli::Commands::Help,
+          ShopifyCLI::Commands::Help,
           "help",
           args.dup[1..-1]
         )

--- a/test/shopify-cli/core/executor_test.rb
+++ b/test/shopify-cli/core/executor_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class ExecutorTest < MiniTest::Test
       include TestHelpers::FakeTask
 
-      class FakeCommand < ShopifyCli::Command
+      class FakeCommand < ShopifyCLI::Command
         prerequisite_task :fake
         prerequisite_task fake_with_args: [:foo, :bar]
 
-        class FakeSubCommand < ShopifyCli::SubCommand
+        class FakeSubCommand < ShopifyCLI::SubCommand
           prerequisite_task :fake
           prerequisite_task fake_with_args: [:sub, :command]
 
@@ -41,7 +41,7 @@ module ShopifyCli
       end
 
       def test_prerequisite_task
-        executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
+        executor = ShopifyCLI::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
         @context.expects(:puts).with("success!")
@@ -51,7 +51,7 @@ module ShopifyCli
       end
 
       def test_options
-        executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
+        executor = ShopifyCLI::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
         @context.expects(:puts).with("success!")
@@ -61,7 +61,7 @@ module ShopifyCli
       end
 
       def test_subcommand
-        executor = ShopifyCli::Core::Executor.new(@context, @registry, log_file: @log)
+        executor = ShopifyCLI::Core::Executor.new(@context, @registry, log_file: @log)
         reg = CLI::Kit::CommandRegistry.new(default: nil, contextual_resolver: nil)
         reg.add(FakeCommand, :fake)
         @context.expects(:puts).with("success!")

--- a/test/shopify-cli/core/help_resolver_test.rb
+++ b/test/shopify-cli/core/help_resolver_test.rb
@@ -1,17 +1,17 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class HelpResolverTest < MiniTest::Test
       def test_outputs_help_with_help_flag
-        ShopifyCli::Commands::Help.expects(:call)
-        assert_raises(ShopifyCli::AbortSilent) do
+        ShopifyCLI::Commands::Help.expects(:call)
+        assert_raises(ShopifyCLI::AbortSilent) do
           run_cmd("-h")
         end
       end
 
       def test_outputs_help_without_argument
-        ShopifyCli::Commands::Help.expects(:call)
+        ShopifyCLI::Commands::Help.expects(:call)
         run_cmd("")
       end
     end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -1,59 +1,59 @@
 require "test_helper"
 require "timecop"
 
-module ShopifyCli
+module ShopifyCLI
   module Core
     class MonorailTest < MiniTest::Test
       def setup
         super
-        ShopifyCli::Core::Monorail.metadata = {}
+        ShopifyCLI::Core::Monorail.metadata = {}
       end
 
       def teardown
-        ShopifyCli::Core::Monorail.metadata = {}
+        ShopifyCLI::Core::Monorail.metadata = {}
         super
       end
 
       def test_log_prompts_for_consent_and_saves_answer
         enabled_and_consented(true, nil)
-        ShopifyCli::Config.expects(:get_section).with("analytics").returns({})
+        ShopifyCLI::Config.expects(:get_section).with("analytics").returns({})
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        ShopifyCli::Config.expects(:set).with("analytics", "enabled", true)
+        ShopifyCLI::Config.expects(:set).with("analytics", "enabled", true)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_prompt_for_consent_if_not_enabled
         enabled_and_consented(false, nil)
-        ShopifyCli::Config.expects(:get_section).never
+        ShopifyCLI::Config.expects(:get_section).never
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_prompt_for_consent_if_already_answered
         enabled_and_consented(true, false)
-        ShopifyCli::Config.expects(:get_section).with("analytics").returns("enabled" => "true")
+        ShopifyCLI::Config.expects(:get_section).with("analytics").returns("enabled" => "true")
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_prompt_for_consent_if_in_ci
-        ShopifyCli::Context.any_instance.stubs(:ci?).returns(true)
-        ShopifyCli::Context.any_instance.stubs(:system?).returns(true)
+        ShopifyCLI::Context.any_instance.stubs(:ci?).returns(true)
+        ShopifyCLI::Context.any_instance.stubs(:system?).returns(true)
         CLI::UI::Prompt.expects(:confirm).never
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_event_contains_schema_and_payload_values
         enabled_and_consented(true, true)
-        ShopifyCli::Shopifolk.expects(:acting_as_shopify_organization?).returns(true)
+        ShopifyCLI::Shopifolk.expects(:acting_as_shopify_organization?).returns(true)
         Timecop.freeze do |time|
           this_time = (time.utc.to_f * 1000).to_i
           stub_request(:post, Monorail::ENDPOINT_URI)
@@ -64,7 +64,7 @@ module ShopifyCli
                 'X-Monorail-Edge-Event-Sent-At-Ms': this_time.to_s,
               },
               body: JSON.dump({
-                schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
+                schema_id: ShopifyCLI::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
                   project_type: "fake",
                   command: "testcommand",
@@ -75,7 +75,7 @@ module ShopifyCli
                   success: true,
                   error_message: nil,
                   uname: RbConfig::CONFIG["host"],
-                  cli_version: ShopifyCli::VERSION,
+                  cli_version: ShopifyCLI::VERSION,
                   ruby_version: RUBY_VERSION,
                   is_employee: true,
                   api_key: "apikey",
@@ -86,8 +86,8 @@ module ShopifyCli
             )
             .to_return(status: 200)
 
-          ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) do
-            ShopifyCli::Core::Monorail.metadata[:foo] = "identifier"
+          ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) do
+            ShopifyCLI::Core::Monorail.metadata[:foo] = "identifier"
             "This is the block and result"
           end
         end
@@ -95,7 +95,7 @@ module ShopifyCli
 
       def test_log_event_handles_errors
         enabled_and_consented(true, true)
-        ShopifyCli::Shopifolk.expects(:acting_as_shopify_organization?).returns(false)
+        ShopifyCLI::Shopifolk.expects(:acting_as_shopify_organization?).returns(false)
         Timecop.freeze do |time|
           this_time = (time.utc.to_f * 1000).to_i
           stub_request(:post, Monorail::ENDPOINT_URI)
@@ -106,7 +106,7 @@ module ShopifyCli
                 'X-Monorail-Edge-Event-Sent-At-Ms': this_time.to_s,
               },
               body: JSON.dump({
-                schema_id: ShopifyCli::Core::Monorail::INVOCATIONS_SCHEMA,
+                schema_id: ShopifyCLI::Core::Monorail::INVOCATIONS_SCHEMA,
                 payload: {
                   project_type: "fake",
                   command: "testcommand",
@@ -117,7 +117,7 @@ module ShopifyCli
                   success: false,
                   error_message: "test error",
                   uname: RbConfig::CONFIG["host"],
-                  cli_version: ShopifyCli::VERSION,
+                  cli_version: ShopifyCLI::VERSION,
                   ruby_version: RUBY_VERSION,
                   is_employee: false,
                   api_key: "apikey",
@@ -128,7 +128,7 @@ module ShopifyCli
             .to_return(status: 200)
 
           begin
-            ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) do
+            ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) do
               raise "test error"
             end
           rescue
@@ -140,7 +140,7 @@ module ShopifyCli
         enabled_and_consented(true, true)
         Net::HTTP.expects(:start).once
 
-        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        result = ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
         assert_equal("This is the block and result", result)
       end
 
@@ -148,7 +148,7 @@ module ShopifyCli
         enabled_and_consented(true, false)
         Net::HTTP.expects(:start).never
 
-        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        result = ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
         assert_equal("This is the block and result", result)
       end
 
@@ -157,7 +157,7 @@ module ShopifyCli
         Net::HTTP.expects(:start).once
 
         assert_raises Exception do
-          ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { raise Exception }
+          ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { raise Exception }
         end
       end
 
@@ -165,21 +165,21 @@ module ShopifyCli
         enabled_and_consented(false, true)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_doesnt_send_monorail_event_if_enabled_but_not_consented
         enabled_and_consented(true, false)
         Net::HTTP.expects(:start).never
 
-        ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
       end
 
       def test_log_send_event_returns_result_if_monorail_returns_not_200
         enabled_and_consented(true, true)
         stub_request(:post, Monorail::ENDPOINT_URI).to_return(status: 500)
 
-        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        result = ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
         assert_equal("This is the block and result", result)
       end
 
@@ -187,17 +187,17 @@ module ShopifyCli
         enabled_and_consented(true, true)
         stub_request(:post, Monorail::ENDPOINT_URI).to_timeout
 
-        result = ShopifyCli::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
+        result = ShopifyCLI::Core::Monorail.log("testcommand", %w(arg argtwo)) { "This is the block and result" }
         assert_equal("This is the block and result", result)
       end
 
       private
 
       def enabled_and_consented(enabled, consented)
-        ShopifyCli::Config.stubs(:get_section).with("analytics").returns({ "enabled" => consented.to_s })
-        ShopifyCli::Context.any_instance.stubs(:system?).returns(enabled)
-        ShopifyCli::Context.any_instance.stubs(:ci?).returns(false)
-        ShopifyCli::Config.stubs(:get_bool).with("analytics", "enabled").returns(consented)
+        ShopifyCLI::Config.stubs(:get_section).with("analytics").returns({ "enabled" => consented.to_s })
+        ShopifyCLI::Context.any_instance.stubs(:system?).returns(enabled)
+        ShopifyCLI::Context.any_instance.stubs(:ci?).returns(false)
+        ShopifyCLI::Config.stubs(:get_bool).with("analytics", "enabled").returns(consented)
       end
     end
   end

--- a/test/shopify-cli/db_test.rb
+++ b/test/shopify-cli/db_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class DBTest < MiniTest::Test
     def test_set
       db = new_db
@@ -49,7 +49,7 @@ module ShopifyCli
     private
 
     def new_db
-      db = DB.new(path: File.join(ShopifyCli::TEMP_DIR, ".test_db.pdb"))
+      db = DB.new(path: File.join(ShopifyCLI::TEMP_DIR, ".test_db.pdb"))
       db.clear
       db.db.transaction do
         db.db[:keyone] = "value"

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class EnvironmentTest < MiniTest::Test
     def test_use_local_partners_instance_returns_true_when_the_env_variable_is_set
       # Given

--- a/test/shopify-cli/feature_test.rb
+++ b/test/shopify-cli/feature_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class FeatureTest < MiniTest::Test
     include TestHelpers::FakeFS
 
@@ -20,20 +20,20 @@ module ShopifyCli
 
     def test_enable_sets_true_bool
       Feature.enable(TEST_FEATURE)
-      assert ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      assert ShopifyCLI::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
     end
 
     def test_disable_sets_false_bool
       Feature.disable(TEST_FEATURE)
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      refute ShopifyCLI::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
     end
 
     def test_enabled_returns_bool_status
       Feature.enable(TEST_FEATURE)
-      assert ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      assert ShopifyCLI::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
       assert Feature.enabled?(TEST_FEATURE)
       Feature.disable(TEST_FEATURE)
-      refute ShopifyCli::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
+      refute ShopifyCLI::Config.get_bool(Feature::SECTION, TEST_FEATURE.to_s)
       refute Feature.enabled?(TEST_FEATURE)
       refute Feature.enabled?(nil)
     end

--- a/test/shopify-cli/form_test.rb
+++ b/test/shopify-cli/form_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class FormTest < MiniTest::Test
-    class TestForm < ShopifyCli::Form
+    class TestForm < ShopifyCLI::Form
       positional_arguments :one, :two
       flag_arguments :three, :four
 
       def ask
-        raise ShopifyCli::Abort, "I was asked to raise" if three == "raise"
+        raise ShopifyCLI::Abort, "I was asked to raise" if three == "raise"
       end
     end
 

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "open3"
 require "shellwords"
 
-module ShopifyCli
+module ShopifyCLI
   class GitTest < MiniTest::Test
     def setup
       super
@@ -20,7 +20,7 @@ module ShopifyCli
         .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["", @status_mock[:true]])
 
-      assert_equal(["master"], ShopifyCli::Git.branches(@context))
+      assert_equal(["master"], ShopifyCLI::Git.branches(@context))
     end
 
     def test_branches_returns_list_of_branches_if_multiple_exist
@@ -28,7 +28,7 @@ module ShopifyCli
         .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["master\nsecond_branch\n", @status_mock[:true]])
 
-      assert_equal(["master", "second_branch"], ShopifyCli::Git.branches(@context))
+      assert_equal(["master", "second_branch"], ShopifyCLI::Git.branches(@context))
     end
 
     def test_branches_raises_if_finding_branches_fails
@@ -36,27 +36,27 @@ module ShopifyCli
         .with("git", "branch", "--list", "--format=%(refname:short)")
         .returns(["", @status_mock[:false]])
 
-      assert_raises ShopifyCli::Abort do
-        ShopifyCli::Git.branches(@context)
+      assert_raises ShopifyCLI::Abort do
+        ShopifyCLI::Git.branches(@context)
       end
     end
 
     def test_init_initializes_successfully
       stub_git_init(status: true, commits: true)
-      assert_nil(ShopifyCli::Git.init(@context))
+      assert_nil(ShopifyCLI::Git.init(@context))
     end
 
     def test_init_raises_if_git_isnt_inited
       stub_git_init(status: false, commits: false)
-      assert_raises ShopifyCli::Abort do
-        ShopifyCli::Git.init(@context)
+      assert_raises ShopifyCLI::Abort do
+        ShopifyCLI::Git.init(@context)
       end
     end
 
     def test_init_raises_if_git_is_inited_but_there_are_no_commits
       stub_git_init(status: true, commits: false)
-      assert_raises ShopifyCli::Abort do
-        ShopifyCli::Git.init(@context)
+      assert_raises ShopifyCLI::Abort do
+        ShopifyCLI::Git.init(@context)
       end
     end
 
@@ -65,14 +65,14 @@ module ShopifyCli
       in_repo do |git_dir|
         File.write(File.join(git_dir, "HEAD"), fake_sha)
 
-        assert_equal(fake_sha, ShopifyCli::Git.sha(dir: File.dirname(git_dir)))
+        assert_equal(fake_sha, ShopifyCLI::Git.sha(dir: File.dirname(git_dir)))
       end
     end
 
     def test_head_sha
       in_repo do |git_dir|
         empty_commit(git_dir: git_dir)
-        refute_nil(ShopifyCli::Git.sha(dir: File.dirname(git_dir)))
+        refute_nil(ShopifyCLI::Git.sha(dir: File.dirname(git_dir)))
       end
     end
 
@@ -86,12 +86,12 @@ module ShopifyCli
         "--progress"
       ).returns(mock(success?: true))
       capture_io do
-        ShopifyCli::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
+        ShopifyCLI::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
       end
     end
 
     def test_clone_failure
-      assert_raises(ShopifyCli::Abort) do
+      assert_raises(ShopifyCLI::Abort) do
         Open3.expects(:popen3).with(
           "git",
           "clone",
@@ -101,7 +101,7 @@ module ShopifyCli
           "--progress"
         ).returns(mock(success?: false))
         capture_io do
-          ShopifyCli::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
+          ShopifyCLI::Git.clone("git@github.com:shopify/test.git", "test-app", ctx: @context)
         end
       end
     end

--- a/test/shopify-cli/heroku_test.rb
+++ b/test/shopify-cli/heroku_test.rb
@@ -1,19 +1,19 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class HerokuTest < MiniTest::Test
     include TestHelpers::Heroku
 
     def setup
       super
       File.stubs(:exist?).returns(false)
-      ShopifyCli::Context.any_instance.stubs(:os).returns(:mac)
+      ShopifyCLI::Context.any_instance.stubs(:os).returns(:mac)
     end
 
     def test_app_uses_existing_heroku_app_if_available
       expects_git_remote_get_url_heroku(status: true, remote: "heroku")
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_equal "app-name", heroku_service.app
     end
@@ -21,7 +21,7 @@ module ShopifyCli
     def test_app_returns_nil_if_choosing_existing_heroku_app_fails
       expects_git_remote_get_url_heroku(status: false, remote: "heroku")
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.app)
     end
@@ -29,7 +29,7 @@ module ShopifyCli
     def test_authenticate_using_full_path_heroku_existing_auth_if_available
       expects_heroku_login(status: true, full_path: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.authenticate)
     end
@@ -37,7 +37,7 @@ module ShopifyCli
     def test_authenticate_using_non_full_path_heroku_existing_auth_if_available
       expects_heroku_login(status: true, full_path: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.authenticate)
     end
@@ -45,9 +45,9 @@ module ShopifyCli
     def test_authenticate_raises_if_heroku_auth_fails
       expects_heroku_login(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.authenticate
       end
     end
@@ -55,7 +55,7 @@ module ShopifyCli
     def test_create_new_app_using_full_path_heroku_to_create_new_heroku_app
       expects_heroku_create(status: true, full_path: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.create_new_app)
     end
@@ -63,7 +63,7 @@ module ShopifyCli
     def test_create_new_app_using_non_full_path_heroku_to_create_new_heroku_app
       expects_heroku_create(status: true, full_path: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.create_new_app)
     end
@@ -71,9 +71,9 @@ module ShopifyCli
     def test_create_new_app_raises_if_creating_new_heroku_app_fails
       expects_heroku_create(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.create_new_app
       end
     end
@@ -81,7 +81,7 @@ module ShopifyCli
     def test_deploy_tries_to_deploy_to_heroku
       expects_heroku_deploy(status: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.deploy("master"))
     end
@@ -89,9 +89,9 @@ module ShopifyCli
     def test_deploy_raises_if_deploy_fails
       expects_heroku_deploy(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.deploy("master")
       end
     end
@@ -100,7 +100,7 @@ module ShopifyCli
       expects_heroku_installed(status: true)
       expects_heroku_download(status: nil)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.download)
     end
@@ -110,7 +110,7 @@ module ShopifyCli
       expects_heroku_download(status: true)
       expects_heroku_download_exists(status: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.download)
     end
@@ -119,9 +119,9 @@ module ShopifyCli
       expects_heroku_installed(status: false)
       expects_heroku_download(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.download
       end
     end
@@ -131,9 +131,9 @@ module ShopifyCli
       expects_heroku_download(status: true)
       expects_heroku_download_exists(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.download
       end
     end
@@ -142,7 +142,7 @@ module ShopifyCli
       expects_heroku_installed(status: true)
       expects_tar_heroku(status: nil)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.install)
     end
@@ -151,7 +151,7 @@ module ShopifyCli
       expects_heroku_installed(status: false, full_path: true)
       expects_tar_heroku(status: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert heroku_service.install
     end
@@ -160,7 +160,7 @@ module ShopifyCli
       expects_heroku_installed(status: false, full_path: false)
       expects_tar_heroku(status: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert heroku_service.install
     end
@@ -169,9 +169,9 @@ module ShopifyCli
       expects_heroku_installed(status: false)
       expects_tar_heroku(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.install
       end
     end
@@ -179,7 +179,7 @@ module ShopifyCli
     def test_select_existing_app_using_full_path_heroku_lets_you_choose_existing_heroku_app
       expects_heroku_select_app(status: true, full_path: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.select_existing_app("app-name"))
     end
@@ -187,7 +187,7 @@ module ShopifyCli
     def test_select_existing_app_using_non_full_path_heroku_lets_you_choose_existing_heroku_app
       expects_heroku_select_app(status: true, full_path: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.select_existing_app("app-name"))
     end
@@ -195,9 +195,9 @@ module ShopifyCli
     def test_select_existing_app_raises_if_choosing_existing_heroku_app_fails
       expects_heroku_select_app(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
-      assert_raises ShopifyCli::Abort do
+      assert_raises ShopifyCLI::Abort do
         heroku_service.select_existing_app("app-name")
       end
     end
@@ -205,7 +205,7 @@ module ShopifyCli
     def test_whoami_using_full_path_heroku_returns_username_if_logged_in
       expects_heroku_whoami(status: true, full_path: true)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_equal "username", heroku_service.whoami
     end
@@ -213,7 +213,7 @@ module ShopifyCli
     def test_whoami_using_non_full_path_heroku_returns_username_if_logged_in
       expects_heroku_whoami(status: true, full_path: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_equal "username", heroku_service.whoami
     end
@@ -221,7 +221,7 @@ module ShopifyCli
     def test_whoami_returns_nil_if_not_logged_in
       expects_heroku_whoami(status: false)
 
-      heroku_service = ShopifyCli::Heroku.new(@context)
+      heroku_service = ShopifyCLI::Heroku.new(@context)
 
       assert_nil(heroku_service.whoami)
     end

--- a/test/shopify-cli/http_request_test.rb
+++ b/test/shopify-cli/http_request_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "shopify_cli/http_request"
 
-module ShopifyCli
+module ShopifyCLI
   class HttpRequestTest < MiniTest::Test
     def test_makes_get_request
       uri = URI.parse("https://example.com")

--- a/test/shopify-cli/identity_auth/servlet_test.rb
+++ b/test/shopify-cli/identity_auth/servlet_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "ostruct"
 require "webrick"
 
-module ShopifyCli
+module ShopifyCLI
   module IdentityAuthTests
     class ServletTest < MiniTest::Test
       Request = Struct.new(:query)

--- a/test/shopify-cli/identity_auth_test.rb
+++ b/test/shopify-cli/identity_auth_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class IdentityAuthTest < MiniTest::Test
     def setup
       super
@@ -165,7 +165,7 @@ module ShopifyCli
       stub_request(:post, "#{endpoint}/authorize?#{URI.encode_www_form(authorize_query)}")
 
       stub_server(client, nil)
-      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
         client.authenticate
       end
       assert_message_output(
@@ -179,7 +179,7 @@ module ShopifyCli
     private
 
     def assert_expected_exchange_tokens(token_suffix:, client:)
-      ShopifyCli::IdentityAuth::APPLICATION_SCOPES.keys.each do |key|
+      ShopifyCLI::IdentityAuth::APPLICATION_SCOPES.keys.each do |key|
         assert_equal(key + token_suffix, client.store.get("#{key}_exchange_token".to_sym))
       end
     end
@@ -195,13 +195,13 @@ module ShopifyCli
     end
 
     def stub_exchange_token_calls(exchange_token: "exchangetoken123", access_token: "accesstoken123", status: nil)
-      ShopifyCli::IdentityAuth::APPLICATION_SCOPES.keys.each do |application|
+      ShopifyCLI::IdentityAuth::APPLICATION_SCOPES.keys.each do |application|
         token_query = {
           grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
           requested_token_type: "urn:ietf:params:oauth:token-type:access_token",
           subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
           client_id: client_id,
-          audience: ShopifyCli::IdentityAuth::APPLICATION_CLIENT_IDS[application],
+          audience: ShopifyCLI::IdentityAuth::APPLICATION_CLIENT_IDS[application],
           scope: scopes(scopes_for(application)),
           subject_token: access_token,
         }.tap do |result|
@@ -223,7 +223,7 @@ module ShopifyCli
 
     def identity_auth_client(*)
       @identity_auth_client ||= begin
-        db = ShopifyCli::DB.new(path: File.join(ShopifyCli::TEMP_DIR, ".test_db.pstore"))
+        db = ShopifyCLI::DB.new(path: File.join(ShopifyCLI::TEMP_DIR, ".test_db.pstore"))
         db.clear
         db.set(shop: "testshop")
         IdentityAuth.new(ctx: @context, store: db, code_verifier: "123456")
@@ -239,11 +239,11 @@ module ShopifyCli
     end
 
     def authorization_scopes
-      ShopifyCli::IdentityAuth::APPLICATION_SCOPES.values.flatten
+      ShopifyCLI::IdentityAuth::APPLICATION_SCOPES.values.flatten
     end
 
     def scopes_for(name)
-      ShopifyCli::IdentityAuth::APPLICATION_SCOPES[name]
+      ShopifyCLI::IdentityAuth::APPLICATION_SCOPES[name]
     end
 
     def stub_auth_response(client)
@@ -269,7 +269,7 @@ module ShopifyCli
 
     def scopes(additional_scopes = [])
       (["openid"] + additional_scopes).tap do |result|
-        result << "employee" if ShopifyCli::Shopifolk.acting_as_shopify_organization?
+        result << "employee" if ShopifyCLI::Shopifolk.acting_as_shopify_organization?
       end.join(" ")
     end
   end

--- a/test/shopify-cli/js_deps_test.rb
+++ b/test/shopify-cli/js_deps_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class JsDepsTest < MiniTest::Test
     def setup
       super

--- a/test/shopify-cli/js_system_test.rb
+++ b/test/shopify-cli/js_system_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "project_types/node/test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class JsSystemTest < MiniTest::Test
     def setup
       super

--- a/test/shopify-cli/lazy_delegator_test.rb
+++ b/test/shopify-cli/lazy_delegator_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "securerandom"
 
-module ShopifyCli
+module ShopifyCLI
   class LazyDelegatorTest < MiniTest::Test
     def test_defers_invocation_of_the_provided_block_until_absolutely_necessary
       person_created = false

--- a/test/shopify-cli/method_object_test.rb
+++ b/test/shopify-cli/method_object_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class MethodObjectTest < Minitest::Test
     class GenerateHelloWorld
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(*)
         "Hello World"
@@ -11,7 +11,7 @@ module ShopifyCli
     end
 
     class GenerateNumber
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       property :range, accepts: Range
 
@@ -21,7 +21,7 @@ module ShopifyCli
     end
 
     class Upcase
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(string)
         string.upcase
@@ -29,7 +29,7 @@ module ShopifyCli
     end
 
     class ToJson
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(**data)
         data.to_json
@@ -37,7 +37,7 @@ module ShopifyCli
     end
 
     class BuildArray
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(*elements)
         elements
@@ -45,7 +45,7 @@ module ShopifyCli
     end
 
     class TransformArray
-      include ShopifyCli::MethodObject
+      include ShopifyCLI::MethodObject
 
       def call(*elements, &transform)
         elements.map(&transform)
@@ -54,7 +54,7 @@ module ShopifyCli
 
     def test_returns_a_result
       GenerateHelloWorld.new.call.tap do |result|
-        assert_kind_of(ShopifyCli::Result::Success, result)
+        assert_kind_of(ShopifyCLI::Result::Success, result)
         assert_equal "Hello World", result.value
       end
     end

--- a/test/shopify-cli/options_test.rb
+++ b/test/shopify-cli/options_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class OptionsTest < MiniTest::Test
     def setup
       super

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class PartnersAPI
     class OrganizationsTest < MiniTest::Test
       include TestHelpers::Partners

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class PartnersAPITest < MiniTest::Test
     include TestHelpers::Project
 
     def test_query_calls_partners_api
-      ShopifyCli::DB.expects(:get).with(:partners_exchange_token).returns("token123")
+      ShopifyCLI::DB.expects(:get).with(:partners_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
@@ -18,7 +18,7 @@ module ShopifyCli
 
     def test_query_can_reauth
       Shopifolk.stubs(:check).returns(false)
-      ShopifyCli::DB.stubs(:get).with(:partners_exchange_token).returns("token123")
+      ShopifyCLI::DB.stubs(:get).with(:partners_exchange_token).returns("token123")
         .then.returns("token456")
 
       api_stub = stub
@@ -36,7 +36,7 @@ module ShopifyCli
       api_stub.stubs(:query).raises(API::APIRequestUnauthorizedError).then.returns("response")
 
       @identity_auth_client = mock
-      ShopifyCli::IdentityAuth
+      ShopifyCLI::IdentityAuth
         .expects(:new)
         .with(ctx: @context).returns(@identity_auth_client)
       @identity_auth_client
@@ -47,7 +47,7 @@ module ShopifyCli
 
     def test_query_fails_gracefully_when_unable_to_authenticate
       Shopifolk.stubs(:check).returns(false)
-      ShopifyCli::DB.expects(:get).with(:partners_exchange_token).returns("token123").twice
+      ShopifyCLI::DB.expects(:get).with(:partners_exchange_token).returns("token123").twice
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
@@ -58,13 +58,13 @@ module ShopifyCli
       api_stub.expects(:query).raises(API::APIRequestUnauthorizedError).twice
 
       @identity_auth_client = mock
-      ShopifyCli::IdentityAuth
+      ShopifyCLI::IdentityAuth
         .expects(:new)
         .with(ctx: @context).returns(@identity_auth_client)
       @identity_auth_client
         .expects(:reauthenticate)
 
-      io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
         PartnersAPI.query(@context, "query")
       end
       assert_message_output(
@@ -76,7 +76,7 @@ module ShopifyCli
     end
 
     def test_query_fails_gracefully_without_partners_account
-      ShopifyCli::DB.expects(:get).with(:partners_exchange_token).returns("token123")
+      ShopifyCLI::DB.expects(:get).with(:partners_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,
@@ -84,12 +84,12 @@ module ShopifyCli
         url: "https://partners.shopify.com/api/cli/graphql",
       ).returns(api_stub)
       api_stub.expects(:query).raises(API::APIRequestNotFoundError)
-      @context.expects(:puts).with(@context.message("core.partners_api.error.account_not_found", ShopifyCli::TOOL_NAME))
+      @context.expects(:puts).with(@context.message("core.partners_api.error.account_not_found", ShopifyCLI::TOOL_NAME))
       PartnersAPI.query(@context, "query")
     end
 
     def test_query
-      ShopifyCli::DB.expects(:get).with(:partners_exchange_token).returns("token123")
+      ShopifyCLI::DB.expects(:get).with(:partners_exchange_token).returns("token123")
       api_stub = stub
       PartnersAPI.expects(:new).with(
         ctx: @context,

--- a/test/shopify-cli/process_supervision_test.rb
+++ b/test/shopify-cli/process_supervision_test.rb
@@ -1,16 +1,16 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class ProcessSuperVisionTest < MiniTest::Test
     def test_pid_has_expected_attributes
       process = ProcessSupervision.new("web", pid: 1234)
       assert_equal(1234, process.pid)
       assert_equal("web", process.identifier)
       assert_equal(
-        File.join(ShopifyCli.cache_dir, "sv/web.pid"), process.pid_path
+        File.join(ShopifyCLI.cache_dir, "sv/web.pid"), process.pid_path
       )
       assert_equal(
-        File.join(ShopifyCli.cache_dir, "sv/web.log"), process.log_path
+        File.join(ShopifyCLI.cache_dir, "sv/web.log"), process.log_path
       )
     end
 

--- a/test/shopify-cli/project_test.rb
+++ b/test/shopify-cli/project_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class ProjectTest < MiniTest::Test
     def setup
       super
@@ -21,7 +21,7 @@ module ShopifyCli
     def test_current_fails_if_no_config
       Dir.mktmpdir do |dir|
         Dir.stubs(:pwd).returns("#{dir}/a/b/c/d")
-        assert_raises ShopifyCli::Abort do
+        assert_raises ShopifyCLI::Abort do
           FileUtils.mkdir_p("#{dir}/a/b/c/d")
           Project.current
         end
@@ -31,7 +31,7 @@ module ShopifyCli
     def test_write_writes_yaml
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
       Dir.stubs(:pwd).returns(@context.root)
-      ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
+      ShopifyCLI::Project.write(@context, project_type: :node, organization_id: 42)
       assert_equal :node, Project.current.config["project_type"]
       assert_equal 42, Project.current.config["organization_id"]
       refute Project.current.config["shopify_organization"]
@@ -40,21 +40,21 @@ module ShopifyCli
     def test_write_writes_yaml_with_shopify_organization_field
       create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(true)
-      ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
+      ShopifyCLI::Project.write(@context, project_type: :node, organization_id: 42)
       assert Project.current.config["shopify_organization"]
     end
 
     def test_write_writes_yaml_without_shopify_organization_field
       create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
-      ShopifyCli::Project.write(@context, project_type: :node, organization_id: 42)
+      ShopifyCLI::Project.write(@context, project_type: :node, organization_id: 42)
       refute Project.current.config["shopify_organization"]
     end
 
     def test_write_includes_identifiers
       create_empty_config
       Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
-      ShopifyCli::Project.write(
+      ShopifyCLI::Project.write(
         @context,
         project_type: :node,
         organization_id: 42,

--- a/test/shopify-cli/project_type_test.rb
+++ b/test/shopify-cli/project_type_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class ProjectTypeTest < MiniTest::Test
     def setup
       super
@@ -29,7 +29,7 @@ module ShopifyCli
     def test_project_filepath
       assert_equal(
         Rails::Project.project_filepath("myfile"),
-        File.join(ShopifyCli::PROJECT_TYPES_DIR, "rails", "myfile")
+        File.join(ShopifyCLI::PROJECT_TYPES_DIR, "rails", "myfile")
       )
     end
   end

--- a/test/shopify-cli/resolve_constant_test.rb
+++ b/test/shopify-cli/resolve_constant_test.rb
@@ -1,4 +1,4 @@
-module ShopifyCli
+module ShopifyCLI
   class ResolveConstantTest < MiniTest::Test
     def test_defaults_to_kernel_namespace
       assert_equal Object, ResolveConstant.call(:object).value

--- a/test/shopify-cli/resources/env_file_test.rb
+++ b/test/shopify-cli/resources/env_file_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Resources
     class EnvFileTest < MiniTest::Test
       include TestHelpers::FakeUI

--- a/test/shopify-cli/result_test.rb
+++ b/test/shopify-cli/result_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Result
     class ConvenienceConstructorTest < Minitest::Test
       def test_success_constructor

--- a/test/shopify-cli/shopifolk_test.rb
+++ b/test/shopify-cli/shopifolk_test.rb
@@ -1,17 +1,17 @@
 require "test_helper"
 require "fileutils"
 
-module ShopifyCli
+module ShopifyCLI
   class ShopifolkTest < MiniTest::Test
     include TestHelpers::FakeFS
 
     def setup
       super
-      ShopifyCli::Feature.disable("shopifolk")
+      ShopifyCLI::Feature.disable("shopifolk")
     end
 
     def teardown
-      ShopifyCli::DB.stubs(:del).with(:acting_as_shopify_organization)
+      ShopifyCLI::DB.stubs(:del).with(:acting_as_shopify_organization)
       super
     end
 
@@ -21,81 +21,81 @@ module ShopifyCli
       FileUtils.touch("/opt/dev/.shopify-build")
       stub_gcloud_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      assert ShopifyCli::Config.get_bool("features", "shopifolk")
+      assert ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_feature_always_returns_true
-      ShopifyCli::Feature.enable("shopifolk")
+      ShopifyCLI::Feature.enable("shopifolk")
 
-      assert ShopifyCli::Shopifolk.check
+      assert ShopifyCLI::Shopifolk.check
     end
 
     def test_no_gcloud_config_disables_shopifolk_feature
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_no_section_in_gcloud_config_disables_shopifolk_feature
       stub_gcloud_ini({ "account" => "test@shopify.com", "project" => "shopify-dev" })
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_no_account_in_gcloud_config_disables_shopifolk_feature
       stub_gcloud_ini({ "[core]" => { "project" => "shopify-dev" } })
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_incorrect_email_in_gcloud_config_disables_shopifolk_feature
       stub_gcloud_ini({ "[core]" => { "account" => "test@test.com", "project" => "shopify-dev" } })
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_incorrect_dev_path_disables_dev_shopifolk_feature
       stub_gcloud_ini({ "[core]" => { "account" => "test@shopify.com", "project" => "shopify-dev" } })
 
-      ShopifyCli::Shopifolk.check
+      ShopifyCLI::Shopifolk.check
 
-      refute ShopifyCli::Config.get_bool("features", "shopifolk")
+      refute ShopifyCLI::Config.get_bool("features", "shopifolk")
     end
 
     def test_setting_act_as_shopify_organization
-      ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
-      refute ShopifyCli::Shopifolk.acting_as_shopify_organization?
+      ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
+      refute ShopifyCLI::Shopifolk.acting_as_shopify_organization?
 
-      ShopifyCli::DB.expects(:set).with(acting_as_shopify_organization: true)
-      ShopifyCli::Shopifolk.act_as_shopify_organization
+      ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true)
+      ShopifyCLI::Shopifolk.act_as_shopify_organization
 
-      ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).returns(true)
-      assert ShopifyCli::Shopifolk.acting_as_shopify_organization?
+      ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).returns(true)
+      assert ShopifyCLI::Shopifolk.acting_as_shopify_organization?
 
-      ShopifyCli::DB.expects(:del).with(:acting_as_shopify_organization)
-      ShopifyCli::Shopifolk.reset
+      ShopifyCLI::DB.expects(:del).with(:acting_as_shopify_organization)
+      ShopifyCLI::Shopifolk.reset
 
-      ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
-      refute ShopifyCli::Shopifolk.acting_as_shopify_organization?
+      ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
+      refute ShopifyCLI::Shopifolk.acting_as_shopify_organization?
     end
 
     def test_reading_shopify_organization_from_config
-      ShopifyCli::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
+      ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).returns(nil)
       Project.expects(:has_current?).returns(true)
       project = stub("project", config: { "shopify_organization" => true })
       Project.expects(:current).returns(project)
 
-      assert ShopifyCli::Shopifolk.acting_as_shopify_organization?
+      assert ShopifyCLI::Shopifolk.acting_as_shopify_organization?
     end
 
     private

--- a/test/shopify-cli/smoke_test.rb
+++ b/test/shopify-cli/smoke_test.rb
@@ -1,11 +1,11 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class SmokeTest < MiniTest::Test
     def test_exit_non_zero
       assert_nothing_raised do
         capture_io do
-          ShopifyCli::Core::EntryPoint.call(["help"])
+          ShopifyCLI::Core::EntryPoint.call(["help"])
         end
       end
     end

--- a/test/shopify-cli/tasks/confirm_store_test.rb
+++ b/test/shopify-cli/tasks/confirm_store_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class ConfirmStoreTest < MiniTest::Test
       def setup
@@ -9,20 +9,20 @@ module ShopifyCli
       end
 
       def test_aborts_if_no_shop_stored
-        ShopifyCli::DB.stubs(:exists?).with(:shop).returns(false)
+        ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(false)
 
-        exception = assert_raises ShopifyCli::Abort do
+        exception = assert_raises ShopifyCLI::Abort do
           ConfirmStore.call(@context)
         end
         assert_includes exception.message, "No store found"
       end
 
       def test_aborts_if_user_says_no
-        ShopifyCli::DB.stubs(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
         CLI::UI::Prompt.stubs(:confirm).returns(false)
 
         io = capture_io do
-          assert_raises ShopifyCli::AbortSilent do
+          assert_raises ShopifyCLI::AbortSilent do
             ConfirmStore.call(@context)
           end
         end
@@ -30,9 +30,9 @@ module ShopifyCli
       end
 
       def test_does_not_abort_if_user_says_yes
-        ShopifyCli::DB.stubs(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
         fake_store = "not-a-real-shop.shopify.io"
-        ShopifyCli::DB.stubs(:get).with(:shop).returns(fake_store)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns(fake_store)
         CLI::UI::Prompt.stubs(:confirm).returns(true)
 
         io = capture_io do

--- a/test/shopify-cli/tasks/create_api_client_test.rb
+++ b/test/shopify-cli/tasks/create_api_client_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class CreateApiClientTest < MiniTest::Test
       include TestHelpers::Partners
 
       def teardown
-        ShopifyCli::Core::Monorail.metadata = {}
+        ShopifyCLI::Core::Monorail.metadata = {}
         super
       end
 
@@ -17,7 +17,7 @@ module ShopifyCli
             org: 42,
             title: "Test app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -41,7 +41,7 @@ module ShopifyCli
 
         refute_nil(api_client)
         assert_equal("newapikey", api_client["apiKey"])
-        assert_equal("newapikey", ShopifyCli::Core::Monorail.metadata[:api_key])
+        assert_equal("newapikey", ShopifyCLI::Core::Monorail.metadata[:api_key])
       end
 
       def test_call_will_return_any_general_errors
@@ -51,7 +51,7 @@ module ShopifyCli
             org: 42,
             title: "Test app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -61,7 +61,7 @@ module ShopifyCli
           }
         )
 
-        err = assert_raises ShopifyCli::Abort do
+        err = assert_raises ShopifyCLI::Abort do
           Tasks::CreateApiClient.call(
             @context,
             org_id: 42,
@@ -79,7 +79,7 @@ module ShopifyCli
             org: 42,
             title: "Test app",
             type: "public",
-            app_url: ShopifyCli::Tasks::CreateApiClient::DEFAULT_APP_URL,
+            app_url: ShopifyCLI::Tasks::CreateApiClient::DEFAULT_APP_URL,
             redir: ["http://127.0.0.1:3456"],
           },
           resp: {
@@ -93,7 +93,7 @@ module ShopifyCli
           }
         )
 
-        err = assert_raises ShopifyCli::Abort do
+        err = assert_raises ShopifyCLI::Abort do
           Tasks::CreateApiClient.call(
             @context,
             org_id: 42,

--- a/test/shopify-cli/tasks/ensure_dev_store_test.rb
+++ b/test/shopify-cli/tasks/ensure_dev_store_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class EnsureDevStoreTest < MiniTest::Test
       include TestHelpers::Partners
@@ -14,7 +14,7 @@ module ShopifyCli
         stub_org_request
         stub_env(domain: "notther.myshopify.com")
 
-        exception = assert_raises ShopifyCli::Abort do
+        exception = assert_raises ShopifyCLI::Abort do
           EnsureDevStore.call(@context)
         end
         assert_includes exception.message, @context.message(

--- a/test/shopify-cli/tasks/ensure_env_test.rb
+++ b/test/shopify-cli/tasks/ensure_env_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class EnsureEnvTest < MiniTest::Test
       include TestHelpers::FakeUI
@@ -11,7 +11,7 @@ module ShopifyCli
         @context = TestHelpers::FakeContext.new(root: root)
         Project.write(@context, project_type: :fake, organization_id: 42)
         FileUtils.cd(@context.root)
-        ShopifyCli::Tunnel.stubs(:start)
+        ShopifyCLI::Tunnel.stubs(:start)
         Shopifolk.stubs(:check)
       end
 
@@ -24,10 +24,10 @@ module ShopifyCli
           }],
           "apps" => [],
         }]
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
         CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_name")).returns("new app")
         CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_type.select")).returns("public")
-        ShopifyCli::Tasks::CreateApiClient.expects(:call).with(
+        ShopifyCLI::Tasks::CreateApiClient.expects(:call).with(
           @context,
           org_id: 421,
           title: "new app",
@@ -58,7 +58,7 @@ module ShopifyCli
             }],
           }],
         }]
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
         env_file.expect(:write, nil, [@context])
@@ -67,7 +67,7 @@ module ShopifyCli
 
       def test_uses_default_values_for_env_file
         Resources::EnvFile.expects(:parse_external_env).raises(Errno::ENOENT)
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
@@ -77,7 +77,7 @@ module ShopifyCli
 
       def test_keep_existing_env_values
         Resources::EnvFile.expects(:parse_external_env).returns({ host: "host" })
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values.merge({ host: "host" })).returns(env_file)
@@ -87,7 +87,7 @@ module ShopifyCli
 
       def test_not_all_required_values_found
         Resources::EnvFile.expects(:parse_external_env).returns(existing_env_file_values)
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
@@ -105,7 +105,7 @@ module ShopifyCli
         Resources::EnvFile
           .expects(:parse_external_env)
           .returns(existing_env_file_values.merge({ shop: "shop", host: "host" }))
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values.merge({ host: "host" })).returns(env_file)
@@ -115,7 +115,7 @@ module ShopifyCli
 
       def test_regenerate_empty_env_file
         Resources::EnvFile.expects(:parse_external_env).returns({})
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)

--- a/test/shopify-cli/tasks/ensure_loopback_url_test.rb
+++ b/test/shopify-cli/tasks/ensure_loopback_url_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class EnsureLoopbackURLTest < MiniTest::Test
       include TestHelpers::Partners
@@ -24,7 +24,7 @@ module ShopifyCli
             },
           },
         )
-        ShopifyCli::Tasks::EnsureLoopbackURL.call(@context)
+        ShopifyCLI::Tasks::EnsureLoopbackURL.call(@context)
       end
 
       def test_url_is_added_if_it_is_not_there
@@ -58,7 +58,7 @@ module ShopifyCli
             },
           },
         )
-        ShopifyCli::Tasks::EnsureLoopbackURL.call(@context)
+        ShopifyCLI::Tasks::EnsureLoopbackURL.call(@context)
       end
     end
   end

--- a/test/shopify-cli/tasks/ensure_project_type_test.rb
+++ b/test/shopify-cli/tasks/ensure_project_type_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class EnsureProjectTypeTest < MiniTest::Test
       def setup
@@ -9,13 +9,13 @@ module ShopifyCli
       end
 
       def test_returns_true_if_in_proper_project_type
-        ShopifyCli::Project.expects(:current_project_type).returns(:rails)
+        ShopifyCLI::Project.expects(:current_project_type).returns(:rails)
         assert EnsureProjectType.call(@context, "rails")
       end
 
       def test_aborts_if_in_invalid_project_type
-        ShopifyCli::Project.expects(:current_project_type).returns(nil)
-        exception = assert_raises ShopifyCli::Abort do
+        ShopifyCLI::Project.expects(:current_project_type).returns(nil)
+        exception = assert_raises ShopifyCLI::Abort do
           EnsureProjectType.call(@context, "rails")
         end
         assert_includes exception.message, @context.message(

--- a/test/shopify-cli/tasks/select_org_and_shop_test.rb
+++ b/test/shopify-cli/tasks/select_org_and_shop_test.rb
@@ -1,15 +1,15 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class SelectOrgAndShopTest < MiniTest::Test
       def teardown
-        ShopifyCli::Core::Monorail.metadata = {}
+        ShopifyCLI::Core::Monorail.metadata = {}
         super
       end
 
       def test_user_will_be_prompted_if_more_than_one_organization
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([
           {
             "id" => 421,
             "businessName" => "one",
@@ -28,13 +28,13 @@ module ShopifyCli
           .with(@context.message("core.tasks.select_org_and_shop.organization_select"))
           .returns(431)
         form = call(org_id: nil, shop: nil)
-        assert_equal(431, ShopifyCli::Core::Monorail.metadata[:organization_id])
+        assert_equal(431, ShopifyCLI::Core::Monorail.metadata[:organization_id])
         assert_equal(431, form[:organization_id])
         assert_equal("other.myshopify.com", form[:shop_domain])
       end
 
       def test_will_auto_pick_with_only_one_org
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns(
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns(
           [
             {
               "id" => 421,
@@ -58,7 +58,7 @@ module ShopifyCli
       end
 
       def test_organization_will_be_fetched_if_id_is_provided_but_not_shop
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
           {
             "id" => 123,
             "stores" => [
@@ -72,10 +72,10 @@ module ShopifyCli
       end
 
       def test_it_will_fail_if_no_orgs_are_available
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([])
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_all).with(@context).returns([])
 
         form = nil
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           form = call(org_id: nil, shop: nil)
         end
         assert_nil(form)
@@ -88,7 +88,7 @@ module ShopifyCli
       end
 
       def test_returns_no_shop_if_none_are_available
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
           { "id" => 123, "stores" => [] },
         )
 
@@ -102,7 +102,7 @@ module ShopifyCli
       end
 
       def test_autopicks_only_shop
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
           {
             "id" => 123,
             "stores" => [
@@ -120,7 +120,7 @@ module ShopifyCli
       end
 
       def test_prompts_user_to_pick_from_shops
-        ShopifyCli::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch).with(@context, id: 123).returns(
           {
             "id" => 123,
             "stores" => [

--- a/test/shopify-cli/tasks/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/tasks/update_dashboard_urls_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   module Tasks
     class UpdateDashboardURLSTest < MiniTest::Test
       include TestHelpers::Partners
@@ -25,7 +25,7 @@ module ShopifyCli
             },
           },
         )
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://123abc.ngrok.io",
           callback_url: "/callback/fake",
@@ -64,7 +64,7 @@ module ShopifyCli
             },
           },
         )
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
           callback_url: "/callback/fake",
@@ -111,7 +111,7 @@ module ShopifyCli
             },
           }
         )
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
           callback_url: "/callback/fake",
@@ -156,7 +156,7 @@ module ShopifyCli
           }
         )
         CLI::UI::Prompt.expects(:confirm).returns(false)
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://myowndomain.io",
           callback_url: "/callback/fake",
@@ -201,7 +201,7 @@ module ShopifyCli
           }
         )
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://myowndomain.io",
           callback_url: "/callback/fake",
@@ -239,7 +239,7 @@ module ShopifyCli
             },
           }
         )
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
           callback_url: "/callback/fake",
@@ -283,7 +283,7 @@ module ShopifyCli
           }
         )
         CLI::UI::Prompt.expects(:confirm).returns(true)
-        ShopifyCli::Tasks::UpdateDashboardURLS.call(
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://123adifferenturl.ngrok.io",
           callback_url: "/callback/fake",

--- a/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
+++ b/test/shopify-cli/theme/dev_server/certificate_manager_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 require "shopify_cli/theme/dev_server"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class CertificateManagerTest < Minitest::Test

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -3,13 +3,13 @@ require "test_helper"
 require "shopify_cli/theme/dev_server"
 require "rack/mock"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class HotReloadTest < Minitest::Test
         def setup
           super
-          root = ShopifyCli::ROOT + "/test/fixtures/theme"
+          root = ShopifyCLI::ROOT + "/test/fixtures/theme"
           @ctx = TestHelpers::FakeContext.new(root: root)
           @theme = Theme.new(@ctx, root: root)
           @syncer = stub("Syncer", enqueue_uploads: true)
@@ -27,7 +27,7 @@ module ShopifyCli
           HTML
 
           reload_js = ::File.read(
-            ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload.js", ShopifyCli::ROOT)
+            ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload.js", ShopifyCLI::ROOT)
           )
           reload_script = "<script>\n#{reload_js}</script>"
           expected_html = <<~HTML
@@ -75,7 +75,7 @@ module ShopifyCli
 
         def test_doesnt_broadcast_watcher_events_when_the_list_is_empty
           root_path = Pathname.new(__dir__)
-          ignore_filter = ShopifyCli::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
+          ignore_filter = ShopifyCLI::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
           modified = ["ignored/style.css"]
           SSE::Streams.any_instance
             .expects(:broadcast)

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 require "shopify_cli/theme/dev_server"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class IntegrationTest < Minitest::Test
@@ -17,21 +17,21 @@ module ShopifyCli
           super
           WebMock.disable_net_connect!(allow: "127.0.0.1:#{@@port}")
 
-          ShopifyCli::DB.expects(:get)
+          ShopifyCLI::DB.expects(:get)
             .with(:shopify_exchange_token)
             .at_least_once.returns('token123')
 
-          ShopifyCli::DB.expects(:exists?).with(:shop).at_least_once.returns(true)
-          ShopifyCli::DB.expects(:get)
+          ShopifyCLI::DB.expects(:exists?).with(:shop).at_least_once.returns(true)
+          ShopifyCLI::DB.expects(:get)
             .with(:shop)
             .at_least_once.returns("dev-theme-server-store.myshopify.com")
-          ShopifyCli::DB.stubs(:get)
+          ShopifyCLI::DB.stubs(:get)
             .with(:development_theme_name)
             .returns("Development theme")
-          ShopifyCli::DB.stubs(:get)
+          ShopifyCLI::DB.stubs(:get)
             .with(:development_theme_id)
             .returns("123456789")
-          ShopifyCli::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
+          ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(nil)
         end
 
         def teardown
@@ -81,7 +81,7 @@ module ShopifyCli
             "settings_data.json",
             "ignores_file",
           ]
-          theme_root = "#{ShopifyCli::ROOT}/test/fixtures/theme"
+          theme_root = "#{ShopifyCLI::ROOT}/test/fixtures/theme"
 
           Pathname.new(theme_root).glob("**/*").each do |file|
             next unless file.file? && !ignored_files.include?(file.basename.to_s)
@@ -109,7 +109,7 @@ module ShopifyCli
           # Wait for server to start & sync the files
           get("/assets/bogus.css")
 
-          theme_root = "#{ShopifyCli::ROOT}/test/fixtures/theme"
+          theme_root = "#{ShopifyCLI::ROOT}/test/fixtures/theme"
 
           # Modify a file. Should upload on the fly.
           file = Pathname.new("#{theme_root}/assets/added.css")
@@ -161,7 +161,7 @@ module ShopifyCli
           # Read the head
           assert_includes(socket.readpartial(1024), "HTTP/1.1 200 OK")
           # Add a file
-          file = Pathname.new("#{ShopifyCli::ROOT}/test/fixtures/theme/assets/theme.css")
+          file = Pathname.new("#{ShopifyCLI::ROOT}/test/fixtures/theme/assets/theme.css")
           file.write("modified")
           begin
             assert_equal("2a\r\ndata: {\"modified\":[\"assets/theme.css\"]}\n\n\n\r\n", socket.readpartial(1024))
@@ -174,9 +174,9 @@ module ShopifyCli
         private
 
         def start_server
-          @ctx = TestHelpers::FakeContext.new(root: "#{ShopifyCli::ROOT}/test/fixtures/theme")
+          @ctx = TestHelpers::FakeContext.new(root: "#{ShopifyCLI::ROOT}/test/fixtures/theme")
           @server_thread = Thread.new do
-            DevServer.start(@ctx, "#{ShopifyCli::ROOT}/test/fixtures/theme", port: @@port)
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
           rescue Exception => e
             puts "Failed to start DevServer:"
             puts e.message

--- a/test/shopify-cli/theme/dev_server/local_assets_test.rb
+++ b/test/shopify-cli/theme/dev_server/local_assets_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 require "shopify_cli/theme/dev_server"
 require "rack/mock"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class LocalAssetsTest < Minitest::Test
@@ -40,7 +40,7 @@ module ShopifyCli
           response = serve("<WRONG>", path: "/assets/theme.css")
           assert_equal("text/css", response["Content-Type"])
           assert_equal(
-            ::File.read("#{ShopifyCli::ROOT}/test/fixtures/theme/assets/theme.css"),
+            ::File.read("#{ShopifyCLI::ROOT}/test/fixtures/theme/assets/theme.css"),
             response.body
           )
         end
@@ -49,7 +49,7 @@ module ShopifyCli
           response = serve("<WRONG>", path: "/assets/theme.js")
           assert_equal("application/javascript", response["Content-Type"])
           assert_equal(
-            ::File.read("#{ShopifyCli::ROOT}/test/fixtures/theme/assets/theme.css"),
+            ::File.read("#{ShopifyCLI::ROOT}/test/fixtures/theme/assets/theme.css"),
             response.body
           )
         end
@@ -66,7 +66,7 @@ module ShopifyCli
           app = lambda do |_env|
             [200, {}, [response_body]]
           end
-          root = ShopifyCli::ROOT + "/test/fixtures/theme"
+          root = ShopifyCLI::ROOT + "/test/fixtures/theme"
           ctx = TestHelpers::FakeContext.new(root: root)
           theme = Theme.new(ctx, root: root)
           stack = LocalAssets.new(ctx, app, theme: theme)

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -4,7 +4,7 @@ require "shopify_cli/theme/dev_server"
 require "rack/mock"
 require "timecop"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class ProxyTest < Minitest::Test
@@ -12,18 +12,18 @@ module ShopifyCli
 
         def setup
           super
-          root = ShopifyCli::ROOT + "/test/fixtures/theme"
+          root = ShopifyCLI::ROOT + "/test/fixtures/theme"
           @ctx = TestHelpers::FakeContext.new(root: root)
           @theme = DevelopmentTheme.new(@ctx, root: root)
           @syncer = stub(pending_updates: [])
           @proxy = Proxy.new(@ctx, theme: @theme, syncer: @syncer)
 
-          ShopifyCli::DB.stubs(:exists?).with(:shop).returns(true)
-          ShopifyCli::DB
+          ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:shop)
             .returns("dev-theme-server-store.myshopify.com")
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:development_theme_id)
             .returns("123456789")
@@ -129,7 +129,7 @@ module ShopifyCli
 
           stub_session_id_request
 
-          file = ShopifyCli::ROOT + "/test/fixtures/theme/assets/theme.css"
+          file = ShopifyCLI::ROOT + "/test/fixtures/theme/assets/theme.css"
 
           request.post("/cart/add", params: {
             "form_type" => "product",
@@ -187,12 +187,12 @@ module ShopifyCli
         end
 
         def test_pass_pending_templates_to_storefront
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:shop)
             .returns("dev-theme-server-store.myshopify.com")
 
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:storefront_renderer_production_exchange_token)
             .returns("TOKEN")
@@ -229,12 +229,12 @@ module ShopifyCli
         end
 
         def test_do_not_pass_pending_files_to_core
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:shop)
             .returns("dev-theme-server-store.myshopify.com")
 
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:storefront_renderer_production_exchange_token)
             .returns("TOKEN")
@@ -282,7 +282,7 @@ module ShopifyCli
         end
 
         def test_requires_exchange_token
-          ShopifyCli::DB
+          ShopifyCLI::DB
             .stubs(:get)
             .with(:storefront_renderer_production_exchange_token)
             .returns(nil)

--- a/test/shopify-cli/theme/dev_server/sse_test.rb
+++ b/test/shopify-cli/theme/dev_server/sse_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 require "shopify_cli/theme/dev_server/sse"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     module DevServer
       class SSETest < Minitest::Test

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -2,27 +2,27 @@
 require "test_helper"
 require "shopify_cli/theme/development_theme"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class DevelopmentThemeTest < Minitest::Test
       def setup
         super
-        root = ShopifyCli::ROOT + "/test/fixtures/theme"
+        root = ShopifyCLI::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
         @theme = DevelopmentTheme.new(@ctx, root: root)
-        ShopifyCli::DB.stubs(:del).with(:acting_as_shopify_organization)
+        ShopifyCLI::DB.stubs(:del).with(:acting_as_shopify_organization)
       end
 
       def test_creates_development_theme_if_missing_from_storage
         shop = "dev-theme-server-store.myshopify.com"
         theme_name = "Development (5676d8-theme-dev)"
 
-        ShopifyCli::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
-        ShopifyCli::DB.stubs(:get).with(:development_theme_id).returns(nil)
-        ShopifyCli::DB.expects(:set).with(development_theme_id: "12345678")
+        ShopifyCLI::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_id).returns(nil)
+        ShopifyCLI::DB.expects(:set).with(development_theme_id: "12345678")
         @theme.stubs(:name).returns(theme_name)
 
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
           path: "themes.json",
@@ -49,19 +49,19 @@ module ShopifyCli
         theme_name = "Development (5676d8-theme-dev)"
         theme_id = "12345678"
 
-        ShopifyCli::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
-        ShopifyCli::DB.stubs(:get).with(:development_theme_id).returns(theme_id)
-        ShopifyCli::DB.expects(:set).with(development_theme_id: "12345678")
+        ShopifyCLI::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_id).returns(theme_id)
+        ShopifyCLI::DB.expects(:set).with(development_theme_id: "12345678")
         @theme.stubs(:name).returns(theme_name)
 
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
           path: "themes/#{theme_id}.json",
           api_version: "unstable",
-        ).raises(ShopifyCli::API::APIRequestNotFoundError)
+        ).raises(ShopifyCLI::API::APIRequestNotFoundError)
 
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
           path: "themes.json",
@@ -88,10 +88,10 @@ module ShopifyCli
         hash = "5676d"
         theme_name = "Development (#{hash}-#{hostname.split(".").shift})"
 
-        ShopifyCli::DB.stubs(:get).with(:development_theme_name).returns(nil)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_name).returns(nil)
         SecureRandom.expects(:hex).returns(hash)
         Socket.expects(:gethostname).returns(hostname)
-        ShopifyCli::DB.expects(:set).with(development_theme_name: theme_name)
+        ShopifyCLI::DB.expects(:set).with(development_theme_name: theme_name)
 
         assert_equal(theme_name, @theme.name)
       end
@@ -101,15 +101,15 @@ module ShopifyCli
         hostname = "theme-dev-lan-very-long-name-that-will-be-truncated"
         hash = "5676d"
         theme_name = "Development ()"
-        hostname_character_limit = ShopifyCli::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
+        hostname_character_limit = ShopifyCLI::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
         identifier = "#{hash}-#{hostname[0, hostname_character_limit]}"
         theme_name_without_truncation = "Development (#{hash}-#{hostname})"
         theme_name = "Development (#{identifier})"
 
-        ShopifyCli::DB.stubs(:get).with(:development_theme_name).returns(theme_name_without_truncation)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_name).returns(theme_name_without_truncation)
         SecureRandom.expects(:hex).returns(hash)
         Socket.expects(:gethostname).returns(hostname)
-        ShopifyCli::DB.expects(:set).with(development_theme_name: theme_name)
+        ShopifyCLI::DB.expects(:set).with(development_theme_name: theme_name)
 
         # When/Then
         assert_equal(theme_name, @theme.name)
@@ -120,14 +120,14 @@ module ShopifyCli
         hostname = "theme-dev-lan-very-long-name-that-will-be-truncated"
         hash = "5676d"
         theme_name = "Development ()"
-        hostname_character_limit = ShopifyCli::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
+        hostname_character_limit = ShopifyCLI::Theme::API_NAME_LIMIT - theme_name.length - hash.length - 1
         identifier = "#{hash}-#{hostname[0, hostname_character_limit]}"
         theme_name = "Development (#{identifier})"
 
-        ShopifyCli::DB.stubs(:get).with(:development_theme_name).returns(nil)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_name).returns(nil)
         SecureRandom.expects(:hex).returns(hash)
         Socket.expects(:gethostname).returns(hostname)
-        ShopifyCli::DB.expects(:set).with(development_theme_name: theme_name)
+        ShopifyCLI::DB.expects(:set).with(development_theme_name: theme_name)
 
         # When/Then
         assert_equal(theme_name, @theme.name)
@@ -137,16 +137,16 @@ module ShopifyCli
         shop = "dev-theme-server-store.myshopify.com"
         theme_id = "12345678"
 
-        ShopifyCli::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
-        ShopifyCli::DB.stubs(:get).with(:development_theme_id).returns(theme_id)
-        ShopifyCli::DB.stubs(:exists?).with(:development_theme_id).returns(true)
-        ShopifyCli::DB.stubs(:del).with(:development_theme_id)
-        ShopifyCli::DB.stubs(:exists?).with(:development_theme_name).returns(true)
-        ShopifyCli::DB.stubs(:del).with(:development_theme_name)
+        ShopifyCLI::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_id).returns(theme_id)
+        ShopifyCLI::DB.stubs(:exists?).with(:development_theme_id).returns(true)
+        ShopifyCLI::DB.stubs(:del).with(:development_theme_id)
+        ShopifyCLI::DB.stubs(:exists?).with(:development_theme_name).returns(true)
+        ShopifyCLI::DB.stubs(:del).with(:development_theme_name)
 
         @theme.expects(:exists?).returns(true)
 
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
           path: "themes/#{theme_id}.json",

--- a/test/shopify-cli/theme/ignore_filter_test.rb
+++ b/test/shopify-cli/theme/ignore_filter_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 require "shopify_cli/theme/ignore_filter"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class IgnoreFilterTest < Minitest::Test
       def test_new_filter
@@ -41,7 +41,7 @@ module ShopifyCli
       end
 
       def test_from_path
-        filter = IgnoreFilter.from_path("#{ShopifyCli::ROOT}/test/fixtures/theme")
+        filter = IgnoreFilter.from_path("#{ShopifyCLI::ROOT}/test/fixtures/theme")
 
         assert_includes(filter.globs, "*config/settings_data.json")
         assert_includes(filter.globs, "*.jpg")

--- a/test/shopify-cli/theme/mime_type_test.rb
+++ b/test/shopify-cli/theme/mime_type_test.rb
@@ -2,7 +2,7 @@
 require "test_helper"
 require "shopify_cli/theme/mime_type"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class MimeTypeTest < Minitest::Test
       def test_by_filename

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -3,22 +3,22 @@ require "test_helper"
 require "shopify_cli/theme/syncer"
 require "shopify_cli/theme/theme"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class SyncerTest < Minitest::Test
       def setup
         super
-        root = ShopifyCli::ROOT + "/test/fixtures/theme"
+        root = ShopifyCLI::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
         @theme = Theme.new(@ctx, root: root)
         @syncer = Syncer.new(@ctx, theme: @theme)
 
-        ShopifyCli::DB.stubs(:exists?).with(:shop).returns(true)
-        ShopifyCli::DB
+        ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB
           .stubs(:get)
           .with(:shop)
           .returns("dev-theme-server-store.myshopify.com")
-        ShopifyCli::DB
+        ShopifyCLI::DB
           .stubs(:get)
           .with(:development_theme_id)
           .returns("12345678")
@@ -34,7 +34,7 @@ module ShopifyCli
       end
 
       def test_update_text_file
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -62,7 +62,7 @@ module ShopifyCli
       end
 
       def test_update_binary_file
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -90,7 +90,7 @@ module ShopifyCli
       end
 
       def test_delete_file
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -116,14 +116,14 @@ module ShopifyCli
       def test_upload_when_unmodified
         @syncer.checksums["assets/theme.css"] = @theme["assets/theme.css"].checksum
 
-        ShopifyCli::AdminAPI.expects(:rest_request).never
+        ShopifyCLI::AdminAPI.expects(:rest_request).never
 
         @syncer.enqueue_updates([@theme["assets/theme.css"]])
         @syncer.wait!
       end
 
       def test_fetch_checksums
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -145,7 +145,7 @@ module ShopifyCli
       end
 
       def test_fetch_checksums_with_duplicate_liquid_assets
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -174,7 +174,7 @@ module ShopifyCli
       end
 
       def test_update_checksum_after_upload
-        ShopifyCli::AdminAPI.expects(:rest_request).returns([
+        ShopifyCLI::AdminAPI.expects(:rest_request).returns([
           200,
           {
             "asset" => {
@@ -207,7 +207,7 @@ module ShopifyCli
 
         file = @theme.static_asset_files.first
         @ctx.expects(:puts).once
-        ShopifyCli::AdminAPI.expects(:rest_request).raises(RuntimeError.new("oops"))
+        ShopifyCLI::AdminAPI.expects(:rest_request).raises(RuntimeError.new("oops"))
 
         @syncer.enqueue_updates([file])
         @syncer.wait!
@@ -218,7 +218,7 @@ module ShopifyCli
 
         expected_size = @theme.theme_files.size
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .times(expected_size + 1) # +1 for checksums
           .returns([200, {}, {}])
 
@@ -238,7 +238,7 @@ module ShopifyCli
           .times(expected_size)
           .with("new content")
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .at_least(expected_size + 1) # +1 for checksums
           .returns([
             200,
@@ -266,7 +266,7 @@ module ShopifyCli
         File.any_instance.expects(:delete).never
         File.any_instance.expects(:write).never
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .at_least(1) # 1 for checksums
           .returns([200, {}, {}])
 
@@ -284,7 +284,7 @@ module ShopifyCli
           .times(expected_size)
           .with("new content")
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .at_least(expected_size + 1) # +1 for checksums
           .returns([
             200,
@@ -305,7 +305,7 @@ module ShopifyCli
 
         expected_size = (@theme.liquid_files + @theme.json_files).size
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .at_least(expected_size)
           .returns([200, {}, {}])
 
@@ -336,7 +336,7 @@ module ShopifyCli
         }
 
         # Checksum request
-        ShopifyCli::AdminAPI.expects(:rest_request).with(
+        ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
@@ -348,11 +348,11 @@ module ShopifyCli
         ])
 
         # Other assets have matching checksum, so should not be uploaded
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .with(@ctx, has_entries(method: "PUT"))
           .never
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
           .with(@ctx, has_entries(
             method: "DELETE",
             body: JSON.generate(
@@ -370,7 +370,7 @@ module ShopifyCli
         @syncer.start_threads
         file = @theme.liquid_files.first
 
-        ShopifyCli::AdminAPI.expects(:rest_request).returns([
+        ShopifyCLI::AdminAPI.expects(:rest_request).returns([
           200,
           {},
           {
@@ -388,7 +388,7 @@ module ShopifyCli
         @syncer.start_threads
         file = @theme.liquid_files.first
 
-        ShopifyCli::AdminAPI.expects(:rest_request).returns([
+        ShopifyCLI::AdminAPI.expects(:rest_request).returns([
           200,
           {},
           {
@@ -415,8 +415,8 @@ module ShopifyCli
           }
         )
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
-          .raises(ShopifyCli::API::APIRequestClientError.new(
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .raises(ShopifyCLI::API::APIRequestClientError.new(
             "message", response: mock(body: response_body)
           ))
 
@@ -440,8 +440,8 @@ module ShopifyCli
           }
         )
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
-          .raises(ShopifyCli::API::APIRequestClientError.new(
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .raises(ShopifyCLI::API::APIRequestClientError.new(
             "exception message", response: mock(body: response_body)
           ))
 
@@ -467,8 +467,8 @@ module ShopifyCli
           }
         )
 
-        ShopifyCli::AdminAPI.expects(:rest_request)
-          .raises(ShopifyCli::API::APIRequestClientError.new(
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .raises(ShopifyCLI::API::APIRequestClientError.new(
             "message", response: mock(body: response_body)
           ))
 

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -2,12 +2,12 @@
 require "test_helper"
 require "shopify_cli/theme/theme"
 
-module ShopifyCli
+module ShopifyCLI
   module Theme
     class ThemeTest < Minitest::Test
       def setup
         super
-        root = ShopifyCli::ROOT + "/test/fixtures/theme"
+        root = ShopifyCLI::ROOT + "/test/fixtures/theme"
         @ctx = TestHelpers::FakeContext.new(root: root)
         @theme = Theme.new(@ctx, root: root, id: "123")
       end
@@ -27,7 +27,7 @@ module ShopifyCli
       def test_get_file
         assert_equal(Pathname.new("layout/theme.liquid"), @theme["layout/theme.liquid"].relative_path)
         assert_equal(Pathname.new("layout/theme.liquid"),
-          @theme[Pathname.new("#{ShopifyCli::ROOT}/test/fixtures//theme/layout/theme.liquid")].relative_path)
+          @theme[Pathname.new("#{ShopifyCLI::ROOT}/test/fixtures//theme/layout/theme.liquid")].relative_path)
         assert_equal(@theme.theme_files.first, @theme[@theme.theme_files.first])
       end
 
@@ -43,7 +43,7 @@ module ShopifyCli
       def test_is_theme_file
         assert(@theme.theme_file?(@theme["layout/theme.liquid"]))
         assert(@theme.theme_file?(
-          @theme[Pathname.new(ShopifyCli::ROOT).join("test/fixtures/theme/layout/theme.liquid")]
+          @theme[Pathname.new(ShopifyCLI::ROOT).join("test/fixtures/theme/layout/theme.liquid")]
         ))
       end
 

--- a/test/shopify-cli/transform_data_structure_test.rb
+++ b/test/shopify-cli/transform_data_structure_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class TransformDataStructureTest < MiniTest::Test
     def test_primitive_values_are_returned_as_is
       [true, false, 1, "hello", :hello].each do |value|

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -1,114 +1,114 @@
 require "test_helper"
 
-module ShopifyCli
+module ShopifyCLI
   class TunnelTest < MiniTest::Test
     def setup
-      ShopifyCli::Tunnel.any_instance.stubs(:install)
+      ShopifyCLI::Tunnel.any_instance.stubs(:install)
       super
     end
 
     def test_auth_calls_ngrok_authtoken
-      @context.expects(:system).with("#{ShopifyCli.cache_dir}/ngrok", "authtoken", "token")
-      ShopifyCli::Tunnel.auth(@context, "token")
+      @context.expects(:system).with("#{ShopifyCLI.cache_dir}/ngrok", "authtoken", "token")
+      ShopifyCLI::Tunnel.auth(@context, "token")
     end
 
     def test_start_running_returns_url
-      ShopifyCli::ProcessSupervision.stubs(:running?)
+      ShopifyCLI::ProcessSupervision.stubs(:running?)
         .with(:ngrok).returns(:true)
       with_log do
-        ShopifyCli::Tunnel.start(@context)
-        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
+        ShopifyCLI::Tunnel.start(@context)
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
     end
 
     def test_start_not_running_starts_ngrok
       with_log do
-        ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCli::ProcessSupervision.expects(:start).with(
+        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
+          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
+        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
         @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
-        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
-        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
     end
 
     def test_start_running_timed_out_restarts_ngrok
       start_time = Time.now.to_i - (60 * 60 * 9)
       with_log(time: start_time.to_s) do
-        ShopifyCli::ProcessSupervision.expects(:start).twice.with(
+        ShopifyCLI::ProcessSupervision.expects(:start).twice.with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
+          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
         ).returns(
-          ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
+          ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
         ).then.returns(
-          ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000)
+          ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000)
         )
         @context.expects(:puts).with(@context.message("core.tunnel.timed_out"))
-        ShopifyCli::ProcessSupervision.expects(:stop)
+        ShopifyCLI::ProcessSupervision.expects(:stop)
           .with(:ngrok).returns(true)
         @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
         @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
-        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
-        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
     end
 
     def test_start_accepts_configurable_port
       configured_port = 3000
       with_log do
-        ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCli::ProcessSupervision.expects(:start).with(
+        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false"\
+          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false"\
             " -log=stdout -log-level=debug #{configured_port}"
-        ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
+        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
         @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
-        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCli::TOOL_NAME))
-        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context, port: configured_port)
+        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context, port: configured_port)
       end
     end
 
     def test_start_displays_url_with_account
       with_log(fixture: "ngrok_account") do
-        ShopifyCli::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCli::ProcessSupervision.expects(:start).with(
+        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
+          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
+        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
           @context.message("core.tunnel.start_with_account", "https://example.ngrok.io", "Tom Cruise")
         )
-        assert_equal "https://example.ngrok.io", ShopifyCli::Tunnel.start(@context)
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
     end
 
     def test_start_raises_error_on_ngrok_failure
       with_log(fixture: "ngrok_error") do
-        ShopifyCli::ProcessSupervision.expects(:start).with(
+        ShopifyCLI::ProcessSupervision.expects(:start).with(
           :ngrok,
-          "\"#{File.join(ShopifyCli.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000))
-        assert_raises ShopifyCli::Tunnel::NgrokError do
-          ShopifyCli::Tunnel.start(@context)
+          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
+        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
+        assert_raises ShopifyCLI::Tunnel::NgrokError do
+          ShopifyCLI::Tunnel.start(@context)
         end
       end
     end
 
     def test_stop_doesnt_stop_what_isnt_started
-      ShopifyCli::ProcessSupervision.expects(:running?).with(:ngrok).returns(false)
+      ShopifyCLI::ProcessSupervision.expects(:running?).with(:ngrok).returns(false)
       @context.expects(:puts).with(@context.message("core.tunnel.not_running"))
-      ShopifyCli::Tunnel.stop(@context)
+      ShopifyCLI::Tunnel.stop(@context)
     end
 
     def test_start_raises_error_when_ngrok_cannot_be_stopped
-      ShopifyCli::ProcessSupervision.stubs(:running?).with(:ngrok).returns(true)
-      ShopifyCli::ProcessSupervision.stubs(:stop).with(:ngrok).returns(false)
-      assert_raises(ShopifyCli::Abort) do
-        ShopifyCli::Tunnel.stop(@context)
+      ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(true)
+      ShopifyCLI::ProcessSupervision.stubs(:stop).with(:ngrok).returns(false)
+      assert_raises(ShopifyCLI::Abort) do
+        ShopifyCLI::Tunnel.stop(@context)
       end
     end
 
@@ -162,8 +162,8 @@ module ShopifyCli
     private
 
     def with_log(fixture: "ngrok", time: Time.now.strftime("%s"))
-      log_path = File.join(ShopifyCli::ROOT, "test/fixtures/#{fixture}.log")
-      process = ShopifyCli::ProcessSupervision.new(:ngrok, pid: 40000, time: time)
+      log_path = File.join(ShopifyCLI::ROOT, "test/fixtures/#{fixture}.log")
+      process = ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000, time: time)
       process.write
       File.write(process.log_path, File.read(log_path))
       yield
@@ -179,7 +179,7 @@ module ShopifyCli
     end
 
     def fake_ngrok_api_response
-      @ngrok_api_response ||= JSON.parse(File.read(File.join(ShopifyCli::ROOT, "test", "fixtures", "ngrok_api.json")))
+      @ngrok_api_response ||= JSON.parse(File.read(File.join(ShopifyCLI::ROOT, "test", "fixtures", "ngrok_api.json")))
     end
   end
 end

--- a/test/test_helpers/fake_context.rb
+++ b/test/test_helpers/fake_context.rb
@@ -1,5 +1,5 @@
 module TestHelpers
-  class FakeContext < ShopifyCli::Context
+  class FakeContext < ShopifyCLI::Context
     attr_accessor :output_captured
 
     def puts(*args)

--- a/test/test_helpers/fake_project.rb
+++ b/test/test_helpers/fake_project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module TestHelpers
-  class FakeProject < ShopifyCli::Project
+  class FakeProject < ShopifyCLI::Project
     include SmartProperties
     property :directory
     property :config

--- a/test/test_helpers/fake_task.rb
+++ b/test/test_helpers/fake_task.rb
@@ -1,19 +1,19 @@
 module TestHelpers
   module FakeTask
-    class FakeTask < ShopifyCli::Task
+    class FakeTask < ShopifyCLI::Task
       def call(ctx)
         ctx.puts("success!")
       end
     end
 
-    class FakeTaskWithArgs < ShopifyCli::Task
+    class FakeTaskWithArgs < ShopifyCLI::Task
       def call(ctx, *args)
         ctx.puts("success with args #{args.reject(&:empty?).join}!")
       end
     end
 
     def setup
-      @registry = ShopifyCli::Tasks::TaskRegistry.new
+      @registry = ShopifyCLI::Tasks::TaskRegistry.new
       @registry.add(FakeTask, :fake)
       @registry.add(FakeTaskWithArgs, :fake_with_args)
       super

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -56,11 +56,11 @@ module TestHelpers
     def expects_tar_heroku(status:)
       if status.nil?
         @context.expects(:system)
-          .with("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
+          .with("tar", "-xf", download_path, chdir: ShopifyCLI.cache_dir)
           .never
       else
         @context.expects(:system)
-          .with("tar", "-xf", download_path, chdir: ShopifyCli.cache_dir)
+          .with("tar", "-xf", download_path, chdir: ShopifyCLI.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
 
@@ -158,14 +158,14 @@ module TestHelpers
       if status.nil?
         @context.expects(:system)
           .with("curl", "-o", download_path,
-            ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
-            chdir: ShopifyCli.cache_dir)
+            ShopifyCLI::Heroku::DOWNLOAD_URLS[:mac],
+            chdir: ShopifyCLI.cache_dir)
           .never
       else
         @context.expects(:system)
           .with("curl", "-o", download_path,
-            ShopifyCli::Heroku::DOWNLOAD_URLS[:mac],
-            chdir: ShopifyCli.cache_dir)
+            ShopifyCLI::Heroku::DOWNLOAD_URLS[:mac],
+            chdir: ShopifyCLI.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
     end
@@ -207,13 +207,13 @@ module TestHelpers
     end
 
     def download_path
-      File.join(ShopifyCli.cache_dir, download_filename)
+      File.join(ShopifyCLI.cache_dir, download_filename)
     end
 
     def heroku_command(full_path: false)
       if full_path
         File.stubs(:exist?).returns(true)
-        File.join(ShopifyCli.cache_dir, "heroku", "bin", "heroku").to_s
+        File.join(ShopifyCLI.cache_dir, "heroku", "bin", "heroku").to_s
       else
         "heroku"
       end

--- a/test/test_helpers/partners.rb
+++ b/test/test_helpers/partners.rb
@@ -2,17 +2,17 @@
 module TestHelpers
   module Partners
     def setup
-      ShopifyCli::DB.set(partners_exchange_token: "faketoken")
+      ShopifyCLI::DB.set(partners_exchange_token: "faketoken")
       super
     end
 
     def teardown
-      ShopifyCli::DB.del(:partners_exchange_token)
+      ShopifyCLI::DB.del(:partners_exchange_token)
       super
     end
 
     def stub_partner_req(query, variables: {}, status: 200, resp: {})
-      filepaths = Dir[File.join(ShopifyCli::ROOT, "lib", "**", "graphql", "#{query}.graphql")]
+      filepaths = Dir[File.join(ShopifyCLI::ROOT, "lib", "**", "graphql", "#{query}.graphql")]
       if filepaths.count > 1
         raise "Multiple queries in the codebase with filename #{query}.graphql, please rename your query."
       end
@@ -23,14 +23,14 @@ module TestHelpers
     end
 
     def stub_partner_req_not_found(query, variables: {})
-      filepaths = Dir[File.join(ShopifyCli::ROOT, "lib", "**", "graphql", "#{query}.graphql")]
+      filepaths = Dir[File.join(ShopifyCLI::ROOT, "lib", "**", "graphql", "#{query}.graphql")]
       if filepaths.count > 1
         raise "Multiple queries in the codebase with filename #{query}.graphql, please rename your query."
       end
       stub_request(:post, "https://partners.shopify.com/api/cli/graphql").with(body: {
         query: File.read(filepaths.first).tr("\n", ""),
         variables: variables,
-      }.to_json).to_raise(ShopifyCli::PartnersAPI::APIRequestNotFoundError)
+      }.to_json).to_raise(ShopifyCLI::PartnersAPI::APIRequestNotFoundError)
     end
 
     def stub_shopify_org_confirmation(response: false)

--- a/test/test_helpers/schema.rb
+++ b/test/test_helpers/schema.rb
@@ -2,9 +2,9 @@ module TestHelpers
   module Schema
     def setup
       super
-      json_data = File.read(File.join(ShopifyCli::ROOT, "test/fixtures/shopify_schema.json"))
-      schema = ShopifyCli::AdminAPI::Schema[JSON.parse(json_data)]
-      ShopifyCli::AdminAPI::Schema.stubs(:get).returns(schema)
+      json_data = File.read(File.join(ShopifyCLI::ROOT, "test/fixtures/shopify_schema.json"))
+      schema = ShopifyCLI::AdminAPI::Schema[JSON.parse(json_data)]
+      ShopifyCLI::AdminAPI::Schema.stubs(:get).returns(schema)
     end
   end
 end

--- a/test/test_helpers/shopifolk.rb
+++ b/test/test_helpers/shopifolk.rb
@@ -2,7 +2,7 @@
 module TestHelpers
   module Shopifolk
     def teardown
-      ShopifyCli::Shopifolk.reset
+      ShopifyCLI::Shopifolk.reset
       super
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

`ShopifyCli` is incorrect and should be `ShopifyCLI`. This PR renames the references to the name with the typo.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
