### PR TITLE
Refactor TaskRunner base class 

### DIFF
--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -9,25 +9,12 @@ module Script
           SCRIPT_SDK_BUILD = "npm run build"
           MIN_NPM_VERSION = "5.2.0"
           MIN_NODE_VERSION = "14.5.0"
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-          REQUIRED_TOOL_VERSIONS = [
-            { "tool_name": "npm", "min_version": MIN_NPM_VERSION },
-            { "tool_name": "node", "min_version": MIN_NODE_VERSION },
-          ]
-=======
->>>>>>> 2abe8cee (refactor task_runner)
           INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
 
-          attr_reader :ctx, :script_name
-
-          def initialize(ctx, script_name)
-            super()
-            @ctx = ctx
-            @script_name = script_name
+          def build
+            compile
+            bytecode
           end
->>>>>>> 6d10b0dc (refactor task_runner)
 
           def install_dependencies
             check_system_dependencies!
@@ -39,11 +26,6 @@ module Script
           def project_dependencies_installed?
             # Assuming if node_modules folder exist at root of script folder, all deps are installed
             ctx.dir_exist?("node_modules")
-          end
-
-          def check_system_dependencies!
-            check_tool_version!("npm", MIN_NPM_VERSION)
-            check_tool_version!("node", MIN_NODE_VERSION)
           end
 
           def library_version(library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -29,11 +29,6 @@ module Script
           end
 >>>>>>> 6d10b0dc (refactor task_runner)
 
-          def build
-            compile
-            bytecode
-          end
-
           def compiled_type
             "wasm"
           end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -10,11 +10,14 @@ module Script
           MIN_NPM_VERSION = "5.2.0"
           MIN_NODE_VERSION = "14.5.0"
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
           REQUIRED_TOOL_VERSIONS = [
             { "tool_name": "npm", "min_version": MIN_NPM_VERSION },
             { "tool_name": "node", "min_version": MIN_NODE_VERSION },
           ]
+=======
+>>>>>>> 2abe8cee (refactor task_runner)
           INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
 
           attr_reader :ctx, :script_name
@@ -62,6 +65,28 @@ module Script
             Domain::Metadata.create_from_json(@ctx, raw_contents)
           end
 
+          def project_dependencies_installed?
+            # Assuming if node_modules folder exist at root of script folder, all deps are installed
+            ctx.dir_exist?("node_modules")
+          end
+
+          protected
+
+          def required_tool_versions
+            [
+              { "tool_name": "npm", "min_version": MIN_NPM_VERSION },
+              { "tool_name": "node", "min_version": MIN_NODE_VERSION },
+            ]
+          end
+
+          def tool_version_output(tool, min_required_version)
+            output, status = @ctx.capture2e(tool, "--version")
+            unless status.success?
+              raise Errors::NoDependencyInstalledError.new(tool, min_required_version)
+            end
+
+            output
+          end
 
           private
 

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -32,8 +32,8 @@ module Script
           def install_dependencies
             check_system_dependencies!
 
-            output, status = ctx.capture2e("npm install --no-audit --no-optional --legacy-peer-deps --loglevel error")
-            raise Errors::DependencyInstallationError, output unless status.success?
+            stdout, stderr, status = ctx.capture3(self.class::INSTALL_COMMAND)
+            raise Errors::DependencyInstallationError, stderr unless status.success?
           end
 
           def project_dependencies_installed?
@@ -44,16 +44,6 @@ module Script
           def check_system_dependencies!
             check_tool_version!("npm", MIN_NPM_VERSION)
             check_tool_version!("node", MIN_NODE_VERSION)
-          end
-
-          def metadata
-            unless @ctx.file_exist?(METADATA_FILE)
-              msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)
-              raise Domain::Errors::MetadataNotFoundError, msg
-            end
-
-            raw_contents = File.read(METADATA_FILE)
-            Domain::Metadata.create_from_json(@ctx, raw_contents)
           end
 
           def library_version(library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -12,8 +12,8 @@ module Script
 <<<<<<< HEAD
 =======
           REQUIRED_TOOL_VERSIONS = [
-            {"tool_name": "npm", "min_version": MIN_NPM_VERSION},
-            {"tool_name": "node", "min_version": MIN_NODE_VERSION}
+            { "tool_name": "npm", "min_version": MIN_NPM_VERSION },
+            { "tool_name": "node", "min_version": MIN_NODE_VERSION },
           ]
           INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
 

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -6,10 +6,25 @@ module Script
       module Languages
         class AssemblyScriptTaskRunner < TaskRunner
           BYTECODE_FILE = "build/script.wasm"
-          METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
           MIN_NPM_VERSION = "5.2.0"
           MIN_NODE_VERSION = "14.5.0"
+<<<<<<< HEAD
+=======
+          REQUIRED_TOOL_VERSIONS = [
+            {"tool_name": "npm", "min_version": MIN_NPM_VERSION},
+            {"tool_name": "node", "min_version": MIN_NODE_VERSION}
+          ]
+          INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
+
+          attr_reader :ctx, :script_name
+
+          def initialize(ctx, script_name)
+            super()
+            @ctx = ctx
+            @script_name = script_name
+          end
+>>>>>>> 6d10b0dc (refactor task_runner)
 
           def build
             compile
@@ -47,12 +62,6 @@ module Script
             Domain::Metadata.create_from_json(@ctx, raw_contents)
           end
 
-          def library_version(library_name)
-            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
-            library_version_from_npm_list(output, library_name)
-          rescue Errors::SystemCallFailureError => error
-            library_version_from_npm_list_error_output(error, library_name)
-          end
 
           private
 

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -79,6 +79,14 @@ module Script
               raise Errors::MissingDependencyVersionError.new(tool, output.strip, min_required_version)
             end
           end
+
+          def compile
+            raise NotImplementedError
+          end
+
+          def bytecode
+            raise NotImplementedError
+          end
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -46,10 +46,6 @@ module Script
             raise Errors::DependencyInstallationError, output unless status.success?
           end
 
-          def compiled_type
-            "wasm"
-          end
-
           def metadata
             unless @ctx.file_exist?(METADATA_FILE)
               msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -37,7 +37,7 @@ module Script
           end
 
           def check_system_dependencies!
-            self.class::REQUIRED_TOOL_VERSIONS.each { |tool| check_tool_version!(tool[:tool_name], tool[:min_version])}
+            self.class::REQUIRED_TOOL_VERSIONS.each { |tool| check_tool_version!(tool[:tool_name], tool[:min_version]) }
           end
 
           def install_dependencies

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -60,10 +60,6 @@ module Script
             raise NotImplementedError
           end
 
-          def metadata
-            raise NotImplementedError
-          end
-
           protected
 
           def check_tool_version!(tool, min_required_version)

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -37,7 +37,7 @@ module Script
           end
 
           def check_system_dependencies!
-            self.class::REQUIRED_TOOL_VERSIONS.each { |tool| check_tool_version!(tool[:tool_name], tool[:min_version]) }
+            required_tool_versions.each { |tool| check_tool_version!(tool[:tool_name], tool[:min_version]) }
           end
 
           def install_dependencies
@@ -48,11 +48,6 @@ module Script
 
           def compiled_type
             "wasm"
-          end
-
-          def project_dependencies_installed?
-            # Assuming if node_modules folder exist at root of script folder, all deps are installed
-            ctx.dir_exist?("node_modules")
           end
 
           def metadata
@@ -76,10 +71,7 @@ module Script
           protected
 
           def check_tool_version!(tool, min_required_version)
-            output, status = @ctx.capture2e(tool, "--version")
-            unless status.success?
-              raise Errors::NoDependencyInstalledError.new(tool, min_required_version)
-            end
+            output = tool_version_output(tool, min_required_version)
 
             require "semantic/semantic"
             version = ::Semantic::Version.new(output.gsub(/^v/, ""))

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -6,7 +6,6 @@ module Script
       module Languages
         class TypeScriptTaskRunner < TaskRunner
           BYTECODE_FILE = "build/index.wasm"
-          METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
           GEN_METADATA = "npm run gen-metadata"
           MIN_NPM_VERSION = "5.2.0"

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -7,6 +7,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
   TS_EXACT_NODE_VERSION = "v14.15.0"
   TS_EXACT_NPM_VERSION = "5.2.0"
 
+  INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_name) { "foo" }
   let(:language) { "TypeScript" }

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -7,7 +7,8 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
   TS_EXACT_NODE_VERSION = "v14.15.0"
   TS_EXACT_NPM_VERSION = "5.2.0"
 
-  INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
+  TS_INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
+
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_name) { "foo" }
   let(:language) { "TypeScript" }


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/2796

### WHY are these changes introduced?

AssemblyScriptTaskRunner and TypescriptTaskRunner share almost the same code. TaskRunner base class is refactored to handle this cleanly. 

### WHAT is this pull request doing?

Refactored AssemblyScriptTaskRunner and TypescriptTaskRunner to inherit from baseclass TaskRunner

### Update checklist
<!--
  Ideally, CHANGELOG entries should be in the format
  `* [#PR](PR URL): Message`. You should consider adding your PR
  and then making the CHANGELOG update once you know the PR number.
-->
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
