### PR TITLE
[scripts] update metadata_validation_help

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -81,8 +81,8 @@ module Script
           system_call_failure_cause: "An error was returned while running {{command:%{cmd}}}.",
           system_call_failure_help: "Review the following error and try again.\n{{red:%{out}}}",
 
-          metadata_validation_cause: "Invalid Script API metadata.",
-          metadata_validation_help: "Ensure the script's library package is up to date.",
+          metadata_validation_cause: "The Script API metadata is incorrect.",
+          metadata_validation_help: "The 'schemaVersions.major' field contains an unsupported version.",
 
           metadata_schema_versions_missing: "Invalid Script metadata:" \
                                             " 'schemaVersions' field is missing",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/3654

### WHAT is this pull request doing?

Improves the error message that is returned when a push fails because of schema validation.

### How to test your changes?

Change the `schemaMajorVersion` value that CLI sends to SS to be invalid.
Edit it directly on your local CLI here:
https://github.com/Shopify/shopify-cli/blob/215a656668d5e2d02d3f9328ac6bae060d11b313/lib/project_types/script/layers/infrastructure/script_service.rb#L31 

### Post-release steps

N/A

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above.