### PR TITLE
dev server support all argo extension types

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -3,10 +3,6 @@
 module Extension
   class Command
     class Create < ShopifyCLI::SubCommand
-      DEVELOPMENT_SERVER_SUPPORTED_TYPES = [
-        "checkout_ui_extension",
-      ]
-
       prerequisite_task :ensure_authenticated
 
       options do |parser, flags|
@@ -66,6 +62,7 @@ module Extension
         @ctx.chdir(form.directory_name)
         write_env_file(form)
       rescue => error
+        @ctx.debug(error)
         raise error
       end
 

--- a/lib/project_types/extension/forms/questions/ask_template.rb
+++ b/lib/project_types/extension/forms/questions/ask_template.rb
@@ -4,10 +4,6 @@ module Extension
       class AskTemplate
         include ShopifyCLI::MethodObject
 
-        TEMPLATE_REQUIRED_TYPES = [
-          "checkout_ui_extension",
-        ]
-
         property! :ctx
         property :template, accepts: Models::ServerConfig::Development::VALID_TEMPLATES
         property :prompt,
@@ -25,7 +21,7 @@ module Extension
         def template_required?(project_details)
           return false unless extension_server_beta?
           type = project_details&.type&.identifier
-          TEMPLATE_REQUIRED_TYPES.include?(type.downcase)
+          Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
         end
 
         def extension_server_beta?

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -6,10 +6,9 @@ module Extension
     class DevelopmentServerRequirements
       SUPPORTED_EXTENSION_TYPES = [
         "checkout_ui_extension",
+        "checkout_post_purchase",
+        "product_subscription",
       ]
-
-      UNIX_NAME = "shopify-extensions"
-      WINDOWS_NAME = "shopify-extensions.exe"
 
       class << self
         def supported?(type)

--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -16,7 +16,7 @@ module Extension
 
         def self.find(type)
           case type.downcase
-          when "admin_ui_extension"
+          when "product_subscription"
             new(name: "@shopify/admin-ui-extensions")
           when "checkout_ui_extension"
             new(name: "@shopify/checkout-ui-extensions")

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -7,10 +7,6 @@ module Extension
     class RunExtensionCommand < ShopifyCLI::Task
       include SmartProperties
 
-      SUPPORTED_EXTENSION_TYPES = [
-        "checkout_ui_extension",
-      ]
-
       SUPPORTED_COMMANDS = [
         "create",
         "build",
@@ -18,7 +14,7 @@ module Extension
       ]
 
       property! :command, accepts: SUPPORTED_COMMANDS
-      property! :type, accepts: SUPPORTED_EXTENSION_TYPES
+      property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
       property :context, accepts: ShopifyCLI::Context
       property :config_file_name, accepts: String
       property :port, accepts: Integer, default: 39351

--- a/test/project_types/extension/models/server_config/extension_test.rb
+++ b/test/project_types/extension/models/server_config/extension_test.rb
@@ -24,7 +24,7 @@ module Extension
           assert_nothing_raised do
             extension = ServerConfig::Extension.build(
               template: "javascript",
-              type: "admin_ui_extension",
+              type: "product_subscription",
               root_dir: "test"
             )
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-cli-extensions/issues/140

### WHAT is this pull request doing?

Adds support of new extensions development server for `CHECKOUT_POST_PURCHASE` and `PRODUCT_SUBSCRIPTION` extensions.

### How to test your changes?

* within the `shopify-cli` repo, run `rake extensions:install`
* give yourself the required beta flag: `shopify config feature extension_server_beta --enable`

**Product Subscription extensions:**

 * run `shopify extension create --type=PRODUCT_SUBSCRIPTION`
 * cd into your new extension
 * run `yarn install`
 * run `shopify extension build`
 * run `shopify extension serve`

You should see this output
<img width="986" alt="product_subscription" src="https://user-images.githubusercontent.com/989784/139726031-99964655-7e47-42b1-b236-3030172352fa.png">
<img width="825" alt="product_subscription_build" src="https://user-images.githubusercontent.com/989784/139726034-d02d9b72-0002-4bcf-acb0-d2f8009024fa.png">

**Post Purchase extensions:**

 * run `shopify extension create --type=CHECKOUT_POST_PURCHASE`
 * cd into your new extension
 * run `yarn install`
 * run `shopify extension build`
 * run `shopify extension serve`

You should see this output:
<img width="986" alt="product_subscription" src="https://user-images.githubusercontent.com/989784/139726177-f8ecb237-e8f3-4a5b-aa3a-cffee7f2e26a.png">
<img width="825" alt="product_subscription_build" src="https://user-images.githubusercontent.com/989784/139726182-cde78805-b4ce-49f4-9d80-4a6234aaeb50.png">

**Checkout UI Extensions** should continue to work as they did before:

<img width="955" alt="checkout_ui" src="https://user-images.githubusercontent.com/989784/139726230-fe4defcc-f59b-42bf-95b2-d1201a59335d.png">
<img width="796" alt="checkout_ui_build" src="https://user-images.githubusercontent.com/989784/139726232-2e9f7484-063e-4fa7-9088-9ac92a057366.png">

🚨 Disable the beta once you are finished tophatting 🚨 
`shopify config feature extension_server_beta --disable`

### Post-release steps

N/A

### Update checklist

~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~ not user facing yet
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
~- [ ] I've included any post-release steps in the section above.~