### PR TITLE
default to depth=1 for package list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
 * [#1609](https://github.com/Shopify/shopify-cli/pull/1609): Add `--bind=HOST` option to `shopify theme serve`.
+* [#1685](https://github.com/Shopify/shopify-cli/pull/1685): Fix issue listing dependencies for `PRODUCT_SUBSCRIPTION` extensions on `shopify extension push`
 
 ## Version 2.6.5
 ### Fixed

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -47,10 +47,10 @@ module Extension
         end
       end
 
-      def renderer_package(context)
+      def renderer_package(context, production_only: false)
         js_system = ShopifyCLI::JsSystem.new(ctx: context)
         Tasks::FindNpmPackages
-          .exactly_one_of(renderer_package_name, js_system: js_system, production_only: true)
+          .exactly_one_of(renderer_package_name, js_system: js_system, production_only: production_only)
           .unwrap { |err| raise err }
       rescue Extension::PackageResolutionFailed
         context.abort(

--- a/lib/project_types/extension/tasks/find_npm_packages.rb
+++ b/lib/project_types/extension/tasks/find_npm_packages.rb
@@ -84,11 +84,11 @@ module Extension
       end
 
       def yarn_list
-        production_only? ? %w[list --production --depth=0] : %w[list]
+        production_only? ? %w[list --production --depth=0] : %w[list --depth=1]
       end
 
       def npm_list
-        production_only? ? %w[list --prod --depth=0] : %w[list]
+        production_only? ? %w[list --prod --depth=0] : %w[list --depth=1]
       end
 
       def search_packages(packages, package_list)

--- a/test/project_types/extension/tasks/find_npm_packages_test.rb
+++ b/test/project_types/extension/tasks/find_npm_packages_test.rb
@@ -109,8 +109,8 @@ module Extension
       def test_includes_development_dependencies_by_default
         js_system = stub_js_system do |expect_js_system_call|
           expect_js_system_call.with do |config|
-            assert_equal ["list"], config.fetch(:yarn)
-            assert_equal ["list"], config.fetch(:npm)
+            assert_equal ["list", "--depth=1"], config.fetch(:yarn)
+            assert_equal ["list", "--depth=1"], config.fetch(:npm)
           end
         end
         result = FindNpmPackages.call(js_system: js_system)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/1683

This is happening because in order to solve an issue with duplicate dependencies, we switched to using `depth=0` by default to list package dependencies. Instead of defaulting to `depth=0`, this PR modifies the code so we only default to `production_only` or `depth=0` when specified

### WHAT is this pull request doing?

* Adds optional `production_only` keyword argument to `renderer_package` in the `Argo` class. Default is `false`

### How to test your changes?

1. Create or `cd` into an existing `PRODUCT_SUBSCRIPTION` extension that uses Javascript + React or Typescript + React
2. From the `main` branch, try to run `shopify extension push`, you will see the command will fail
3. Now switch to this branch `git checkout fix/product-subscription-push`
4. Run `shopify extension push`, you should see the command succeed

### Post-release steps
N/A

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.