### PR TITLE
[new extensions only] add template flag to extension create

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -11,6 +11,7 @@ module Extension
 
       options do |parser, flags|
         parser.on("--name=NAME") { |name| flags[:name] = name }
+        parser.on("--template=TEMPLATE") { |template| flags[:template] = template }
         parser.on("--type=TYPE") { |type| flags[:type] = type.upcase }
         parser.on("--api-key=KEY") { |key| flags[:api_key] = key.downcase }
         parser.on("--getting-started") { flags[:getting_started] = true }

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -24,7 +24,7 @@ module Extension
         ShopifyCLI::Result.wrap(ExtensionProjectDetails.new)
           .then(&Questions::AskApp.new(ctx: ctx, api_key: api_key))
           .then(&Questions::AskType.new(ctx: ctx, type: type))
-          .then(&Questions::AskTemplate.new(ctx: ctx))
+          .then(&Questions::AskTemplate.new(ctx: ctx, template: template))
           .then(&Questions::AskName.new(ctx: ctx, name: name))
           .unwrap { |e| raise e }
           .tap do |project_details|

--- a/lib/project_types/extension/forms/questions/ask_template.rb
+++ b/lib/project_types/extension/forms/questions/ask_template.rb
@@ -9,13 +9,14 @@ module Extension
         ]
 
         property! :ctx
+        property :template, accepts: Models::ServerConfig::Development::VALID_TEMPLATES
         property :prompt,
           accepts: ->(prompt) { prompt.respond_to?(:call) },
           default: -> { CLI::UI::Prompt.method(:ask) }
 
         def call(project_details)
           return project_details unless template_required?(project_details)
-          project_details.template = choose_interactively
+          project_details.template = template || choose_interactively
           project_details
         end
 

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -75,7 +75,7 @@ module Extension
           project_details
         end)
 
-        Questions::AskTemplate.expects(:new).with(ctx: @context).returns(->(project_details) do
+        Questions::AskTemplate.expects(:new).with(ctx: @context, template: nil).returns(->(project_details) do
           project_details.template = "javascript"
           project_details
         end)

--- a/test/project_types/extension/forms/questions/ask_template_test.rb
+++ b/test/project_types/extension/forms/questions/ask_template_test.rb
@@ -12,8 +12,7 @@ module Extension
         end
 
         def test_does_not_prompt_for_template_when_not_required
-          ShopifyCLI::Shopifolk.stubs(:check).returns(false)
-          ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(false)
+          mock_environment_settings(shopifolk: false, extension_server_beta: false)
           project_details = OpenStruct.new(
             type: OpenStruct.new(
               identifier: "THEME_APP_EXTENSION",
@@ -26,8 +25,7 @@ module Extension
         end
 
         def test_prompts_for_template_when_required
-          ShopifyCLI::Shopifolk.stubs(:check).returns(true)
-          ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(true)
+          mock_environment_settings
           project_details = OpenStruct.new(
             type: OpenStruct.new(
               identifier: "CHECKOUT_UI_EXTENSION",
@@ -45,10 +43,28 @@ module Extension
           assert_nothing_raised { AskTemplate.new(ctx: FakeContext.new) }
         end
 
+        def test_user_provided_template_is_chosen_over_interactive_option
+          mock_environment_settings
+          project_details = OpenStruct.new(
+            type: OpenStruct.new(
+              identifier: "CHECKOUT_UI_EXTENSION",
+            )
+          )
+
+          AskTemplate.new(ctx: context, template: "typescript").call(project_details).tap do
+            assert_equal("typescript", project_details.template)
+          end
+        end
+
         private
 
         def context
           FakeContext.new
+        end
+
+        def mock_environment_settings(shopifolk: true, extension_server_beta: true)
+          ShopifyCLI::Shopifolk.stubs(:check).returns(shopifolk)
+          ShopifyCLI::Feature.stubs(:enabled?).with(:extension_server_beta).returns(extension_server_beta)
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/shopify-cli-extensions/issues/86

### WHAT is this pull request doing?

Adding support for `--template` flag for new extensions using the new go executable. The go executable needs to know which template to use when creating a new extension. 

Currently we show a list to the end-user to select an option, but we would like to support passing in a `--template` flag as well.

### How to test your changes?

1. Enable extension server beta: `shopify config feature extension_server_beta --enable`
2. `dev clone shopify-cli-extensions`
3. Run `make build` to generate a build
4. Copy the generated binary into the correct folder in your local shopify-cli repo: `shopify-cli/ext/shopify-extensions`
5. In a separate terminal / directory, now run `shopify create extension --type=CHECKOUT_UI_EXTENSION --template=javascript`
 * other templates supported: javascript-react, typescript, typescript-react

New flow with flag:

![tophat-template](https://user-images.githubusercontent.com/989784/138159581-492b65b9-478e-4108-8ac0-94172bac5b95.gif)

New flow without flag (notice user still gets prompted):

![test-no-template](https://user-images.githubusercontent.com/989784/138159618-58e77d7f-7ac5-4f03-a047-f166e2683c98.gif)

Old flow remains the same, note it does not support flag:

<img width="1277" alt="Screen Shot 2021-10-20 at 2 22 42 PM" src="https://user-images.githubusercontent.com/989784/138159701-147d7d3c-d642-415b-9bd7-c1131f84e5d6.png">

**Backwards compatibility:** I believe a change would need to be made on the template generator side in order to support the new flag with the old flow, but I do not know if this is worth it given we're switching to the new flow.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing) -- not public facing yet
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.