### PR TITLE
Add a utility for detecting the app type

### DIFF
--- a/lib/shopify_cli.rb
+++ b/lib/shopify_cli.rb
@@ -96,6 +96,7 @@ module ShopifyCLI
     )
   end
 
+  autoload :AppTypeDetector, "shopify_cli/app_type_detector"
   autoload :Constants, "shopify_cli/constants"
   autoload :Environment, "shopify_cli/environment"
   autoload :AdminAPI, "shopify_cli/admin_api"

--- a/lib/shopify_cli/app_type_detector.rb
+++ b/lib/shopify_cli/app_type_detector.rb
@@ -1,0 +1,28 @@
+require "json"
+
+module ShopifyCLI
+  class AppTypeDetector
+    Error = Class.new(StandardError)
+    TypeNotFoundError = Class.new(Error)
+
+    def self.detect(project_directory:)
+      return :node if node?(project_directory: project_directory)
+      return :rails if rails?(project_directory: project_directory)
+      return :php if php?(project_directory: project_directory)
+      raise TypeNotFoundError, "Couldn't detect the project type in directory: #{project_directory}"
+    end
+
+    def self.node?(project_directory:)
+      package_json_path = File.join(project_directory, "package.json")
+      return false unless File.exist?(package_json_path)
+      package_json = JSON.parse(File.read(package_json_path))
+      !package_json.dig("scripts", "dev").nil?
+    end
+
+    def self.rails?(project_directory:)
+    end
+
+    def self.php?(project_directory:)
+    end
+  end
+end

--- a/lib/shopify_cli/app_type_detector.rb
+++ b/lib/shopify_cli/app_type_detector.rb
@@ -20,9 +20,13 @@ module ShopifyCLI
     end
 
     def self.rails?(project_directory:)
+      rails_binstub_path = File.join(project_directory, "bin/rails")
+      File.exist?(rails_binstub_path)
     end
 
     def self.php?(project_directory:)
+      bootstrap_app_path = File.join(project_directory, "bootstrap/app.php")
+      File.exist?(bootstrap_app_path)
     end
   end
 end

--- a/test/shopify-cli/app_type_detector_test.rb
+++ b/test/shopify-cli/app_type_detector_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "json"
+require "fileutils"
 
 module ShopifyCLI
   class AppTypeDetectorTest < MiniTest::Test
@@ -34,6 +35,28 @@ module ShopifyCLI
 
       # When/Then
       assert_equal :node, AppTypeDetector.detect(project_directory: project_directory)
+    end
+
+    def test_when_type_is_rails
+      # Given
+      project_directory = @tmp_dir
+      rails_binstub_path = File.join(project_directory, "bin/rails")
+      FileUtils.mkdir_p(File.dirname(rails_binstub_path))
+      FileUtils.touch(rails_binstub_path)
+
+      # When/Then
+      assert_equal :rails, AppTypeDetector.detect(project_directory: project_directory)
+    end
+
+    def test_when_type_is_php
+      # Given
+      project_directory = @tmp_dir
+      bootstrap_app_path = File.join(project_directory, "bootstrap/app.php")
+      FileUtils.mkdir_p(File.dirname(bootstrap_app_path))
+      FileUtils.touch(bootstrap_app_path)
+
+      # When/Then
+      assert_equal :php, AppTypeDetector.detect(project_directory: project_directory)
     end
   end
 end

--- a/test/shopify-cli/app_type_detector_test.rb
+++ b/test/shopify-cli/app_type_detector_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "json"
+
+module ShopifyCLI
+  class AppTypeDetectorTest < MiniTest::Test
+    include TestHelpers::TemporaryDirectory
+
+    def test_when_type_cannot_be_detected
+      # Given
+      project_directory = @tmp_dir
+
+      # When
+      error = assert_raises(AppTypeDetector::TypeNotFoundError) do
+        AppTypeDetector.detect(project_directory: project_directory)
+      end
+
+      # Then
+      assert_equal(
+        "Couldn't detect the project type in directory: #{project_directory}",
+        error.message
+      )
+    end
+
+    def test_when_type_is_node
+      # Given
+      project_directory = @tmp_dir
+      package_json_path = File.join(project_directory, "package.json")
+      package_json = {
+        "scripts" => {
+          "dev" => "nodemon ./server/index.js",
+        },
+      }
+      File.write(package_json_path, package_json.to_json)
+
+      # When/Then
+      assert_equal :node, AppTypeDetector.detect(project_directory: project_directory)
+    end
+  end
+end


### PR DESCRIPTION
Related https://github.com/Shopify/shopify-cli-planning/issues/59

### WHY are these changes introduced?
As part of the effort of having all the app-related commands under `shopify app`, we are removing the need for passing the app type because that's information that we can infer from the directory as [described here](https://github.com/Shopify/shopify-cli-planning/issues/59#issuecomment-938536803) 

### WHAT is this pull request doing?
This PR adds a new utility, `ShopifyCLI::AppDetector` that follows [this logic](https://github.com/Shopify/shopify-cli-planning/issues/59#issuecomment-938536803) to return `:rails`, `:node`, `:php` or raise an error if the app type can't be detected.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.