### PR TITLE
[scripts] Use npm -s list to silence irrelevant warnings

### DIFF
--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -48,7 +48,7 @@ module Script
           end
 
           def library_version(library_name)
-            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm list --json"))
+            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -49,7 +49,7 @@ module Script
           end
 
           def library_version(library_name)
-            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm list --json"))
+            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -118,7 +118,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     describe "when the package is in the dependencies list" do
       it "should return a valid version number" do
         command_runner.any_instance.stubs(:call)
-          .with("npm list --json")
+          .with("npm -s list --json")
           .returns(
             {
               "dependencies" => {
@@ -135,7 +135,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     describe "when the package is not in the dependencies list" do
       it "should return an error" do
         command_runner.any_instance.stubs(:call)
-          .with("npm list --json")
+          .with("npm -s list --json")
           .returns(
             {
               "dependencies" => {},
@@ -150,7 +150,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     describe "when CommandRunner raises SystemCallFailureError" do
       describe "when error is not json" do
         it "should re-raise SystemCallFailureError" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(
@@ -165,7 +165,7 @@ out: "some non-json parsable error output", cmd: cmd
 
       describe "when error is json, but doesn't contain the expected structure" do
         it "should re-raise SystemCallFailureError" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(
@@ -182,7 +182,7 @@ out: "some non-json parsable error output", cmd: cmd
 
       describe "when error contains expected versioning data" do
         it "should rescue SystemCallFailureError if the library version is present" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -193,7 +193,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     describe "when the package is in the dependencies list" do
       it "should return a valid version number" do
         command_runner.any_instance.stubs(:call)
-          .with("npm list --json")
+          .with("npm -s list --json")
           .returns(
             {
               "dependencies" => {
@@ -210,7 +210,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     describe "when the package is not in the dependencies list" do
       it "should return an error" do
         command_runner.any_instance.stubs(:call)
-          .with("npm list --json")
+          .with("npm -s list --json")
           .returns(
             {
               "dependencies" => {},
@@ -225,7 +225,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     describe "when CommandRunner raises SystemCallFailureError" do
       describe "when error is not json" do
         it "should re-raise SystemCallFailureError" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(
@@ -241,7 +241,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
 
       describe "when error is json, but doesn't contain the expected structure" do
         it "should re-raise SystemCallFailureError" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(
@@ -258,7 +258,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
 
       describe "when error contains expected versioning data" do
         it "should rescue SystemCallFailureError if the library version is present" do
-          cmd = "npm list --json"
+          cmd = "npm -s list --json"
           command_runner.any_instance.stubs(:call)
             .with(cmd)
             .raises(Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3891

### WHAT is this pull request doing?

NPM will show warnings during commands unless they are silenced by a cli flag. When calling `npm list --json`, we want to silence warnings because we are expecting JSON. We can do that with `npm -s list --json`.

The `-s` flag will silence all NPM warnings and NPM errors. This does NOT silence errors from the command failing (like if you don't have the dependency installed, the command still returns the expected failing JSON and exits with a non-zero code). Any error that is blocking will be caught during the `npm install` command that runs before `npm list`, so really, these errors aren't relevant at this point anyway.

### How to test your changes?

I haven't found an easier way to reproduce, but this is what I did:

1. Using node `v14.16.1` and npm `v6.14.12`
2. Create a new TS script
3. run `npm list --json` and check if an `npm WARN` appears. 
    - If not, in the `package-lock.json` file, change your `lockfileVersion` from 1 -> 2 OR from 2 -> 1. This will trigger an npm warning.
    - Run `npm list --json` again to verify
5. run `shopify script push` and verify that no errors are raised

### Update checklist

- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).