### PR TITLE
Pin the exact theme-check version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     shopify-cli (2.6.3)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
-      theme-check (~> 1.7)
+      theme-check (~> 1.7.2)
 
 GEM
   remote: https://rubygems.org/
@@ -151,4 +151,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.22
+   2.2.29

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -45,12 +45,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("bugsnag", "~> 6.22")
   spec.add_dependency("listen", "~> 3.7.0")
-
-  # Note: theme-check is _intentionally_ not specifying the third
-  # digit. We _want_ new features to make their way into new installs
-  # of the Shopify CLI. Otherwise updates need to be released twice.
-  #
-  # That is, DO USE ~> 1.X, DO NOT USE ~> 1.X.Y, this would unnecessarily
-  # fix the feature version.
-  spec.add_dependency("theme-check", "~> 1.7")
+  spec.add_dependency("theme-check", "~> 1.7.2")
 end


### PR DESCRIPTION
### WHY are these changes introduced?
I was looking at the `.gemspec` and I realized that we are explicitly avoiding pinning a version of `theme-check`. This is not ideal because two users installing the CLI might get different versions of `theme-check` and thus non-deterministic results that might confuse them and make our debugging experience more cumbersome. 

### WHAT is this pull request doing?
With the goal of ensuring a **deterministic** experience for users, and **easing the debugging of bugs** on our side, I'm binding the version of the CLI to a version of theme-check. I'm aware this means theme-check updates need to adhere to the [CLI](https://development-lifecycle.docs.shopify.io/releasing) schedule, which should be frequent enough (bi-weekly) for users to get improvements. If there's a serious bug on theme-check that requires an off-schedule release, we can also do it.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.