### PR TITLE
Remove Script create's `--no-config-ui`

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -13,7 +13,6 @@ module Script
         parser.on("--extension-point=EP_NAME") { |ep_name| flags[:extension_point] = ep_name }
         parser.on("--language=LANGUAGE") { |language| flags[:language] = language }
         parser.on("--branch=BRANCH") { |branch| flags[:branch] = branch }
-        parser.on("--no-config-ui") { |no_config_ui| flags[:no_config_ui] = no_config_ui }
       end
 
       def call(args, _name)
@@ -30,7 +29,6 @@ module Script
           sparse_checkout_branch: options.flags[:branch] || "master",
           script_name: form.name,
           extension_point_type: form.extension_point,
-          no_config_ui: options.flags.key?(:no_config_ui)
         )
         @ctx.puts(@ctx.message("script.create.change_directory_notice", project.script_name))
       rescue StandardError => e

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -7,7 +7,7 @@ module Script
     module Application
       class CreateScript
         class << self
-          def call(ctx:, language:, sparse_checkout_branch:, script_name:, extension_point_type:, no_config_ui:)
+          def call(ctx:, language:, sparse_checkout_branch:, script_name:, extension_point_type:)
             raise Infrastructure::Errors::ScriptProjectAlreadyExistsError, script_name if ctx.dir_exist?(script_name)
 
             in_new_directory_context(ctx, script_name) do
@@ -36,7 +36,7 @@ module Script
               )
 
               install_dependencies(ctx, language, script_name, project_creator)
-              script_project_repo.update_or_create_script_json(title: script_name, configuration_ui: !no_config_ui)
+              script_project_repo.update_or_create_script_json(title: script_name)
               project
             end
           end

--- a/lib/project_types/script/layers/domain/script_json.rb
+++ b/lib/project_types/script/layers/domain/script_json.rb
@@ -15,7 +15,7 @@ module Script
           @version = @content["version"].to_s
           @title = @content["title"]
           @description = @content["description"]
-          @configuration_ui = @content["configurationUi"]
+          @configuration_ui = @content.fetch("configurationUi", true)
           @configuration = @content["configuration"]
         end
 

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -81,10 +81,10 @@ module Script
           )
         end
 
-        def update_or_create_script_json(title:, configuration_ui: false)
+        def update_or_create_script_json(title:)
           script_json = ScriptJsonRepository
             .new(ctx: ctx)
