### PR TITLE
Add "reporting on/off" command to enable/disable automatic usage reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#1542](https://github.com/Shopify/shopify-cli/pull/1542): Add option theme serve --poll to force polling when watching files
-
+* [#1635](https://github.com/Shopify/shopify-cli/pull/1635): Command to enable or disable anonymous usage and error reporting.
 ### Removed
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :development, :test do
   gem "rubocop-shopify", require: false
   gem "rubocop-minitest", require: false
   gem "rubocop-rake", require: false
+  gem "iniparse", "~> 1.5"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     fakefs (1.3.2)
     ffi (1.15.4)
     hashdiff (1.0.1)
+    iniparse (1.5.0)
     liquid (5.1.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -136,6 +137,7 @@ DEPENDENCIES
   byebug
   cucumber (~> 7.0)
   fakefs (>= 1.0)
+  iniparse (~> 1.5)
   minitest (>= 5.0.0)
   minitest-fail-fast
   minitest-reporters
@@ -151,4 +153,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.22
+   2.2.29

--- a/Rakefile
+++ b/Rakefile
@@ -22,11 +22,6 @@ namespace :linux do
   task :test do
     Utilities::Docker.run_and_rm_container("bundle", "exec", "rake", "test")
   end
-
-  desc "Runs the acceptance tests suite in a Linux Docker environment"
-  task :features do
-    Utilities::Docker.run_and_rm_container("bundle", "exec", "cucumber")
-  end
 end
 
 RuboCop::RakeTask.new

--- a/features/reporting.feature
+++ b/features/reporting.feature
@@ -1,0 +1,9 @@
+Feature: The installation process
+
+  Scenario: The user enables reporting
+     Given I have a VM with the CLI and a working directory
+     Then I can turn the reporting on
+
+  Scenario: The user disables reporting
+     Given I have a VM with the CLI and a working directory
+     Then I can turn the reporting off

--- a/features/step_definitions/commands/reporting.rb
+++ b/features/step_definitions/commands/reporting.rb
@@ -1,0 +1,23 @@
+require "iniparse"
+
+Then(/I can turn the reporting (.+)/) do |on_off|
+  enable = case on_off
+  when "on"
+    true
+  when "off"
+    false
+  else
+    flunk("Invalid reporting #{on_off} value")
+  end
+
+  @container.exec_shopify("reporting", on_off)
+  config_content = @container.capture("cat", @container_shopify_config_path).chomp
+  document = IniParse.parse(config_content)
+  config_value = document["analytics"]["enabled"]
+
+  if enable
+    assert config_value
+  else
+    refute config_value
+  end
+end

--- a/features/step_definitions/commands/script.rb
+++ b/features/step_definitions/commands/script.rb
@@ -1,19 +1,13 @@
 require_relative "../../../utilities/utilities"
 
 When(/I create a (.+) script named (.+)/) do |extension_point, script_name|
-  Process.exec_shopify(
+  @container.exec_shopify(
     "script", "create",
     "--name", script_name,
-    "--extension-point=#{extension_point}",
-    cwd: @docker_tmp_dir,
-    container_id: @docker_container_id
+    "--extension-point=#{extension_point}"
   )
 end
 
-Then(/I should be able to (.+) the script in directory (.+)/) do |action, script_name|
-  Utilities::Docker.exec(
-    "npm", "run", action,
-    cwd: File.join(@docker_tmp_dir, script_name),
-    container_id: @docker_container_id
-  )
+Then(/I should be able to (.+) the script in directory (.+)/) do |action, _script_name|
+  @container.exec("npm", "run", action)
 end

--- a/features/step_definitions/commands/script.rb
+++ b/features/step_definitions/commands/script.rb
@@ -8,6 +8,6 @@ When(/I create a (.+) script named (.+)/) do |extension_point, script_name|
   )
 end
 
-Then(/I should be able to (.+) the script in directory (.+)/) do |action, _script_name|
-  @container.exec("npm", "run", action)
+Then(/I should be able to (.+) the script in directory (.+)/) do |action, directory|
+  @container.exec("npm", "run", action, relative_dir: directory)
 end

--- a/features/step_definitions/commands/theme.rb
+++ b/features/step_definitions/commands/theme.rb
@@ -2,6 +2,6 @@ When(/I create a theme named (.+)/) do |theme_name|
   @container.exec_shopify("theme", "init", theme_name)
 end
 
-Then(/I should be able to check the theme in directory (.+)/) do |_theme_directory|
-  @container.exec_shopify("theme", "check")
+Then(/I should be able to check the theme in directory (.+)/) do |directory|
+  @container.exec_shopify("theme", "check", relative_dir: directory)
 end

--- a/features/step_definitions/commands/theme.rb
+++ b/features/step_definitions/commands/theme.rb
@@ -1,16 +1,7 @@
 When(/I create a theme named (.+)/) do |theme_name|
-  Process.exec_shopify(
-    "theme", "init",
-    theme_name,
-    cwd: @docker_tmp_dir,
-    container_id: @docker_container_id
-  )
+  @container.exec_shopify("theme", "init", theme_name)
 end
 
-Then(/I should be able to check the theme in directory (.+)/) do |theme_directory|
-  Process.exec_shopify(
-    "theme", "check",
-    cwd: File.join(@docker_tmp_dir, theme_directory),
-    container_id: @docker_container_id
-  )
+Then(/I should be able to check the theme in directory (.+)/) do |_theme_directory|
+  @container.exec_shopify("theme", "check")
 end

--- a/features/step_definitions/commands/version.rb
+++ b/features/step_definitions/commands/version.rb
@@ -1,8 +1,4 @@
 Then("'version' returns the right version") do
-  output = Process.capture_shopify(
-    "version",
-    cwd: @docker_tmp_dir,
-    container_id: @docker_container_id
-  ).chomp
+  output = @container.capture_shopify("version").chomp
   assert_equal CLI.version, output
 end

--- a/features/step_definitions/shared/docker.rb
+++ b/features/step_definitions/shared/docker.rb
@@ -4,20 +4,10 @@ require "securerandom"
 require_relative "../../../utilities/utilities"
 
 Given(/I have a VM with the CLI and a working directory/) do
-  @docker_container_id = SecureRandom.hex
-  @docker_tmp_dir = "/tmp/#{SecureRandom.hex}"
-  Utilities::Docker.run(
-    "tail", "-f", "/dev/null",
-    container_id: @docker_container_id
-  )
-  Utilities::Docker.exec(
-    "mkdir", "-p", @docker_tmp_dir,
-    container_id: @docker_container_id
-  )
+  @container = Utilities::Docker.create_container(env: { "SHOPIFY_CLI_ACCEPTANCE_TEST" => "1" })
+  @container_shopify_config_path = File.join(@container.xdg_config_home, "shopify/config")
 end
 
 After do |_scenario|
-  unless @docker_container_id.nil?
-    Utilities::Docker.rm(container_id: @docker_container_id)
-  end
+  @container&.remove
 end

--- a/features/support/process.rb
+++ b/features/support/process.rb
@@ -2,9 +2,6 @@ require "open3"
 require_relative "../../utilities/utilities"
 
 module Process
-  ENV_VARIABLES = { "SHOPIFY_CLI_ACCEPTANCE_TEST" => "1" }
-  VM_SHOPIFY_BIN_PATH = "/usr/src/app/bin/shopify"
-
   class ProcessError < StandardError
     attr_reader :exit_status, :stderr
     def initialize(exit_status:, stderr:)
@@ -18,27 +15,9 @@ module Process
     end
   end
 
-  def self.exec_shopify(*args, container_id:, cwd: nil)
-    Utilities::Docker.exec(
-      VM_SHOPIFY_BIN_PATH, *args,
-      container_id: container_id,
-      cwd: cwd,
-      env: ENV_VARIABLES
-    )
-  end
-
-  def self.capture_shopify(*args, container_id:, cwd: nil)
-    Utilities::Docker.capture(
-      VM_SHOPIFY_BIN_PATH, *args,
-      container_id: container_id,
-      cwd: cwd,
-      env: ENV_VARIABLES
-    )
-  end
-
   def self.run(*args, cwd: nil)
     cwd ||= Dir.pwd
-    _, err, stat = Open3.capture3(ENV_VARIABLES, *args, chdir: cwd)
+    _, err, stat = Open3.capture3(*args, chdir: cwd)
     raise ProcessError.new(exit_status: stat.exitstatus, stderr: err) unless stat.success?
   end
 

--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -128,6 +128,7 @@ module ShopifyCLI
   autoload :ResolveConstant, "shopify_cli/resolve_constant"
   autoload :Resources, "shopify_cli/resources"
   autoload :Result, "shopify_cli/result"
+  autoload :Services, "shopify_cli/services"
   autoload :Shopifolk, "shopify_cli/shopifolk"
   autoload :SubCommand, "shopify_cli/sub_command"
   autoload :Task, "shopify_cli/task"

--- a/lib/shopify_cli/commands.rb
+++ b/lib/shopify_cli/commands.rb
@@ -23,6 +23,7 @@ module ShopifyCLI
     register :Login, "login", "shopify_cli/commands/login", true
     register :Logout, "logout", "shopify_cli/commands/logout", true
     register :Populate, "populate", "shopify_cli/commands/populate", true
+    register :Reporting, "reporting", "shopify_cli/commands/reporting", true
     register :Store, "store", "shopify_cli/commands/store", true
     register :Switch, "switch", "shopify_cli/commands/switch", true
     register :System, "system", "shopify_cli/commands/system", true

--- a/lib/shopify_cli/commands/reporting.rb
+++ b/lib/shopify_cli/commands/reporting.rb
@@ -6,7 +6,13 @@ module ShopifyCLI
       def call(args, _name)
         enable_reporting = reporting_enabled?(args)
         Services::ReportingService.call(enable: enable_reporting)
-        @ctx.puts(@ctx.message("core.reporting.turned_on_off", enable_reporting ? "on" : "off"))
+
+        message = if enable_reporting
+          @ctx.message("core.reporting.turned_on_message")
+        else
+          @ctx.message("core.reporting.turned_off_message", ShopifyCLI::TOOL_NAME)
+        end
+        @ctx.puts(message)
       end
 
       def reporting_enabled?(args)

--- a/lib/shopify_cli/commands/reporting.rb
+++ b/lib/shopify_cli/commands/reporting.rb
@@ -5,8 +5,8 @@ module ShopifyCLI
     class Reporting < ShopifyCLI::Command
       def call(args, _name)
         enable_reporting = reporting_enabled?(args)
-        ReportingConfigurationController.enable_reporting(enable_reporting)
-        @ctx.puts(@ctx.message("core.reporting.turned_on_off", args.first))
+        Services::ReportingService.call(enable: enable_reporting)
+        @ctx.puts(@ctx.message("core.reporting.turned_on_off", enable_reporting ? "on" : "off"))
       end
 
       def reporting_enabled?(args)

--- a/lib/shopify_cli/commands/reporting.rb
+++ b/lib/shopify_cli/commands/reporting.rb
@@ -1,0 +1,32 @@
+require "shopify_cli"
+
+module ShopifyCLI
+  module Commands
+    class Reporting < ShopifyCLI::Command
+      def call(args, _name)
+        enable_reporting = reporting_enabled?(args)
+        ReportingConfigurationController.set_reporting_enabled(enable_reporting)
+        @ctx.puts(@ctx.message("core.reporting.turned_on_off", args.first))
+      end
+
+      def reporting_enabled?(args)
+        case args.first
+        when nil
+          @ctx.abort(@ctx.message("core.reporting.missing_argument", ShopifyCLI::TOOL_NAME))
+        when "on"
+          true
+        when "off"
+          false
+        else
+          @ctx.abort(
+            @ctx.message("core.reporting.invalid_argument", ShopifyCLI::TOOL_NAME, args.first)
+          )
+        end
+      end
+
+      def self.help
+        ShopifyCLI::Context.message("core.reporting.help", ShopifyCLI::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/commands/reporting.rb
+++ b/lib/shopify_cli/commands/reporting.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     class Reporting < ShopifyCLI::Command
       def call(args, _name)
         enable_reporting = reporting_enabled?(args)
-        ReportingConfigurationController.set_reporting_enabled(enable_reporting)
+        ReportingConfigurationController.enable_reporting(enable_reporting)
         @ctx.puts(@ctx.message("core.reporting.turned_on_off", args.first))
       end
 

--- a/lib/shopify_cli/core/monorail.rb
+++ b/lib/shopify_cli/core/monorail.rb
@@ -48,7 +48,7 @@ module ShopifyCLI
 
         def report?(prompt:)
           return true if Environment.send_monorail_events?
-          ReportingConfigurationController.check_or_prompt_report_automatically(prompt: prompt)
+          ReportingConfigurationController.check_or_prompt_report_automatically(source: :usage, prompt: prompt)
         end
 
         def send_event(start_time, commands, args, err = nil)

--- a/lib/shopify_cli/core/monorail.rb
+++ b/lib/shopify_cli/core/monorail.rb
@@ -48,7 +48,7 @@ module ShopifyCLI
 
         def report?(prompt:)
           return true if Environment.send_monorail_events?
-          ReportingConfigurationController.can_report_automatically?(prompt: prompt)
+          ReportingConfigurationController.check_or_prompt_report_automatically(prompt: prompt)
         end
 
         def send_event(start_time, commands, args, err = nil)

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -26,7 +26,7 @@ module ShopifyCLI
       env_variable_truthy?(
         Constants::EnvironmentVariables::STACKTRACE,
         env_variables: env_variables
-      )
+      ) || development?(env_variables: env_variables)
     end
 
     def self.test?(env_variables: ENV)

--- a/lib/shopify_cli/exception_reporter.rb
+++ b/lib/shopify_cli/exception_reporter.rb
@@ -3,13 +3,17 @@ module ShopifyCLI
     def self.report(error, _logs = nil, _api_key = nil, custom_metadata = {})
       context = ShopifyCLI::Context.new
 
-      context.puts("\n")
-      context.puts(context.message("core.error_reporting.unhandled_error.message"))
-      context.puts(context.message("core.error_reporting.unhandled_error.issue_message"))
+      unless ShopifyCLI::Environment.development?
+        context.puts(context.message("core.error_reporting.unhandled_error.message"))
+        context.puts(context.message("core.error_reporting.unhandled_error.issue_message"))
+      end
+
+      # Stack trace hint
       unless ShopifyCLI::Environment.print_stacktrace?
         context.puts(context.message("core.error_reporting.unhandled_error.stacktrace_message",
           "#{ShopifyCLI::Constants::EnvironmentVariables::STACKTRACE}=1"))
       end
+
       context.puts("\n")
 
       return unless reportable_error?(error)
@@ -46,6 +50,8 @@ module ShopifyCLI
     end
 
     def self.report_error?(context:)
+      return false if Environment.development?
+
       CLI::UI::Prompt.ask(context.message("core.error_reporting.report_error.question")) do |handler|
         handler.option(context.message("core.error_reporting.report_error.yes")) { |_| true }
         handler.option(context.message("core.error_reporting.report_error.no")) { |_| false }

--- a/lib/shopify_cli/exception_reporter.rb
+++ b/lib/shopify_cli/exception_reporter.rb
@@ -38,12 +38,12 @@ module ShopifyCLI
 
     def self.report?(context:)
       return true if ReportingConfigurationController.reporting_prompted? &&
-        ReportingConfigurationController.check_or_prompt_report_automatically
+        ReportingConfigurationController.check_or_prompt_report_automatically(source: :uncaught_error)
 
       report_error = report_error?(context: context)
 
       unless ReportingConfigurationController.reporting_prompted?
-        ReportingConfigurationController.check_or_prompt_report_automatically
+        ReportingConfigurationController.check_or_prompt_report_automatically(source: :uncaught_error)
       end
 
       report_error

--- a/lib/shopify_cli/exception_reporter.rb
+++ b/lib/shopify_cli/exception_reporter.rb
@@ -33,13 +33,13 @@ module ShopifyCLI
     end
 
     def self.report?(context:)
-      return true if ReportingConfigurationController.automatic_reporting_prompted? &&
-        ReportingConfigurationController.can_report_automatically?
+      return true if ReportingConfigurationController.reporting_prompted? &&
+        ReportingConfigurationController.check_or_prompt_report_automatically
 
       report_error = report_error?(context: context)
 
-      unless ReportingConfigurationController.automatic_reporting_prompted?
-        ReportingConfigurationController.can_report_automatically?
+      unless ReportingConfigurationController.reporting_prompted?
+        ReportingConfigurationController.check_or_prompt_report_automatically
       end
 
       report_error

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -486,7 +486,21 @@ module ShopifyCLI
 
           MESSAGE
         },
-
+        reporting: {
+          help: <<~HELP,
+            Turns anonymous reporting on or off.
+              Usage: {{command:%s reporting on}}
+          HELP
+          invalid_argument: <<~MESSAGE,
+            {{command:%s reporting %s}} is not supported. The valid values are {{command:on}} or {{command:off}}
+          MESSAGE
+          missing_argument: <<~MESSAGE,
+            {{command:%s reporting}} expects an argument {{command:on}} or {{command:off}}
+          MESSAGE
+          turned_on_off: <<~MESSAGE,
+            Anonymous reporting turned %s
+          MESSAGE
+        },
         whoami: {
           help: <<~HELP,
             Identifies which partner organization or store you are currently logged into.

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -29,9 +29,17 @@ module ShopifyCLI
         },
         analytics: {
           enable_prompt: {
-            question: "Automatically send reports from now on?",
-            yes: "Yes, automatically send anonymized reports to Shopify",
-            no: "No, don't send",
+            uncaught_error: {
+              question: "Automatically send reports from now on?",
+              yes: "Yes, automatically send anonymized reports to Shopify",
+              no: "No, don't send",
+            },
+            usage: {
+              question: "Automatically send anonymized usage and error reports to Shopify? We use these"\
+                " to make development on Shopify better.",
+              yes: "Yes, automatically send anonymized reports to Shopify",
+              no: "No, don't send",
+            },
           },
         },
         connect: {

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -32,7 +32,6 @@ module ShopifyCLI
             question: "Automatically send reports from now on?",
             yes: "Yes, automatically send anonymized reports to Shopify",
             no: "No, don't send",
-            enabled: "Anonymized reports will be sent to Shopify. ",
           },
         },
         connect: {
@@ -497,8 +496,11 @@ module ShopifyCLI
           missing_argument: <<~MESSAGE,
             {{command:%s reporting}} expects an argument {{command:on}} or {{command:off}}
           MESSAGE
-          turned_on_off: <<~MESSAGE,
-            Anonymous reporting turned %s
+          turned_on_message: <<~MESSAGE,
+            Anonymized reports will be sent to Shopify.
+          MESSAGE
+          turned_off_message: <<~MESSAGE,
+            Turn on automatic reporting later wtih {{command:%s reporting on}}.
           MESSAGE
         },
         whoami: {

--- a/lib/shopify_cli/reporting_configuration_controller.rb
+++ b/lib/shopify_cli/reporting_configuration_controller.rb
@@ -1,19 +1,35 @@
 module ShopifyCLI
   module ReportingConfigurationController
-    def self.automatic_reporting_prompted?
+    def self.enable_reporting(enabled)
+      ShopifyCLI::Config.set(
+        Constants::Config::Sections::Analytics::NAME,
+        Constants::Config::Sections::Analytics::Fields::ENABLED,
+        enabled
+      )
+    end
+
+    def self.reporting_prompted?
       ShopifyCLI::Config.get_section(Constants::Config::Sections::Analytics::NAME).key?(
         Constants::Config::Sections::Analytics::Fields::ENABLED
       )
     end
 
-    def self.can_report_automatically?(prompt: true, context: ShopifyCLI::Context.new)
+    def self.reporting_enabled?
+      ShopifyCLI::Config.get_bool(
+        Constants::Config::Sections::Analytics::NAME,
+        Constants::Config::Sections::Analytics::Fields::ENABLED,
+        default: false
+      )
+    end
+
+    def self.check_or_prompt_report_automatically(prompt: true, context: ShopifyCLI::Context.new)
       return false if ShopifyCLI::Environment.development? || ShopifyCLI::Environment.test?
 
       # If the terminal is not interactive we can't prompt the user.
       return false unless ShopifyCLI::Environment.interactive?
 
-      if automatic_reporting_prompted?
-        automatic_reporting_enabled?
+      if reporting_prompted?
+        reporting_enabled?
       elsif prompt
         prompt_user(context: context)
       else
@@ -36,14 +52,6 @@ module ShopifyCLI
       )
 
       enable_automatic_tracking
