### PR TITLE
Extract Docker-related business logic to be reused in acceptance tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,4 @@ WORKDIR /usr/src/app
 COPY Gemfile Gemfile.lock ./
 COPY shopify-cli.gemspec  shopify-cli.gemspec
 COPY lib/shopify_cli/version.rb  lib/shopify_cli/version.rb
-COPY . .
-
 RUN bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,13 @@
 ENV["SHOPIFY_CLI_TEST"] = "1"
 
 require_relative "bin/load_shopify"
+require_relative "utilities/utilities"
 require "rake/testtask"
 require "rubocop/rake_task"
 require "bundler/gem_tasks"
 require "shellwords"
+require "digest"
+require "open3"
 
 Rake::TestTask.new do |t|
   t.libs += %w(test)
@@ -17,26 +20,12 @@ desc "A set of tasks that run in Linux environments"
 namespace :linux do
   desc "Runs the test suite in a Linux Docker environment"
   task :test do
-    system("docker", "build", __dir__, "-t", "shopify-cli") || abort
-    system(
-      "docker", "run",
-      "-t", "--rm",
-      "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
-      "shopify-cli",
-      "bundle", "exec", "rake", "test"
-    ) || abort
+    Utilities::Docker.run_and_rm_container("bundle", "exec", "rake", "test")
   end
 
   desc "Runs the acceptance tests suite in a Linux Docker environment"
   task :features do
-    system("docker", "build", __dir__, "-t", "shopify-cli") || abort
-    system(
-      "docker", "run",
-      "-t", "--rm",
-      "--volume", "#{Shellwords.escape(__dir__)}:/usr/src/app",
-      "shopify-cli",
-      "bundle", "exec", "cucumber"
-    ) || abort
+    Utilities::Docker.run_and_rm_container("bundle", "exec", "cucumber")
   end
 end
 

--- a/test/project_types/php/commands/create_test.rb
+++ b/test/project_types/php/commands/create_test.rb
@@ -53,7 +53,7 @@ module PHP
       end
 
       def test_check_composer_installed
-        @context.expects(:which).with("php").returns("/usr/bin/php")
+        PHP::Command::Create.any_instance.stubs(:check_php)
         @context.expects(:which).with("composer").returns(nil)
         assert_raises ShopifyCLI::Abort, "php.create.error.composer_required" do
           perform_command

--- a/utilities/docker.rb
+++ b/utilities/docker.rb
@@ -1,0 +1,71 @@
+require "open3"
+
+module Utilities
+  module Docker
+    Error = Class.new(StandardError)
+
+    class << self
+      def create_and_start_disposable_container
+        build_image_if_needed
+        container_id, create_err, create_stat = Open3.capture3("docker", "create", "-t", "-i", image_tag)
+        raise Error, create_err unless create_stat.success?
+        _, start_err, start_stat = Open3.capture3("docker", "start", "-i", container_id)
+        raise Error, start_err unless start_stat.success?
+        container_id
+      end
+
+      def run(*args, container_id:)
+        system(
+          "docker", "run",
+          "-t",
+          "--volume", "#{Shellwords.escape(root_dir)}:/usr/src/app",
+          container_id,
+          *args
+        ) || abort
+      end
+
+      def delete_container(id)
+        _, err, stat = Open3.capture3("docker", "container", "rm", "-f", id)
+        raise Error, err unless stat.success?
+      end
+
+      def run_and_rm_container(*args)
+        build_image_if_needed
+        system(
+          "docker", "run",
+          "-t", "--rm",
+          "--volume", "#{Shellwords.escape(root_dir)}:/usr/src/app",
+          image_tag,
+          *args
+        ) || abort
+      end
+
+      private
+
+      def root_dir
+        File.expand_path("..", __dir__)
+      end
+
+      def build_image_if_needed
+        unless image_exists?(image_tag)
+          system("docker", "build", root_dir, "-t", image_tag) || abort
+        end
+      end
+
+      def image_tag
+        dockerfile_path = File.expand_path("./Dockerfile", root_dir)
+        image_sha = Digest::SHA256.hexdigest(File.read(dockerfile_path))
+        "shopify-cli-#{image_sha}"
+      end
+
+      def image_exists?(tag)
+        _, stat = Open3.capture2(
+          "docker", "inspect",
+          "--type=image",
+          tag
+        )
+        stat.success?
+      end
+    end
+  end
+end

--- a/utilities/utilities.rb
+++ b/utilities/utilities.rb
@@ -1,0 +1,5 @@
+$LOAD_PATH.unshift(__dir__) unless $LOAD_PATH.include?(__dir__)
+
+module Utilities
+  autoload :Docker, "docker"
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Until now, we were using Docker images to run unit and acceptance tests in Linux environments from macOS environments. In a recent pairing session with @hannachen we realized we might need sandboxing also for running acceptance tests for commands that have implicit dependencies with the environments (e.g. Rails or PHP being present in the system).

### WHAT is this pull request doing?
Because we don't want contributors and CI environments to have those installed, because that'll add non-determinism to the test execution, I'm making the logic generic so that it can be used from Rake tasks and acceptance tests.

### Update checklist
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
