### PR TITLE
Fix the Homebrew formula name

### DIFF
--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -6,7 +6,7 @@
 require "formula"
 require "fileutils"
 
-class ShopifyCLI < Formula
+class ShopifyCli < Formula
   module RubyBin
     def ruby_bin
       Formula["ruby"].opt_bin


### PR DESCRIPTION
### WHY are these changes introduced?

The recent typo fix on `ShopifyCli` broke the Homebrew formula that we generate because Homebrew expects the name to be `ShopifyCli`. 

### WHAT is this pull request doing?
This PR fixes the template that we use for generating the formula.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
