### PR TITLE
add extension_points to ServerConfig::Extension model

### DIFF
--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -63,7 +63,7 @@ module Extension
         ShopifyCLI::Tasks::EnsureDevStore.call(context) if required_fields.include?(:shop)
 
         project = ExtensionProject.current
-        ensure_resource_resource_url! if specification_handler.supplies_resource_url?
+        ensure_resource_resource_url! if specification_handler.supplies_resource_url? && !supports_development_server?
 
         return if required_fields.all? do |field|
           value = project.env.public_send(field)

--- a/lib/project_types/extension/models/server_config/extension.rb
+++ b/lib/project_types/extension/models/server_config/extension.rb
@@ -5,10 +5,12 @@ module Extension
     module ServerConfig
       class Extension < Base
         include SmartProperties
+
         property! :uuid, accepts: String
         property! :type, accepts: String
         property! :user, accepts: ServerConfig::User
         property! :development, accepts: ServerConfig::Development
+        property :extension_points, accepts: Array
 
         def self.build(uuid: "", template:, type:, root_dir:)
           renderer = ServerConfig::DevelopmentRenderer.find(type)

--- a/lib/project_types/extension/tasks/converters/server_config_converter.rb
+++ b/lib/project_types/extension/tasks/converters/server_config_converter.rb
@@ -5,13 +5,11 @@ module Extension
   module Tasks
     module Converters
       module ServerConfigConverter
-        def self.from_hash(hash, type)
+        def self.from_hash(hash:, type:, registration_uuid:)
           context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
 
-          project = ExtensionProject.current
-
           extension = Models::ServerConfig::Extension.new(
-            uuid: project.registration_uuid,
+            uuid: registration_uuid,
             type: type.upcase,
             user: Models::ServerConfig::User.new,
             development: Models::ServerConfig::Development.new(
@@ -20,7 +18,8 @@ module Extension
               entries: Models::ServerConfig::DevelopmentEntries.new(
                 main: hash.dig("development", "entries", "main")
               )
-            )
+            ),
+            extension_points: hash.dig("extension_points")
           )
 
           Models::ServerConfig::Root.new(extensions: [extension])

--- a/lib/project_types/extension/tasks/load_server_config.rb
+++ b/lib/project_types/extension/tasks/load_server_config.rb
@@ -10,7 +10,12 @@ module Extension
       class << self
         def call(file_name:, type:)
           config = YAML.load_file(file_name)
-          Tasks::Converters::ServerConfigConverter.from_hash(config, type)
+          project = ExtensionProject.current
+          Tasks::Converters::ServerConfigConverter.from_hash(
+            hash: config,
+            type: type,
+            registration_uuid: project.registration_uuid
+          )
         rescue Psych::SyntaxError => e
           raise(
             ShopifyCLI::Abort,

--- a/test/project_types/extension/tasks/converters/server_config_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/server_config_converter_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "yaml"
+
+module Extension
+  module Tasks
+    module Converters
+      class ServerConfigConverterTest < MiniTest::Test
+        def test_server_config_converter_parses_extension_config_yaml
+          type = "CHECKOUT_UI_EXTENSION"
+          registration_uuid = "00000000-0000-0000-0000-000000000000"
+          config_file = YAML.load(mock_extension_config_yaml)
+
+          result = Converters::ServerConfigConverter.from_hash(
+            hash: config_file,
+            type: type,
+            registration_uuid: registration_uuid
+          )
+          extension = result.extensions.first
+          assert_equal(39351, result.port)
+          assert_equal(type, extension.type)
+          assert_equal(registration_uuid, extension.uuid)
+          assert_equal("build", extension.development.build_dir)
+          assert_equal("src/index.js", extension.development.entries.main)
+          assert_equal(["Checkout::Feature::Render"], extension.extension_points)
+          assert_equal("@shopify/checkout-ui-extensions", extension.development.renderer.name)
+        end
+
+        private
+
+        def mock_extension_config_yaml
+          <<~YAML
+            ---
+            development:
+              entries:
+                main: "src/index.js"
+              build_dir: "build"
+            extension_points:
+              - Checkout::Feature::Render
+          YAML
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-cli-extensions/issues/87

### WHAT is this pull request doing?

* Add `extension_points` to `ServerConfig::Extension` model
* Parse `extension_points` from the extension config file

### How to test your changes?

run `dev test test/project_types/extension/tasks/converters/server_config_converter_test.rb`

### Post-release steps

N/A

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing) -- not user facing yet
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.