### PR TITLE
Cleanup unreferenced messages

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -212,10 +212,6 @@ module Script
           built: "Built",
           pushing: "Pushing",
           pushed: "Pushed",
-          disabling: "Disabling",
-          disabled: "Disabled",
-          enabling: "Enabling",
-          enabled: "Enabled",
           ensure_env: {
             organization: "Partner organization {{green:%s (%s)}}.",
             organization_select: "Which partner organization do you want to use?",


### PR DESCRIPTION
Script enabling/disabling has been removed, but some messages were
left behind. This commit fixes that.

Fixes Shopify/script-service#3836