### PR TITLE
"theme serve --http-bind" follow-up work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## Version 2.6.6
 ### Added
-* [#1609](https://github.com/Shopify/shopify-cli/pull/1609): Add `--bind=HOST` option to `shopify theme serve`.
+* [#1609](https://github.com/Shopify/shopify-cli/pull/1609): Add `--http-bind=HOST` option to `shopify theme serve`.
 
 ### Fixed
 * [#1678](https://github.com/Shopify/shopify-cli/pull/1678): Fix migrator's incompatibility with Ruby 2.5.

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -4,17 +4,23 @@ require "shopify_cli/theme/dev_server"
 module Theme
   class Command
     class Serve < ShopifyCLI::Command::SubCommand
+      DEFAULT_HTTP_HOST = "127.0.0.1"
+
       options do |parser, flags|
-        parser.on("--bind=HOST") { |bind| flags[:bind] = bind.to_s }
+        parser.on("--host=HOST") { |host| flags[:host] = host.to_s }
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
       end
 
       def call(*)
         flags = options.flags.dup
-        ShopifyCLI::Theme::DevServer.start(@ctx, ".", **flags) do |syncer|
+        host = flags[:host] || DEFAULT_HTTP_HOST
+        ShopifyCLI::Theme::DevServer.start(@ctx, ".", http_bind: host, **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
+      rescue ShopifyCLI::Theme::DevServer::AddressBindingError
+        raise ShopifyCLI::Abort,
+          ShopifyCLI::Context.message("theme.serve.error.address_binding_error", ShopifyCLI::TOOL_NAME)
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -94,7 +94,7 @@ module Theme
             Options:
               {{command:--port=PORT}} Local port to serve theme preview from
               {{command:--poll}}      Force polling to detect file changes
-              {{command:--http-bind=HOST}} Set which network interface the web server listens on
+              {{command:--http-bind=HOST}} Set which network interface the web server listens on. The default value is 127.0.0.1.
           HELP
           serve: "Viewing theme…",
           open_fail: "Couldn't open the theme",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -94,12 +94,13 @@ module Theme
             Options:
               {{command:--port=PORT}} Local port to serve theme preview from
               {{command:--poll}}      Force polling to detect file changes
-              {{command:--http-bind=HOST}} Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--host=HOST}} Set which network interface the web server listens on. The default value is 127.0.0.1.
           HELP
           serve: "Viewing theme…",
           open_fail: "Couldn't open the theme",
           error: {
-            address_binding_error: "Couldn't bind to localhost. To serve your theme, set a different address with {{command:%s theme serve --http-bind=<address>}}",
+            address_binding_error: "Couldn't bind to localhost."\
+              " To serve your theme, set a different address with {{command:%s theme serve --host=<address>}}",
           },
         },
         check: {

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -94,10 +94,13 @@ module Theme
             Options:
               {{command:--port=PORT}} Local port to serve theme preview from
               {{command:--poll}}      Force polling to detect file changes
-              {{command:--bind=HOST}} Set which network interface the web server listens on
+              {{command:--http-bind=HOST}} Set which network interface the web server listens on
           HELP
           serve: "Viewing theme…",
           open_fail: "Couldn't open the theme",
+          error: {
+            address_binding_error: "Couldn't bind to localhost. To serve your theme, set a different address with {{command:%s theme serve --http-bind=<address>}}",
+          },
         },
         check: {
           help: <<~HELP,

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -23,7 +23,7 @@ module Theme
           .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND)
           .raises(ShopifyCLI::Theme::DevServer::AddressBindingError)
 
-        assert_raises ShopifyCLI::Abort,  do
+        assert_raises ShopifyCLI::Abort do
           Theme::Command::Serve.new(context).call
         end
       end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -9,23 +9,37 @@ module Theme
 
       def test_serve_command
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", optionally({}))
+        ShopifyCLI::Theme::DevServer
+          .expects(:start)
+          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND)
 
         Theme::Command::Serve.new(context).call
       end
 
+      def test_serve_command_raises_abort_when_cant_bind_address
+        context = ShopifyCLI::Context.new
+        ShopifyCLI::Theme::DevServer
+          .expects(:start)
+          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND)
+          .raises(ShopifyCLI::Theme::DevServer::AddressBindingError)
+
+        assert_raises ShopifyCLI::Abort,  do
+          Theme::Command::Serve.new(context).call
+        end
+      end
+
       def test_can_specify_bind_address
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", bind: "0.0.0.0")
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: "0.0.0.0")
 
         command = Theme::Command::Serve.new(context)
-        command.options.flags[:bind] = "0.0.0.0"
+        command.options.flags[:http_bind] = "0.0.0.0"
         command.call
       end
 
       def test_can_specify_port
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", port: 9293)
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND, port: 9293)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:port] = 9293
@@ -34,7 +48,7 @@ module Theme
 
       def test_can_specify_poll
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", poll: true)
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND, poll: true)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:poll] = true

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -11,7 +11,7 @@ module Theme
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND)
+          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST)
 
         Theme::Command::Serve.new(context).call
       end
@@ -20,7 +20,7 @@ module Theme
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND)
+          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST)
           .raises(ShopifyCLI::Theme::DevServer::AddressBindingError)
 
         assert_raises ShopifyCLI::Abort do
@@ -39,7 +39,8 @@ module Theme
 
       def test_can_specify_port
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND, port: 9293)
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
+          http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST, port: 9293)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:port] = 9293
@@ -48,7 +49,8 @@ module Theme
 
       def test_can_specify_poll
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_BIND, poll: true)
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
+          http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:poll] = true


### PR DESCRIPTION
Related: https://github.com/Shopify/shopify-cli/pull/1609

### WHY are these changes introduced?
I'm doing some follow-up work after @tyler-eon's [contribution ](https://github.com/Shopify/shopify-cli/pull/1609).

### WHAT is this pull request doing?
- Rename the argument from `--bind` to `--http-bind`.
- Added some logic to detect the error and suggest the user to use the `--http-bind` option.

### How to test your changes?
Testing this is a bit tricky because it requires having a network interface that doesn't support binding to 127.0.0.1. For example, a Docker environment that contains a theme project with the CLI in it.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.