### PR TITLE
Fix/extension connect product subs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
+### Fixed
+* [#1672](https://github.com/Shopify/shopify-cli/pull/1672): Fix `shopify extension connect` command for `PRODUCT_SUBSCRIPTION` extensions
 
 ## Version 2.6.4
 ### Fixed

--- a/lib/project_types/extension/commands/connect.rb
+++ b/lib/project_types/extension/commands/connect.rb
@@ -25,7 +25,7 @@ module Extension
       private
 
       def with_connect_form(args)
-        form = Forms::Connect.ask(@ctx, args, { type: specification_handler.identifier.downcase })
+        form = Forms::Connect.ask(@ctx, args, { type: specification_handler.graphql_identifier })
         return @ctx.puts(self.class.help) if form.nil?
 
         yield form

--- a/lib/project_types/extension/models/specification_handlers/product_subscription.rb
+++ b/lib/project_types/extension/models/specification_handlers/product_subscription.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module SpecificationHandlers
+      class ProductSubscription < Default
+        def graphql_identifier
+          "SUBSCRIPTION_MANAGEMENT"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/ui-extensions-private/issues/1652

### WHAT is this pull request doing?

`shopify extension connect` was not working for `PRODUCT_SUBSCRIPTION` extensions, as our API was expecting us to use the `graphql_identifier` instead of the `specification_identifier`.

This PR changes the behaviour so we can pass the correct identifier our API expects.

### How to test your changes?

1. Start in the `main` branch of `shopify-cli`
2. `cd` into a `PRODUCT_SUBSCRIPTION` extension
3. Remove the `.env` file 
4. Run `shopify extension connect`
5. See the command will fail
6. `git checkout -b fix/extension-connect-product-subs` to change into this branch
7. Run `shopify extension connect` again
8. Notice command will now succeed

### Post-release steps

None

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.