### PR TITLE
Handle `npm list` non-zero exit status

### DIFF
--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -51,12 +51,12 @@ module Script
             output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
-            library_version_from_npm_list_error(error, library_name)
+            library_version_from_npm_list_error_output(error, library_name)
           end
 
           private
 
-          def library_version_from_npm_list_error(error, library_name)
+          def library_version_from_npm_list_error_output(error, library_name)
             # npm list can return a failure status code, even when returning the correct data.
             # This causes the CommandRunner to throw a SystemCallFailure error that contains the data.
             # In here, we check that the output contains `npm list`'s structure and extract the version.

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -49,11 +49,30 @@ module Script
 
           def library_version(library_name)
             output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm list --json"))
-            raise Errors::APILibraryNotFoundError.new(library_name), output unless output["dependencies"][library_name]
-            output["dependencies"][library_name]["version"]
+            library_version_from_npm_list(output, library_name)
+          rescue Errors::SystemCallFailureError => error
+            library_version_from_npm_list_error(error, library_name)
           end
 
           private
+
+          def library_version_from_npm_list_error(error, library_name)
+            # npm list can return a failure status code, even when returning the correct data.
+            # This causes the CommandRunner to throw a SystemCallFailure error that contains the data.
+            # In here, we check that the output contains `npm list`'s structure and extract the version.
+            output = JSON.parse(error.out)
+            raise error unless output.key?("dependencies")
+
+            library_version_from_npm_list(output, library_name)
+          rescue JSON::ParserError
+            raise error
+          end
+
+          def library_version_from_npm_list(output, library_name)
+            output.dig("dependencies", library_name, "version").tap do |version|
+              raise Errors::APILibraryNotFoundError, library_name unless version
+            end
+          end
 
           def check_node_version!
             output, status = @ctx.capture2e("node", "--version")

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -158,6 +158,23 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
           subject
         end
       end
+
+      it "should rescue SystemCallFailureError if the library version is present" do
+        cmd = "npm list --json"
+        command_runner.any_instance.stubs(:call)
+          .with(cmd)
+          .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(
+            out: {
+              "dependencies" => {
+                extension_point_config["assemblyscript"][:package] => {
+                  "version" => "1.3.7",
+                },
+              },
+            }.to_json,
+            cmd: cmd
+          ))
+        assert_equal "1.3.7", subject
+      end
     end
   end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3852

### WHAT is this pull request doing?

It appears that sometimes, `npm list --json` returns a non-zero status code, even though the parts of the command that we care about are returned. This PR makes it so that we handle this case.

### How to test your changes?

https://github.com/Shopify/shopify-cli/blob/9e51e44dfcb9dbc4c43b0cb6a060974e70533569/lib/project_types/script/layers/infrastructure/command_runner.rb#L13-L13
You can reproduce this error by editing the above command runner line to either:
- change nothing: works as expected
- comment out the `unless success` end of line: effectively reproduces the issue in https://github.com/Shopify/script-service/issues/3852
- change `out: out.chomp` to any other value: this should catch other errors where the values we seek were not actually returned. I need to double check this case.

### Post-release steps

N/A?

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.