### PR TITLE
Added ruby os platform metadata to bugsnag reporting

### DIFF
--- a/lib/shopify_cli/exception_reporter.rb
+++ b/lib/shopify_cli/exception_reporter.rb
@@ -31,10 +31,10 @@ module ShopifyCLI
         config.auto_capture_sessions = false
       end
 
-      metadata = {rubyPlatform: RUBY_PLATFORM}
+      metadata = { rubyPlatform: RUBY_PLATFORM }
       metadata.merge!(custom_metadata)
 
-      Bugsnag.notify(error) do |event|      
+      Bugsnag.notify(error) do |event|
         event.add_metadata(:device, metadata)
       end
     end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Adds ruby platform metadata to bugsnag report to understand on which OS errors occur.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Bugsnag before:
<img width="514" alt="Screen Shot 2021-10-21 at 12 22 44 PM" src="https://user-images.githubusercontent.com/55213953/138318537-d37a49a5-0299-4de7-a735-f4b8ed158f02.png">


Bugsnag after:
<img width="677" alt="Screen Shot 2021-10-21 at 12 23 22 PM" src="https://user-images.githubusercontent.com/55213953/138318587-ebdeea23-8a66-4b54-8af7-d55cfe988273.png">
Note: ruby_platform has since been renamed to rubyPlatform.

### How to test your changes?
1. run a command to raise an error (e.g. shopify node serve --ge)
2. find and open the error on bugsnag
3. open the 'devices' tab for the specific error and verify that the rubyPlatform field is there with the correct environment OS.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.