### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ------
+Version 2.6.1
+------
 
 * [#1608](https://github.com/Shopify/shopify-cli/pull/1608): Fix errors not being reported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ------
 
+* [#1608](https://github.com/Shopify/shopify-cli/pull/1608): Fix errors not being reported.
+
 Version 2.6.0
 ------
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.6.0)
+    shopify-cli (2.6.1)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.7)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end


### PR DESCRIPTION
I'm releasing a hotfix version to include [this fix](https://github.com/Shopify/shopify-cli/pull/1608). Otherwise, we won't get errors reported in 2.6.0