### PR TITLE
Report errors even when backtrace is silenced

### DIFF
--- a/bin/shopify
+++ b/bin/shopify
@@ -37,6 +37,7 @@ exit(proc do
       ShopifyCLI::Core::EntryPoint.call(ARGV.dup)
     end
   rescue StandardError => error
+    ShopifyCLI::ErrorHandler.exception = error
     if ShopifyCLI::Environment.print_stacktrace?
       raise error
     else


### PR DESCRIPTION
### WHY are these changes introduced?

Backtrace silencing causes errors to not be reported: when
`print_stacktrace?` is false, the error reporter never gets called,
thus the error does not reach Bugsnag. This PR fixes that.

### WHAT is this pull request doing?

The CLI Kit uses the handler's `@exception` ivar or the last error to
have been raised (`$!`, or `$ERROR_INFO` when using Ruby's english
package):

https://github.com/Shopify/cli-kit/blob/be4251dea3c7b9bc46b77d60d1d0dcf08d575949/lib/cli/kit/error_handler.rb#L70-L72:

```ruby
def install!
  at_exit { handle_exception(@exception || $ERROR_INFO) }
end
```

Turns out calling `exit` populates `$ERROR_INFO`, overriding whatever
exception was already in there:

```ruby
at_exit { puts $!.inspect }
exit 0

# prints #<SystemExit: exit>
```

By explicitly setting the error handler's `@exception` ivar to the
exception that's causing the program to halt, CLI Kit will pick it
instead of `SystemExit`.

- ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ bugfix of a unreleased feature.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