-    end
-
-    def self.automatic_reporting_enabled?
-      ShopifyCLI::Config.get_bool(
-        Constants::Config::Sections::Analytics::NAME,
-        Constants::Config::Sections::Analytics::Fields::ENABLED,
-        default: false
-      )
     end
   end
 end

--- a/lib/shopify_cli/reporting_configuration_controller.rb
+++ b/lib/shopify_cli/reporting_configuration_controller.rb
@@ -51,6 +51,13 @@ module ShopifyCLI
         enable_automatic_tracking
       )
 
+      message = if enable_automatic_tracking
+        context.message("core.reporting.turned_on_message")
+      else
+        context.message("core.reporting.turned_off_message", ShopifyCLI::TOOL_NAME)
+      end
+      context.puts(message)
+
       enable_automatic_tracking
     end
   end

--- a/lib/shopify_cli/reporting_configuration_controller.rb
+++ b/lib/shopify_cli/reporting_configuration_controller.rb
@@ -22,7 +22,7 @@ module ShopifyCLI
       )
     end
 
-    def self.check_or_prompt_report_automatically(prompt: true, context: ShopifyCLI::Context.new)
+    def self.check_or_prompt_report_automatically(source: :usage, prompt: true, context: ShopifyCLI::Context.new)
       return false if ShopifyCLI::Environment.development? || ShopifyCLI::Environment.test?
 
       # If the terminal is not interactive we can't prompt the user.
