### PR TITLE
Fix `bundle install` crashing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       ruby-progressbar
     mocha (1.13.0)
     multi_test (0.1.2)
-    nokogiri (1.12.4)
+    nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -120,6 +120,7 @@ GEM
     theme-check (1.7.2)
       liquid (>= 5.1.0)
       nokogiri (>= 1.12)
+      parser (~> 3)
     timecop (0.9.2)
     unicode-display_width (2.0.0)
     webmock (3.9.3)


### PR DESCRIPTION
### WHY are these changes introduced?

`bundle install` was crashing with:

> Downloading theme-check-1.7.2 revealed dependencies not in the API or the lockfile (parser (~> 3)).
> Either installing with `--full-index` or running `bundle update theme-check` should fix the problem

I ran `bundle update theme-check` which updated Gemfile.lock.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
