### PR TITLE
add api_key and version to extensions server_config

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -95,6 +95,7 @@ module Extension
 
     module ServerConfig
       autoload :Base, Project.project_filepath("models/server_config/base")
+      autoload :App, Project.project_filepath("models/server_config/app")
       autoload :Development, Project.project_filepath("models/server_config/development")
       autoload :DevelopmentEntries, Project.project_filepath("models/server_config/development_entries")
       autoload :DevelopmentRenderer, Project.project_filepath("models/server_config/development_renderer")

--- a/lib/project_types/extension/models/server_config/app.rb
+++ b/lib/project_types/extension/models/server_config/app.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module ServerConfig
+      class App < Base
+        include SmartProperties
+
+        property! :api_key, accepts: String
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/development.rb
+++ b/lib/project_types/extension/models/server_config/development.rb
@@ -12,12 +12,12 @@ module Extension
 
         CURRENT_DIRECTORY = "."
 
-        property :root_dir, accepts: String, default: CURRENT_DIRECTORY
+        property  :root_dir, accepts: String, default: CURRENT_DIRECTORY
         property! :build_dir, accepts: String, default: "build"
-        property :template, accepts: VALID_TEMPLATES
-        property :renderer, accepts: ServerConfig::DevelopmentRenderer
-        property :entries, accepts: ServerConfig::DevelopmentEntries
-        property :resource, accepts: ServerConfig::DevelopmentResource
+        property  :template, accepts: VALID_TEMPLATES
+        property  :renderer, accepts: ServerConfig::DevelopmentRenderer
+        property  :entries, accepts: ServerConfig::DevelopmentEntries
+        property  :resource, accepts: ServerConfig::DevelopmentResource
       end
     end
   end

--- a/lib/project_types/extension/models/server_config/extension.rb
+++ b/lib/project_types/extension/models/server_config/extension.rb
@@ -10,7 +10,8 @@ module Extension
         property! :type, accepts: String
         property! :user, accepts: ServerConfig::User
         property! :development, accepts: ServerConfig::Development
-        property :extension_points, accepts: Array
+        property  :extension_points, accepts: Array
+        property  :version, accepts: String
 
         def self.build(uuid: "", template:, type:, root_dir:)
           renderer = ServerConfig::DevelopmentRenderer.find(type)

--- a/lib/project_types/extension/models/server_config/root.rb
+++ b/lib/project_types/extension/models/server_config/root.rb
@@ -6,10 +6,11 @@ module Extension
       class Root < Base
         include SmartProperties
 
-        property! :port, accepts: Integer, default: 39351
+        property  :app, accepts: ServerConfig::App
         property! :extensions, accepts: Array, default: -> { [] }
-        property :store, accepts: String
-        property :public_url, accepts: String
+        property! :port, accepts: Integer, default: 39351
+        property  :public_url, accepts: String
+        property  :store, accepts: String
 
         def to_yaml
           to_h.to_yaml.gsub("---\n", "")

--- a/lib/project_types/extension/tasks/converters/server_config_converter.rb
+++ b/lib/project_types/extension/tasks/converters/server_config_converter.rb
@@ -5,28 +5,46 @@ module Extension
   module Tasks
     module Converters
       module ServerConfigConverter
-        def self.from_hash(hash:, type:, registration_uuid:, store:, tunnel_url:, resource_url: nil)
-          context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
+        class << self
+          def from_hash(api_key:, context:, hash:, type:, registration_uuid:, resource_url: nil, store:, tunnel_url:)
+            context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
 
-          extension = Models::ServerConfig::Extension.new(
-            uuid: registration_uuid,
-            type: type.upcase,
-            user: Models::ServerConfig::User.new,
-            development: Models::ServerConfig::Development.new(
-              build_dir: hash.dig("development", "build_dir"),
-              renderer: Models::ServerConfig::DevelopmentRenderer.find(type),
-              entries: Models::ServerConfig::DevelopmentEntries.new(
-                main: hash.dig("development", "entries", "main")
-              )
-            ),
-            extension_points: hash.dig("extension_points")
-          )
+            renderer = Models::ServerConfig::DevelopmentRenderer.find(type)
 
