### PR TITLE
Rename command references from extension-point to api

### DIFF
--- a/features/step_definitions/commands/script.rb
+++ b/features/step_definitions/commands/script.rb
@@ -4,7 +4,7 @@ When(/I create a (.+) script named (.+)/) do |extension_point, script_name|
   @container.exec_shopify(
     "script", "create",
     "--name", script_name,
-    "--extension-point=#{extension_point}"
+    "--api=#{extension_point}"
   )
 end
 

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -9,8 +9,7 @@ module Script
 
       options do |parser, flags|
         parser.on("--name=NAME") { |name| flags[:name] = name }
-        parser.on("--extension_point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
-        parser.on("--extension-point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
+        parser.on("--api=API_NAME") { |ep_name| flags[:extension_point] = ep_name }
         parser.on("--language=LANGUAGE") { |language| flags[:language] = language }
         parser.on("--branch=BRANCH") { |branch| flags[:branch] = branch }
         parser.on("--no-config-ui") { |no_config_ui| flags[:no_config_ui] = no_config_ui }

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -162,7 +162,7 @@ module Script
               Usage: {{command:%1$s script create}}
               Options:
                 {{command:--name=NAME}} Script project name. Use any string.
-                {{command:--extension-point=TYPE}} Script API name. Allowed values: %2$s.
+                {{command:--api=TYPE}} Script API name. Allowed values: %2$s.
                 {{command:--no-config-ui}} Specify this option when you don’t want your script to render an interface in Shopify admin.
           HELP
 

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -92,7 +92,7 @@ module Script
       def perform_command
         run_cmd(
           "script create --name=#{@script_name}
-          --extension-point=#{@ep_type} --language=#{@language}
+          --api=#{@ep_type} --language=#{@language}
           --branch=#{@branch}
           #{@no_config_ui ? "--no-config-ui" : ""}"
         )


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3631

### WHAT is this pull request doing?

Renames command options that referred to `--extension-point` to instead be `--api`

### How to test your changes?

- Run `./bin/shopify script create --help` and observe the new text.
- Run `./bin/shopify script create --extension-point=payment_methods` and observe failure.
- Run `./bin/shopify script create --api=payment_methods` and observe success.
### Post-release steps

- [ ] Documentation updated

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.