@@ -31,18 +31,18 @@ module ShopifyCLI
       if reporting_prompted?
         reporting_enabled?
       elsif prompt
-        prompt_user(context: context)
+        prompt_user(context: context, source: source)
       else
         false
       end
     end
 
-    def self.prompt_user(context:)
+    def self.prompt_user(context:, source:)
       enable_automatic_tracking = CLI::UI::Prompt.ask(
-        context.message("core.analytics.enable_prompt.question")
+        context.message("core.analytics.enable_prompt.#{source}.question")
       ) do |handler|
-        handler.option(context.message("core.analytics.enable_prompt.yes")) { |_| true }
-        handler.option(context.message("core.analytics.enable_prompt.no")) { |_| false }
+        handler.option(context.message("core.analytics.enable_prompt.#{source}.yes")) { |_| true }
+        handler.option(context.message("core.analytics.enable_prompt.#{source}.no")) { |_| false }
       end
 
       ShopifyCLI::Config.set(

--- a/lib/shopify_cli/services.rb
+++ b/lib/shopify_cli/services.rb
@@ -1,0 +1,6 @@
+module ShopifyCLI
+  module Services
+    autoload :BaseService, "shopify_cli/services/base_service"
+    autoload :ReportingService, "shopify_cli/services/reporting_service"
+  end
+end

--- a/lib/shopify_cli/services/base_service.rb
+++ b/lib/shopify_cli/services/base_service.rb
@@ -1,0 +1,13 @@
+module ShopifyCLI
+  module Services
+    class BaseService
+      def self.call(*args, **kwargs, &block)
+        new(*args, **kwargs).call(&block)
+      end
+
+      def call
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/services/reporting_service.rb
+++ b/lib/shopify_cli/services/reporting_service.rb
@@ -1,0 +1,16 @@
+module ShopifyCLI
+  module Services
+    class ReportingService < BaseService
+      attr_reader :enable
+
+      def initialize(enable:)
+        @enable = enable
+        super()
+      end
+
+      def call
+        ReportingConfigurationController.enable_reporting(enable)
+      end
+    end
+  end
+end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -166,7 +166,7 @@ module ShopifyCLI
 
       def enable_reporting(enabled)
         Environment.expects(:send_monorail_events?).returns(enabled)
-        ReportingConfigurationController.stubs(:can_report_automatically?).returns(enabled)
+        ReportingConfigurationController.stubs(:check_or_prompt_report_automatically).returns(enabled)
       end
     end
   end

--- a/test/shopify-cli/reporting_configuration_controller_test.rb
+++ b/test/shopify-cli/reporting_configuration_controller_test.rb
@@ -7,7 +7,21 @@ module ShopifyCLI
       @context = TestHelpers::FakeContext.new
     end
 
-    def test_can_send_returns_false_when_the_environment_is_development
+    def test_enable_reporting_returns_the_right_value
+      # Given
+      ShopifyCLI::Config
+        .expects(:set)
+        .with(
+          Constants::Config::Sections::Analytics::NAME,
+          Constants::Config::Sections::Analytics::Fields::ENABLED,
+          true
+        )
+
+      # When/Then
+      ReportingConfigurationController.enable_reporting(true)
+    end
+
+    def test_check_or_prompt_report_automatically_returns_false_when_the_environment_is_development
       # Given
       ShopifyCLI::Environment.expects(:development?).returns(true)
 
@@ -18,7 +32,7 @@ module ShopifyCLI
       refute got
     end
 
-    def test_can_send_returns_false_when_the_environment_is_test
+    def test_check_or_prompt_report_automatically_returns_false_when_the_environment_is_test
       # Given
       ShopifyCLI::Environment.expects(:development?).returns(false)
       ShopifyCLI::Environment.expects(:test?).returns(true)
@@ -30,7 +44,7 @@ module ShopifyCLI
       refute got
     end
 
-    def test_can_send_returns_false_when_the_environment_is_not_interactive
+    def test_check_or_prompt_report_automatically_returns_false_when_the_environment_is_not_interactive
       # Given
       ShopifyCLI::Environment.expects(:test?).returns(false)
       ShopifyCLI::Environment.expects(:development?).returns(false)
@@ -43,7 +57,7 @@ module ShopifyCLI
       refute got
     end
 
-    def test_can_send_returns_true_when_the_user_was_already_prompted_and_they_enabled_it
+    def test_check_or_prompt_report_automatically_returns_true_when_the_user_was_already_prompted_and_they_enabled_it
       # Given
       ShopifyCLI::Environment.expects(:test?).returns(false)
       ShopifyCLI::Environment.expects(:development?).returns(false)
@@ -68,7 +82,7 @@ module ShopifyCLI
       assert got
     end
 
-    def test_can_send_stores_and_returns_the_value_selected_by_the_user
+    def test_check_or_prompt_report_automatically_stores_and_returns_the_value_selected_by_the_user
       # Given
       ShopifyCLI::Environment.expects(:test?).returns(false)
       ShopifyCLI::Environment.expects(:development?).returns(false)

--- a/test/shopify-cli/reporting_configuration_controller_test.rb
+++ b/test/shopify-cli/reporting_configuration_controller_test.rb
@@ -12,7 +12,7 @@ module ShopifyCLI
       ShopifyCLI::Environment.expects(:development?).returns(true)
 
       # When
-      got = ReportingConfigurationController.can_report_automatically?(context: @context)
+      got = ReportingConfigurationController.check_or_prompt_report_automatically(context: @context)
 
       # Then
       refute got
@@ -24,7 +24,7 @@ module ShopifyCLI
       ShopifyCLI::Environment.expects(:test?).returns(true)
 
       # When
-      got = ReportingConfigurationController.can_report_automatically?(context: @context)
+      got = ReportingConfigurationController.check_or_prompt_report_automatically(context: @context)
 
       # Then
       refute got
@@ -37,7 +37,7 @@ module ShopifyCLI
       ShopifyCLI::Environment.expects(:interactive?).returns(false)
 
       # When
-      got = ReportingConfigurationController.can_report_automatically?(context: @context)
+      got = ReportingConfigurationController.check_or_prompt_report_automatically(context: @context)
 
       # Then
       refute got
@@ -62,7 +62,7 @@ module ShopifyCLI
         .returns(true)
 
       # When
-      got = ReportingConfigurationController.can_report_automatically?(context: @context)
+      got = ReportingConfigurationController.check_or_prompt_report_automatically(context: @context)
 
       # Then
       assert got
@@ -88,7 +88,7 @@ module ShopifyCLI
       CLI::UI::Prompt.expects(:ask).returns(false)
 
       # When
-      got = ReportingConfigurationController.can_report_automatically?(context: @context)
+      got = ReportingConfigurationController.check_or_prompt_report_automatically(context: @context)
 
       # Then
       refute got

--- a/test/shopify-cli/services/reporting_service_test.rb
+++ b/test/shopify-cli/services/reporting_service_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+module ShopifyCLI
+  module Services
+    class ReportingServiceTest < MiniTest::Test
+      def test_it_persists_the_configuration
+        # Given
+        enable = false
+        ReportingConfigurationController.expects(:enable_reporting).with(enable)
+
+        # When/Then
+        ReportingService.call(enable: enable)
+      end
+    end
+  end
+end

--- a/utilities/docker/container.rb
+++ b/utilities/docker/container.rb
@@ -1,0 +1,70 @@
+require "open3"
+
+module Utilities
+  module Docker
+    class Container
+      SHOPIFY_BIN_PATH = "/usr/src/app/bin/shopify"
+
+      Error = Class.new(StandardError)
+
+      attr_reader :id, :env, :cwd, :xdg_config_home, :xdg_cache_home
+
+      def initialize(id:, env:, cwd:)
+        @id = id
+        @cwd = cwd
+        @xdg_config_home = File.join(cwd, ".config")
+        @xdg_cache_home = File.join(cwd, ".cache")
+        @env = env.merge({
+          "XDG_CONFIG_HOME" => @xdg_config_home,
+          "XDG_CACHE_HOME" => @xdg_cache_home,
+        })
+      end
+
+      def remove
+        _, stderr, stat = Open3.capture3(
+          "docker", "rm", "-f", @id
+        )
+        raise Error, stderr unless stat.success?
+      end
+
+      def capture_shopify(*args)
+        capture(*([SHOPIFY_BIN_PATH] + args))
+      end
+
+      def capture(*args)
+        command = ["docker", "exec"]
+        unless @cwd.nil?
+          command += ["-w", @cwd]
+        end
+        @env.each do |env_name, env_value|
+          command += ["--env", "#{env_name}=#{env_value}"]
+        end
+        command << @id
+        command += args
+
+        out, err, stat = Open3.capture3(*command)
+        raise Error, err unless stat.success?
+        out
+      end
+
+      def exec_shopify(*args)
+        exec(*([SHOPIFY_BIN_PATH] + args))
+      end
+
+      def exec(*args)
+        command = ["docker", "exec"]
+        unless @cwd.nil?
+          command += ["-w", @cwd]
+        end
+        @env.each do |env_name, env_value|
+          command += ["--env", "#{env_name}=#{env_value}"]
+        end
+        command << @id
+        command += args
+
+        out, stat = Open3.capture2e(*command)
+        raise Error, out unless stat.success?
+      end
+    end
+  end
+end

--- a/utilities/docker/container.rb
+++ b/utilities/docker/container.rb
@@ -31,11 +31,14 @@ module Utilities
         capture(*([SHOPIFY_BIN_PATH] + args))
       end
 
-      def capture(*args)
+      def capture(*args, relative_dir: nil)
         command = ["docker", "exec"]
-        unless @cwd.nil?
-          command += ["-w", @cwd]
+        cwd = if relative_dir.nil?
+          @cwd
+        else
+          File.join(@cwd, relative_dir)
         end
+        command += ["-w", cwd]
         @env.each do |env_name, env_value|
           command += ["--env", "#{env_name}=#{env_value}"]
         end
@@ -47,15 +50,18 @@ module Utilities
         out
       end
 
-      def exec_shopify(*args)
-        exec(*([SHOPIFY_BIN_PATH] + args))
+      def exec_shopify(*args, relative_dir: nil)
+        exec(*([SHOPIFY_BIN_PATH] + args), relative_dir: relative_dir)
       end
 
-      def exec(*args)
+      def exec(*args, relative_dir: nil)
         command = ["docker", "exec"]
-        unless @cwd.nil?
-          command += ["-w", @cwd]
+        cwd = if relative_dir.nil?
+          @cwd
+        else
+          File.join(@cwd, relative_dir)
         end
+        command += ["-w", cwd]
         @env.each do |env_name, env_value|
           command += ["--env", "#{env_name}=#{env_value}"]
         end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli-planning/issues/56

### WHY are these changes introduced?
As agreed [in this issue](https://github.com/Shopify/shopify-cli-planning/issues/56), we'd like to give users an interface to enable/disable usage reporting. @MeredithCastile suggested introducing a new command, `reporting on/off` for that.

### WHAT is this pull request doing?
- Add `reporting off/on` command.
- Add a unit tests that test the command's business logic in isolation.
- Add an acceptance test that tests the command e2e ensuring the right data is persisted.

### How to test the changes?
1. Delete `~/.config/shopify/config`.
2. Run `bin/shopify reporting on`
3. The content of the file should be `~/.config/shopify/config`:
```
[analytics]
enabled = true
```
4. Fake an error from whoami by adding `raise "error"`
5. Run `bin/shopify whoami`.
6. The CLI shouldn't prompt you on what to do with the error.

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.