-          unless resource_url.nil?
-            extension.development.resource = Models::ServerConfig::DevelopmentResource.new(url: resource_url)
+            extension = Models::ServerConfig::Extension.new(
+              uuid: registration_uuid,
+              type: type.upcase,
+              user: Models::ServerConfig::User.new,
+              development: Models::ServerConfig::Development.new(
+                build_dir: hash.dig("development", "build_dir"),
+                renderer: renderer,
+                entries: Models::ServerConfig::DevelopmentEntries.new(
+                  main: hash.dig("development", "entries", "main")
+                )
+              ),
+              extension_points: hash.dig("extension_points"),
+              version: version(renderer.name, context)
+            )
+
+            unless resource_url.nil?
+              extension.development.resource = Models::ServerConfig::DevelopmentResource.new(url: resource_url)
+            end
+
+            server_config = Models::ServerConfig::Root.new(
+              extensions: [extension],
+              public_url: tunnel_url,
+              store: store
+            )
+
+            unless api_key.nil?
+              server_config.app = Models::ServerConfig::App.new(api_key: api_key)
+            end
+            server_config
           end
 
-          Models::ServerConfig::Root.new(extensions: [extension], store: store, public_url: tunnel_url)
+          def version(renderer, context)
+            Tasks::FindPackageFromJson.call(renderer, context: context).version
+          end
         end
       end
     end

--- a/lib/project_types/extension/tasks/merge_server_config.rb
+++ b/lib/project_types/extension/tasks/merge_server_config.rb
@@ -8,16 +8,18 @@ module Extension
       include SmartProperties
 
       class << self
-        def call(file_name:, type:, resource_url:, tunnel_url:)
+        def call(context:, file_name:, resource_url:, tunnel_url:, type:)
           config = YAML.load_file(file_name)
           project = ExtensionProject.current
           Tasks::Converters::ServerConfigConverter.from_hash(
+            api_key: project.env.api_key,
+            context: context,
             hash: config,
             type: type,
             registration_uuid: project.registration_uuid,
             resource_url: resource_url || project.resource_url,
             store: project.env.shop || "",
-            tunnel_url: tunnel_url
+            tunnel_url: tunnel_url,
           )
         rescue Psych::SyntaxError => e
           raise(

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -47,10 +47,11 @@ module Extension
 
       def merge_server_config
         Tasks::MergeServerConfig.call(
+          context: context,
           file_name: config_file_name,
-          type: type,
           resource_url: resource_url,
-          tunnel_url: tunnel_url
+          tunnel_url: tunnel_url,
+          type: type
         )
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

### WHAT is this pull request doing?

* Adds `ServerConfig::App`
* Adds `version` to `ServerConfig::Extension`
* Parses api key from .env and version from renderer package, and merges that into the `ServerConfig`

### How to test your changes?

* within the shopify-cli repo, run rake extensions:install
* give yourself the required beta flag: shopify config feature extension_server_beta --enable
* cd into an extension project
* [CHECKOUT_UI_EXTENSIONS only] run echo "EXTENSION_RESOURCE_URL=/cart/1:1" >> .env in the extension project (this bypasses the call to the AdminAPI to fetch product data to build the resource_url, as this call is intermittently failing for some users)
* run shopify extension serve

You should see similar output to this:

#### Checkout Post Purchase
<img width="1070" alt="Screen Shot 2021-11-04 at 4 19 17 PM" src="https://user-images.githubusercontent.com/989784/140422466-9212e7f8-296c-4945-8a1c-f3c6b12c570e.png">

#### Product Subscription
<img width="1071" alt="Screen Shot 2021-11-04 at 4 19 50 PM" src="https://user-images.githubusercontent.com/989784/140422478-abfa11bb-2aa6-422d-b044-5082b918eb6c.png">

#### Checkout UI
<img width="1055" alt="Screen Shot 2021-11-04 at 12 23 43 PM" src="https://user-images.githubusercontent.com/989784/140422497-7dfdc728-caf7-4558-b0cd-1462be6bc13f.png">

### Update checklist

~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~ not user facing yet
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.