### PR TITLE
Ensure the CLI can run after being installed after building a .gem

### DIFF
--- a/features/step_definitions/commands/version.rb
+++ b/features/step_definitions/commands/version.rb
@@ -2,3 +2,20 @@ Then("'version' returns the right version") do
   output = @container.capture_shopify("version").chomp
   assert_equal CLI.version, output
 end
+
+And(/^I build the Shopify CLI Gem as (.+)$/) do |gem_name|
+  cli_path = Utilities::Docker::Container::SHOPIFY_PATH
+  gemspec_path = File.join(cli_path, "shopify-cli")
+  gem_path = File.join(@container.cwd, gem_name)
+  @container.exec("gem", "build", gemspec_path, "-o", gem_path, "-C", cli_path)
+end
+
+When(/^I install the Ruby Gem (.+)$/) do |gem_name|
+  gem_path = File.join(@container.cwd, gem_name)
+  @container.exec("gem", "install", gem_path)
+end
+
+Then(/I can run "(.+)" successfully/) do |command|
+  args = command.split(" ")
+  @container.exec(*args)
+end

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,5 +1,11 @@
 Feature: The version command
 
+  Scenario: The Ruby Gem is installed in a Linux environment
+    Given I have a VM with the CLI and a working directory
+    And I build the Shopify CLI Gem as shopify-cli.gem
+    When I install the Ruby Gem shopify-cli.gem
+    Then I can run "shopify version" successfully
+
   Scenario: The user wants to know the version of the CLI
    Given I have a VM with the CLI and a working directory
     Then 'version' returns the right version

--- a/utilities/docker/container.rb
+++ b/utilities/docker/container.rb
@@ -3,6 +3,7 @@ require "open3"
 module Utilities
   module Docker
     class Container
+      SHOPIFY_PATH = "/usr/src/app"
       SHOPIFY_BIN_PATH = "/usr/src/app/bin/shopify"
 
       Error = Class.new(StandardError)


### PR DESCRIPTION
### WHY are these changes introduced?

This is follow-up work for https://github.com/Shopify/shopify-cli/pull/1664

We don't have a mechanism that ensures the release and installation of the Ruby gem will lead to a valid installation with the executable exposed to the environment.

### WHAT is this pull request doing?
I'm adding an acceptance test that tests the following e2e in Linux environments:
- Build the `shopify-cli.gem` using `gem build`
- Install the `shopify-cli.gem` using `gem install`
- Ensure `shopify` can be executed.

### How to test your changes?
Check out the branch and run:
```
bundle exec cucumber 'features/version.feature:3'
```
CI runs the changes too so if it's green we should be confident about the changes.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.