### PR TITLE
parse package.json instead of running npm|yarn list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#1678](https://github.com/Shopify/shopify-cli/pull/1678): Fix migrator's incompatibility with Ruby 2.5.
+* [#1690](https://github.com/Shopify/shopify-cli/pull/1690): Fix `extension push` command for `PRODUCT_SUBSCRIPTION` extensions
   
 ### Changed
 * [#1678](https://github.com/Shopify/shopify-cli/pull/1678): Change the `@shopify/scripts-checkout-apis-temp` package name to `@shopify/scripts-discount-apis`.

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -43,6 +43,7 @@ module Extension
     autoload :GetProduct, Project.project_filepath("tasks/get_product")
     autoload :RunExtensionCommand, Project.project_filepath("tasks/run_extension_command")
     autoload :LoadServerConfig, Project.project_filepath("tasks/load_server_config")
+    autoload :FindPackageFromJson, Project.project_filepath("tasks/find_package_from_json.rb")
 
     module Converters
       autoload :RegistrationConverter, Project.project_filepath("tasks/converters/registration_converter")

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -48,14 +48,7 @@ module Extension
       end
 
       def renderer_package(context)
-        js_system = ShopifyCLI::JsSystem.new(ctx: context)
-        Tasks::FindNpmPackages
-          .exactly_one_of(renderer_package_name, js_system: js_system, production_only: true)
-          .unwrap { |err| raise err }
-      rescue Extension::PackageResolutionFailed
-        context.abort(
-          context.message("features.argo.dependencies.argo_missing_renderer_package_error")
-        )
+        Tasks::FindPackageFromJson.call(renderer_package_name, context: context)
       end
 
       private

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -175,6 +175,7 @@ module Extension
       errors: {
         unknown_type: "Unknown extension type %s",
         package_not_found: "`%s` package not found.",
+        module_not_found: "Unable to find module %s. Ensure your dependencies are up-to-date and try again.",
       },
       warnings: {
         resource_url_auto_generation_failed: "{{*}} {{yellow:Warning:}} Unable to auto generate " \

--- a/lib/project_types/extension/tasks/find_package_from_json.rb
+++ b/lib/project_types/extension/tasks/find_package_from_json.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "json"
+
+module Extension
+  module Tasks
+    class FindPackageFromJson < ShopifyCLI::Task
+      include SmartProperties
+
+      property! :context, accepts: ShopifyCLI::Context
+
+      def self.call(package_name, **config)
+        new(**config).call(package_name)
+      end
+
+      def call(package_name)
+        ShopifyCLI::Result.success(resolve_package_json(package_name))
+          .then { |file| File.read(file) }
+          .then { |file| JSON.parse(file) }
+          .then { |file| file.dig("version") }
+          .then { |version| return Models::NpmPackage.new(name: package_name, version: version) }
+          .unwrap do |error|
+            context.debug(error)
+            context.abort(context.message("errors.module_not_found", package_name))
+          end
+      end
+
+      private
+
+      def resolve_package_json(package_name)
+        path = "path.join(require.resolve('#{package_name}'), '../package.json')"
+        package_json, error, _ = CLI::Kit::System.capture3("node", "-p", path)
+        return error unless !error.nil?
+        package_json.chomp
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -134,18 +134,8 @@ module Extension
       end
 
       def stub_package_manager
-        fake_list_result = <<~YARN
-          yarn list v1.22.5
-          ├─ @fake-package@0.3.9
-          └─ @shopify/admin-ui-extensions@0.3.8
-          ✨  Done in 0.40s.
-        YARN
-
-        ShopifyCLI::JsSystem
-          .new(ctx: @context)
-          .tap { |js_system| js_system.stubs(call: [fake_list_result, nil, stub(success?: true)]) }
-          .yield_self { |js_system| Tasks::FindNpmPackages.new(js_system: js_system) }
-          .tap { |find_npm_packages_stub| Tasks::FindNpmPackages.expects(:new).returns(find_npm_packages_stub) }
+        Tasks::FindPackageFromJson.expects(:call)
+          .returns(Models::NpmPackage.new(name: "@shopify/admin-ui-extensions", version: "0.3.8"))
       end
     end
   end

--- a/test/project_types/extension/tasks/find_package_from_json_test.rb
+++ b/test/project_types/extension/tasks/find_package_from_json_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+module Extension
+  module Tasks
+    class FindPackageFromJsonTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCLI::ProjectType.load_type(:extension)
+      end
+
+      def test_package_is_returned_if_found
+        File.expects(:read).returns(mock_package_json)
+        package = Tasks::FindPackageFromJson.call("@shopify/admin-ui-extensions", context: @context)
+        assert_equal("@shopify/admin-ui-extensions", package.name)
+        assert_equal("0.14.0", package.version)
+        assert_instance_of(Models::NpmPackage, package)
+      end
+
+      def test_error_is_raised_if_package_not_found
+        error = assert_raises ShopifyCLI::Abort do
+          Tasks::FindPackageFromJson.call("does-not-exist", context: @context)
+        end
+
+        assert_instance_of(CLI::Kit::Abort, error)
+        assert_includes error.message, "Unable to find module does-not-exist"
+      end
+
+      private
+
+      def mock_package_json
+        <<~JSON
+          {
+            "name": "@shopify/admin-ui-extensions",
+            "version": "0.14.0"
+          }
+        JSON
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/1683

### WHAT is this pull request doing?

Instead of running `npm | yarn list` to find the `renderer_package` version that is needed for the extension to run, parse the `package.json` file and get the version from there.

Pros: 
* This reduces code complexity as we no longer have to make a JS call to find the renderer version
* Reduces issues when there are multiple versions of a dependency when running `npm | yarn list`
* There is a known bug with the `list` command on earlier versions of Node, and not having to run the command would eliminate said bug

### How to test your changes?

* Run `shopify extension serve`, `shopify extension register` and `shopify extension push` on a `PRODUCT_SUBSCRIPTION` extension

### Tophatted:

**Product Subscription**
* [x] javascript
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript
  * [x] serve
  * [x] register
  * [x] push
* [x] javascript react
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript react
  * [x] serve
  * [x] register
  * [x] push

**Checkout UI**
* [x] javascript
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript
  * [x] serve
  * [x] register
  * [x] push
* [x] javascript react
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript react
  * [x] serve
  * [x] register
  * [x] push

**Post Purchase**
* [x] javascript
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript
  * [x] serve
  * [x] register
  * [x] push
* [x] javascript react
  * [x] serve
  * [x] register
  * [x] push
* [x] typescript react
  * [x] serve
  * [x] register
  * [x] push

### Post-release steps

N/A

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.