### PR TITLE
Split extensible discount apis

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -44,11 +44,20 @@ shipping_methods:
       beta: true
       package: "@shopify/scripts-checkout-apis-temp"
       repo: "https://github.com/Shopify/scripts-apis-examples"
-discount_types:
+delivery_discount_types:
   beta: true
   domain: 'discounts'
   libraries:
     typescript:
       beta: true
-      package: "@shopify/scripts-discount-apis"
+      package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
+merchandise_discount_types:
+  beta: true
+  domain: 'discounts'
+  libraries:
+    typescript:
+      beta: true
+      package: "@shopify/scripts-discounts-apis"
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -69,7 +69,7 @@ module Script
             raise error
           end
 
-          def extract_first_json_hash(output)
+          def extract_first_json_hash(error)
             "#{error.out.split("\n}")[0]}}"
           end
 

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -61,12 +61,16 @@ module Script
             # npm list can return a failure status code, even when returning the correct data.
             # This causes the CommandRunner to throw a SystemCallFailure error that contains the data.
             # In here, we check that the output contains `npm list`'s structure and extract the version.
-            output = JSON.parse(error.out)
+            output = JSON.parse(extract_first_json_hash(error)) 
             raise error unless output.key?("dependencies")
 
             library_version_from_npm_list(output, library_name)
-          rescue JSON::ParserError
+          rescue JSON::ParserError => e
             raise error
+          end
+
+          def extract_first_json_hash(output)
+            "#{error.out.split("\n}")[0]}}"
           end
 
           def library_version_from_npm_list(output, library_name)


### PR DESCRIPTION
### WHY are these changes introduced?

We've split the discount type API into two APIs. One is for Merchandising, and the other for Shipping.

While making this adjustment, I ran into the issue described in the comment below, and needed to patch the CLI to get past it.

### WHAT is this pull request doing?

I'm merging in my patch to bypass errors while parsing the error output of `npm list`

I've also added in the delivery and merchandise APIs under beta functionality.

### How to test your changes?

TBD

### Post-release steps

This change should only be relevant to internal developers at the moment.

### Update checklist

- ~[ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.