### PR TITLE
Add javy command

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -13,6 +13,7 @@ module Script
     hidden_feature(feature_set: :script_project)
     subcommand :Create, "create", Project.project_filepath("commands/create")
     subcommand :Push, "push", Project.project_filepath("commands/push")
+    subcommand :Javy, "javy", Project.project_filepath("commands/javy")
   end
   ShopifyCLI::Commands.register("Script::Command", "script")
 

--- a/lib/project_types/script/commands/javy.rb
+++ b/lib/project_types/script/commands/javy.rb
@@ -18,9 +18,9 @@ module Script
         source = options.flags[:in_file]
         dest = options.flags[:out_file]
 
-        @ctx.abort(@ctx.message("script.javy.errors.invalid_arguments", ShopifyCLI::TOOL_NAME)) unless source && dest
+        @ctx.abort(@ctx.message("script.javy.errors.invalid_arguments", ShopifyCLI::TOOL_NAME)) unless source
 
-        ::Javy.build(source: source, dest: dest)
+        ::Javy.build(source: source, dest: dest).unwrap { |e| @ctx.abort(e.message) }
       end
 
       def self.help

--- a/lib/project_types/script/commands/javy.rb
+++ b/lib/project_types/script/commands/javy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "shopify_cli"
+require_relative "../../../../ext/javy/javy.rb"
+
+module Script
+  class Command
+    class Javy < ShopifyCLI::SubCommand
+      hidden_feature
+
+      prerequisite_task ensure_project_type: :script
+
+      options do |parser, flags|
+        parser.on("--in=IN") { |in_file| flags[:in_file] = in_file }
+        parser.on("--out=OUT") { |out_file| flags[:out_file] = out_file }
+      end
+
+      def call(*)
+        source = options.flags[:in_file]
+        dest = options.flags[:out_file]
+
+        @ctx.abort(@ctx.message("script.javy.errors.invalid_arguments", ShopifyCLI::TOOL_NAME)) unless source && dest
+
+        ::Javy.build(source: source, dest: dest)
+      end
+
+      def self.help
+        ShopifyCLI::Context.message("script.javy.help", ShopifyCLI::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -191,6 +191,19 @@ module Script
           script_pushed: "{{v}} Script pushed to app (API key: %{api_key}).",
         },
 
+        javy: {
+          help: <<~HELP,
+            Compile the JavaScript code into WebAssembly.
+              Usage: {{command:%s script javy}}
+              Options:
+                {{command:--in}} The name of the JavaScript file that will be compiled.
+                {{command:--out}} The name of the file that the WebAssembly should be written to.
+          HELP
+          errors: {
+            invalid_arguments: "Javy was run with invalid arguments. Run {{command: %s script javy --help}} for more information.",
+          },
+        },
+
         project_deps: {
           none_required: "{{v}} None required",
           checking_with_npm: "Checking dependencies with npm",

--- a/test/project_types/script/commands/javy_test.rb
+++ b/test/project_types/script/commands/javy_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+require_relative "../../../../ext/javy/javy.rb"
+
+module Script
+  module Commands
+    class JavyTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include TestHelpers::FakeFS
+
+      def setup
+        super
+        @context = TestHelpers::FakeContext.new
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
+      end
+
+      def test_calls_javy
+        in_filename = "build/index.js"
+        out_filename = "build/script.wasm"
+        Javy.expects(:build).with(source: in_filename, dest: out_filename)
+        capture_io do
+          run_cmd("script javy --in=#{in_filename} --out=#{out_filename}")
+        end
+      end
+
+      def test_invalid_args_fails
+        error = assert_raises(ShopifyCLI::Abort) do
+          capture_io { run_cmd("script javy") }
+        end
+
+        assert_match(@context.message("script.javy.errors.invalid_arguments", ShopifyCLI::TOOL_NAME), error.message)
+      end
+
+      def test_help
+        ShopifyCLI::Context
+          .expects(:message)
+          .with("script.javy.help", ShopifyCLI::TOOL_NAME)
+        Script::Command::Javy.help
+      end
+    end
+  end
+end

--- a/test/project_types/script/commands/javy_test.rb
+++ b/test/project_types/script/commands/javy_test.rb
@@ -15,12 +15,37 @@ module Script
         ShopifyCLI::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
       end
 
-      def test_calls_javy
+      def test_calls_javy_and_succeeds
         in_filename = "build/index.js"
         out_filename = "build/script.wasm"
-        Javy.expects(:build).with(source: in_filename, dest: out_filename)
+
+        stub_build_success(source: in_filename, dest: out_filename)
+
         capture_io do
           run_cmd("script javy --in=#{in_filename} --out=#{out_filename}")
+        end
+      end
+
+      def test_raises_error_when_javy_fails
+        in_filename = "build/index.js"
+        out_filename = "build/script.wasm"
+        error = RuntimeError.new("whoops")
+
+        stub_build_failure(source: in_filename, dest: out_filename, error: error)
+        @context.expects(:abort).with(error.message)
+
+        capture_io do
+          run_cmd("script javy --in=#{in_filename} --out=#{out_filename}")
+        end
+      end
+
+      def test_optionally_accepts_out_argument
+        in_filename = "build/index.js"
+
+        stub_build_success(source: in_filename, dest: nil)
+
+        capture_io do
+          run_cmd("script javy --in=#{in_filename}")
         end
       end
 
@@ -33,10 +58,23 @@ module Script
       end
 
       def test_help
-        ShopifyCLI::Context
-          .expects(:message)
-          .with("script.javy.help", ShopifyCLI::TOOL_NAME)
-        Script::Command::Javy.help
+        assert_includes(Script::Command::Javy.help, "script javy")
+      end
+
+      private
+
+      def stub_build_success(source:, dest:)
+        Javy
+          .expects(:build)
+          .with(source: source, dest: dest)
+          .returns(ShopifyCLI::Result.success(true))
+      end
+
+      def stub_build_failure(source:, dest:, error:)
+        Javy
+          .expects(:build)
+          .with(source: source, dest: dest)
+          .returns(ShopifyCLI::Result.failure(error))
       end
     end
   end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/3718

### WHAT is this pull request doing?

Adds a `script javy` command to support wrapping the Javy executable. This will be a hidden command, so it won't be visible in the help (there is currently a bug in the core code though, so I'll open another PR to fix that). 

### How to test your changes?

1. Ensure you have Javy installed by running `rake scripts:javy:install` in the CLI root.
2. Create a typescript project
2. Compile your TS to JS
3. run  `shopify script javy --in build/index.js --out build/index.wasm`. A new file should be created at `build/index.wasm`. 


### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).