### PR TITLE
use depth 0 for list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1566](https://github.com/Shopify/shopify-cli/pull/1566): Fix bug when running `npm | yarn list` for extension package resolution
 
 Version 2.5.0
 ------

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -44,7 +44,7 @@ module Extension
       def renderer_package(context)
         js_system = ShopifyCLI::JsSystem.new(ctx: context)
         Tasks::FindNpmPackages
-          .exactly_one_of(renderer_package_name, js_system: js_system)
+          .exactly_one_of(renderer_package_name, js_system: js_system, production_only: true)
           .unwrap { |err| raise err }
       rescue Extension::PackageResolutionFailed
         context.abort(

--- a/lib/project_types/extension/tasks/find_npm_packages.rb
+++ b/lib/project_types/extension/tasks/find_npm_packages.rb
@@ -84,11 +84,11 @@ module Extension
       end
 
       def yarn_list
-        production_only? ? %w[list --production] : %w[list]
+        production_only? ? %w[list --production --depth=0] : %w[list]
       end
 
       def npm_list
-        production_only? ? %w[list --prod --depth=1] : %w[list --depth=1]
+        production_only? ? %w[list --prod --depth=0] : %w[list]
       end
 
       def search_packages(packages, package_list)

--- a/test/project_types/extension/tasks/find_npm_packages_test.rb
+++ b/test/project_types/extension/tasks/find_npm_packages_test.rb
@@ -110,7 +110,7 @@ module Extension
         js_system = stub_js_system do |expect_js_system_call|
           expect_js_system_call.with do |config|
             assert_equal ["list"], config.fetch(:yarn)
-            assert_equal ["list", "--depth=1"], config.fetch(:npm)
+            assert_equal ["list"], config.fetch(:npm)
           end
         end
         result = FindNpmPackages.call(js_system: js_system)
@@ -120,8 +120,8 @@ module Extension
       def test_supports_filtering_by_production_dependencies
         js_system = stub_js_system do |expect_js_system_call|
           expect_js_system_call.with do |config|
-            assert_equal ["list", "--production"], config.fetch(:yarn)
-            assert_equal ["list", "--prod", "--depth=1"], config.fetch(:npm)
+            assert_equal ["list", "--production", "--depth=0"], config.fetch(:yarn)
+            assert_equal ["list", "--prod", "--depth=0"], config.fetch(:npm)
           end
         end
         result = FindNpmPackages.call(js_system: js_system, production_only: true)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue with multiple package versions being returned in npm list | yarn list when different versions of the same package are installed:

```ruby
  [#<struct Extension::Models::NpmPackage name="@shopify/post-purchase-ui-extensions", version="0.10.1">,
   #<struct Extension::Models::NpmPackage name="@shopify/post-purchase-ui-extensions", version="0.11.0">]
```

### WHAT is this pull request doing?

Instead of using `depth=1` to list dependencies, we will use `depth=0` so we don't return dev dependencies.

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