-            .update_or_create(title: title, configuration_ui: configuration_ui)
+            .update_or_create(title: title)
 
           Domain::ScriptProject.new(
             id: ctx.root,
@@ -148,11 +148,10 @@ module Script
             current_script_json || raise(Domain::Errors::NoScriptJsonFile)
           end
 
-          def update_or_create(title:, configuration_ui:)
+          def update_or_create(title:)
             json = current_script_json&.content || {}
             json["version"] ||= "1"
             json["title"] = title
-            json["configurationUi"] = !!configuration_ui
 
             ctx.write(SCRIPT_JSON_FILENAME, JSON.pretty_generate(json))
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -163,7 +163,6 @@ module Script
               Options:
                 {{command:--name=NAME}} Script project name. Use any string.
                 {{command:--extension-point=TYPE}} Script API name. Allowed values: %2$s.
-                {{command:--no-config-ui}} Specify this option when you don’t want your script to render an interface in Shopify admin.
           HELP
 
           error: {

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -16,7 +16,6 @@ module Script
         @language = "assemblyscript"
         @script_name = "name"
         @ep_type = "discount"
-        @no_config_ui = false
         @script_project = TestHelpers::FakeScriptProjectRepository.new.create(
           language: @language,
           extension_point_type: @ep_type,
@@ -42,25 +41,6 @@ module Script
           sparse_checkout_branch: @branch,
           script_name: @script_name,
           extension_point_type: @ep_type,
-          no_config_ui: @no_config_ui
-        ).returns(@script_project)
-
-        @context
-          .expects(:puts)
-          .with(@context.message("script.create.change_directory_notice", @script_project.script_name))
-        perform_command
-      end
-
-      def test_can_create_new_script_with_no_config_ui
-        @no_config_ui = true
-
-        Script::Layers::Application::CreateScript.expects(:call).with(
-          ctx: @context,
-          language: @language,
-          sparse_checkout_branch: @branch,
-          script_name: @script_name,
-          extension_point_type: @ep_type,
-          no_config_ui: @no_config_ui
         ).returns(@script_project)
 
         @context
@@ -93,8 +73,7 @@ module Script
         run_cmd(
           "script create --name=#{@script_name}
           --extension-point=#{@ep_type} --language=#{@language}
-          --branch=#{@branch}
-          #{@no_config_ui ? "--no-config-ui" : ""}"
+          --branch=#{@branch}"
         )
       end
     end

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -7,7 +7,6 @@ describe Script::Layers::Application::CreateScript do
 
   let(:script_name) { "path" }
   let(:compiled_type) { "wasm" }
-  let(:no_config_ui) { false }
   let(:script_json_filename) { "script.json" }
 
   let(:extension_point_repository) { TestHelpers::FakeExtensionPointRepository.new }
@@ -73,7 +72,6 @@ describe Script::Layers::Application::CreateScript do
         sparse_checkout_branch: sparse_checkout_branch,
         script_name: script_name,
         extension_point_type: extension_point_type,
-        no_config_ui: no_config_ui
       )
     end
 
@@ -133,7 +131,6 @@ describe Script::Layers::Application::CreateScript do
         script_json = script_project_repository.get.script_json
         assert_equal script_name, script_json.title
         assert_equal "1", script_json.version
-        assert script_json.configuration_ui
       end
     end
 

--- a/test/project_types/script/layers/domain/script_json_test.rb
+++ b/test/project_types/script/layers/domain/script_json_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Domain::ScriptJson do
+  let(:content) do
+    {
+      "version" => "1",
+      "title" => "Some Title",
+      "description" => "Some Description",
+      "configurationUi" => true,
+      "configuration" => {},
+    }
+  end
+
+  subject { Script::Layers::Domain::ScriptJson.new(content: content) }
+
+  describe "#initialize" do
+    it "constructs a ScriptJson" do
+      assert_equal("1", subject.version)
+      assert_equal("Some Title", subject.title)
+      assert_equal("Some Description", subject.description)
+      assert(subject.configuration_ui)
+      assert_equal({}, subject.configuration)
+    end
+  end
+
+  describe "#configuration_ui" do
+    describe "when configurationUi key is not provided" do
+      let(:content) { { "version" => "1", "title" => "Title" } }
+
+      it("is true") { assert(subject.configuration_ui) }
+    end
+
+    describe "when configurationUi is false" do
+      let(:content) { { "version" => "1", "title" => "Title", "configurationUi" => false } }
+
+      it("is false") { refute(subject.configuration_ui) }
+    end
+  end
+end

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -85,7 +85,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       {
         "version" => "1",
         "title" => script_name,
-        "configurationUi" => true,
         "configuration" => {
           "type": "single",
           "schema": [
@@ -148,7 +147,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         assert_equal language, subject.language
         assert_equal script_json_content["version"], subject.script_json.version
         assert_equal script_json_content["version"], subject.script_json.version
-        assert_equal script_json_content["configurationUi"], subject.script_json.configuration_ui
         assert_equal script_json_content["configuration"].to_json, subject.script_json.configuration.to_json
       end
     end
@@ -311,7 +309,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       ShopifyCLI::Project.stubs(:current).returns(current_project)
     end
 
-    subject { instance.update_or_create_script_json(title: new_title, configuration_ui: new_configuration_ui) }
+    subject { instance.update_or_create_script_json(title: new_title) }
 
     describe "script.json does not exist" do
       it "creates a new file with the provided fields" do
@@ -321,7 +319,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         file_content = JSON.parse(ctx.read(script_json_filename))
 
         assert script_json.configuration_ui
-        assert file_content["configurationUi"]
         assert_equal new_title, script_json.title
         assert_equal new_title, file_content["title"]
         assert_equal "1", file_content["version"]
@@ -342,7 +339,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           "version" => "1",
           "title" => initial_title,
           "description" => initial_description,
-          "configurationUi" => false,
           "configuration" => {
             "type": "single",
             "schema": [
@@ -366,8 +362,6 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         script_json = subject.script_json
         file_content = JSON.parse(ctx.read(script_json_filename))
 
-        assert script_json.configuration_ui
-        assert file_content["configurationUi"]
         assert_equal new_title, script_json.title
         assert_equal new_title, file_content["title"]
         refute_equal initial_title, script_json.title

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -38,7 +38,6 @@ describe Script::Layers::Infrastructure::ScriptService do
       "version" => expected_script_json_version,
       "title" => script_name,
       "description" => expected_description,
-      "configurationUi" => expected_configuration_ui,
       "configuration" => expected_configuration,
     }
   end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -36,9 +36,9 @@ module TestHelpers
       @project
     end
 
-    def update_or_create_script_json(title:, configuration_ui: false)
+    def update_or_create_script_json(title:)
       script_json = fake_script_json_repo
-        .update_or_create(title: title, configuration_ui: configuration_ui)
+        .update_or_create(title: title)
 
       @project.script_json = script_json
       @project
@@ -61,10 +61,9 @@ module TestHelpers
         )
       end
 
-      def update_or_create(title:, configuration_ui:)
+      def update_or_create(title:)
         json = @cache&.content || {}
         json["title"] = title
-        json["configurationUi"] = !!configuration_ui
 
         @cache = Script::Layers::Domain::ScriptJson.new(
           content: json,


### PR DESCRIPTION
### WHY are these changes introduced?

Remove Script create's `--no-config-ui`

As per Shopify/script-service#3698, this should no longer be an
option: we want the UI to always be visible.

### WHAT is this pull request doing?

This commit does 2 things:
1. Remove the  `--no-config-ui` from the script create command
2. Make `configurationUi` flag default to true unless it's been
   explicitly set to false.

I also removed the `configurationUi` flag from our example scripts
in tests because it'll be the default moving forward.

Follow-up work: remove the `configurationUi` entry from our example scripts repo.

### How to test your changes?

- When creating a new script, the `--no-config-ui` no longer exists
- Edit a `script.json` and remove its `configurationUi` entry, push the script. The script should still have a `configurationUi` in script-service.

----


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
    **This change is public facing, but only for beta. Is a changelog entry relevant? My 2¢: it's not worth the added noise**. 
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- n/a ~I've included any post-release steps in the section above.~