### PR TITLE
Add `--pull-json-interval=SECONDS` option to `theme serve`

### DIFF
--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -7,6 +7,7 @@ module Theme
       options do |parser, flags|
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
+        parser.on("--pull-json-interval=SECONDS") { |seconds| flags[:pull_json_interval] = seconds.to_i }
       end
 
       def call(*)

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -20,12 +20,12 @@ module ShopifyCLI
       class << self
         attr_accessor :ctx
 
-        def start(ctx, root, port: 9292, poll: false)
+        def start(ctx, root, port: 9292, poll: false, pull_json_interval: nil)
           @ctx = ctx
           theme = DevelopmentTheme.new(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
           @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter)
-          watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, ignore_filter: ignore_filter, poll: poll)
+          watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, ignore_filter: ignore_filter, poll: poll, pull_json_interval: pull_json_interval)
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)


### PR DESCRIPTION
To pull remote JSON files for updates at an interval.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

When developing a theme with `shopify theme serve`, changes made in the Editor/Customizer are not reflected locally.

Changed made to the files locally are reflected in the Editor, because JSON files are upload from the local machine to the Editor. But when the Editor modifies a JSON file in the themes, those changes are not pulled into the local machine.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Starting the `theme serve` command with:

```
shopify theme --pull-json-interval=3
```

Will pull for any change made remotely on any `.json` file.

For example, if you change the order of sections on the product page, `templates/product.json` will be pulled locally and overwrite the local version of the file.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.