### PR TITLE
Hide LoadError for 2.7/ffi_c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ------
+* [#1574](https://github.com/Shopify/shopify-cli/pull/1574): Hide LoadError for ${RUBY_MAJOR}/ffi_c.
 * [#1567](https://github.com/Shopify/shopify-cli/pull/1567): Add ability to set custom port for ngrok tunnel in node serve.
 * [#1584](https://github.com/Shopify/shopify-cli/issues/1584): Fixed extended help message not showing.
 * [#1566](https://github.com/Shopify/shopify-cli/pull/1566): Fix bug when running `npm | yarn list` for extension package resolution.

--- a/bin/shopify
+++ b/bin/shopify
@@ -12,6 +12,8 @@ module Kernel
     raise if (name == "readline.so") && ShopifyCLI::Context.new.windows?
     # Special case for psych (yaml), which rescues this itself
     raise if name == "#{RUBY_VERSION[/\d+\.\d+/]}/psych.so"
+    # Special case for ffi, which rescues this itself
+    raise if name == "#{RUBY_VERSION.split(".")[0, 2].join(".")}/ffi_c"
     STDERR.puts "[Note] You cannot use gems with Shopify CLI."
     STDERR.puts "[LoadError] #{e.message}"
     if ENV["DEBUG"]


### PR DESCRIPTION
Hide unnecessary load error on loading ${RUBY_MAJOR}/ffi_c. Partially fix #1405
