### PR TITLE
Fix ruby 2 keywords delegation warning

### DIFF
--- a/lib/shopify_cli/method_object.rb
+++ b/lib/shopify_cli/method_object.rb
@@ -48,12 +48,14 @@ module ShopifyCLI
   #
   module MethodObject
     module AutoCreateResultObject
+      def self.ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
+
       ##
       # invokes the original `call` implementation and wraps its return value
       # into a result object.
       #
-      def call(*args, **kwargs, &block)
-        Result.wrap { kwargs.any? ? super(*args, **kwargs, &block) : super(*args, &block) }.call
+      ruby2_keywords def call(*args, &block)
+        Result.wrap { super(*args, &block) }.call
       end
     end
 
@@ -66,8 +68,13 @@ module ShopifyCLI
       #
       def call(*args, **kwargs, &block)
         properties.keys.yield_self do |properties|
-          new(**kwargs.slice(*properties))
-            .call(*args, **kwargs.slice(*(kwargs.keys - properties)), &block)
+          instance = new(**kwargs.slice(*properties))
+          kwargs = kwargs.slice(*(kwargs.keys - properties))
+          if kwargs.any?
+            instance.call(*args, **kwargs, &block)
+          else
+            instance.call(*args, &block)
+          end
         end
       end
 


### PR DESCRIPTION
Fixes warnings in the test suite such as:

    test/shopify-cli/transform_data_structure_test.rb:94: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    lib/shopify_cli/method_object.rb:55: warning: The called method `call' is defined here

This is the suggested way as per this news entry on Ruby's website:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#a-compatible-delegation

Applying `ruby2_keywords` patch as-is broke Ruby 2.6: we ended up
calling methods with an extra argument. Not exactly sure I get the
subtleties, but Ruby 2.6 kwargs is misbehaving:

```ruby
#! /opt/rubies/2.6.6/bin/ruby
def one_argument(arg1)
end

def delegate(*args, &block)
  one_argument(*args, &block)
end

kwargs = {}
delegate(*[1], **kwargs)

# Result:
# test.rb:2:in `one_argument': wrong number of arguments (given 2, expected 1) (ArgumentError)
#       from test.rb:6:in `delegate'
#       from test.rb:10:in `<main>'
```

Moving the code that prevented passing empty `**kwargs` to
`ClassMethods#call` – which actually changes the `kwargs`, fixes the
problem and makes sense anyways.


### Update checklist
- No changelog entry given this is not public facing.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is.
