### PR TITLE
Fix `theme serve` failing when the port is already being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
+### Fixed
+* [#1722](https://github.com/Shopify/shopify-cli/pull/1722): Fix `theme serve` failing when the port is already being used
 
 ## Version 2.7.0
 ### Changed

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -114,7 +114,7 @@ module Theme
             {{green:%s}}
 
             Share this theme preview:
-            {{green:%s}}}
+            {{green:%s}}
 
             (Use Ctrl-C to stop)
           CUSTOMIZE_OR_PREVIEW

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -96,12 +96,36 @@ module Theme
               {{command:--poll}}      Force polling to detect file changes
               {{command:--host=HOST}} Set which network interface the web server listens on. The default value is 127.0.0.1.
           HELP
-          serve: "Viewing theme…",
+          viewing_theme: "Viewing theme…",
+          syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
           error: {
             address_binding_error: "Couldn't bind to localhost."\
               " To serve your theme, set a different address with {{command:%s theme serve --host=<address>}}",
           },
+          serving: <<~SERVING,
+
+            Serving %s
+
+          SERVING
+          customize_or_preview: <<~CUSTOMIZE_OR_PREVIEW,
+
+            Customize this theme in the Online Store Editor:
+            {{green:%s}}
+
+            Share this theme preview:
+            {{green:%s}}}
+
+            (Use Ctrl-C to stop)
+          CUSTOMIZE_OR_PREVIEW
+          ensure_user: <<~ENSURE_USER,
+            You are not authorized to edit themes on %s.
+            Make sure you are a user of that store, and allowed to edit themes.
+          ENSURE_USER
+          already_in_use_error: "Error",
+          address_already_in_use: "The address \"%s\" is already in use.",
+          try_this: "Try this",
+          try_port_option: "Use the --port=PORT option to serve the theme in a different port.",
         },
         check: {
           help: <<~HELP,

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -20,7 +20,6 @@ module ShopifyCLI
       # Errors
       Error = Class.new(StandardError)
       AddressBindingError = Class.new(Error)
-      BlankAbort = ShopifyCLI::Abort.new("")
 
       class << self
         attr_accessor :ctx
@@ -105,7 +104,7 @@ module ShopifyCLI
             @ctx.puts(@ctx.message("theme.serve.try_port_option"))
           end
 
-          raise BlankAbort
+          raise ShopifyCLI::AbortSilent
         end
 
         def open_frame(title, color:, &block)

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -20,6 +20,7 @@ module ShopifyCLI
       # Errors
       Error = Class.new(StandardError)
       AddressBindingError = Class.new(Error)
+      BlankAbort = ShopifyCLI::Abort.new("")
 
       class << self
         attr_accessor :ctx
@@ -36,6 +37,7 @@ module ShopifyCLI
           @app = LocalAssets.new(ctx, @app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, ignore_filter: ignore_filter)
           stopped = false
+          address = "http://#{http_bind}:#{port}"
 
           theme.ensure_exists!
 
@@ -44,8 +46,8 @@ module ShopifyCLI
             stop
           end
 
-          CLI::UI::Frame.open(@ctx.message("theme.serve.serve")) do
-            ctx.print_task("Syncing theme ##{theme.id} on #{theme.shop}")
+          CLI::UI::Frame.open(@ctx.message("theme.serve.viewing_theme")) do
+            ctx.print_task(ctx.message("theme.serve.syncing_theme", theme.id, theme.shop))
             @syncer.start_threads
             if block_given?
               yield @syncer
@@ -55,18 +57,9 @@ module ShopifyCLI
 
             return if stopped
 
-            ctx.puts("")
-            ctx.puts("Serving #{theme.root}")
-            ctx.puts("")
-            ctx.open_url!("http://127.0.0.1:#{port}")
-            ctx.puts("")
-            ctx.puts("Customize this theme in the Online Store Editor:")
-            ctx.puts("{{green:#{theme.editor_url}}}")
-            ctx.puts("")
-            ctx.puts("Share this theme preview:")
-            ctx.puts("{{green:#{theme.preview_url}}}")
-            ctx.puts("")
-            ctx.puts("(Use Ctrl-C to stop)")
+            ctx.puts(ctx.message("theme.serve.serving", theme.root))
+            ctx.open_url!(address)
+            ctx.puts(ctx.message("theme.serve.customize_or_preview", theme.editor_url, theme.preview_url))
           end
 
           logger = if ctx.debug?
@@ -87,8 +80,9 @@ module ShopifyCLI
 
         rescue ShopifyCLI::API::APIRequestForbiddenError,
                ShopifyCLI::API::APIRequestUnauthorizedError
-          @ctx.abort("You are not authorized to edit themes on #{theme.shop}.\n" \
-                     "Make sure you are a user of that store, and allowed to edit themes.")
+          raise ShopifyCLI::Abort, @ctx.message("theme.serve.ensure_user", theme.shop)
+        rescue Errno::EADDRINUSE
+          abort_address_already_in_use(address)
         rescue Errno::EADDRNOTAVAIL
           raise AddressBindingError, "Error binding to the address #{http_bind}."
         end
@@ -98,6 +92,24 @@ module ShopifyCLI
           @app.close
           @syncer.shutdown
           WebServer.shutdown
+        end
+
+        private
+
+        def abort_address_already_in_use(address)
+          open_frame(@ctx.message("theme.serve.already_in_use_error"), color: :red) do
+            @ctx.puts(@ctx.message("theme.serve.address_already_in_use", address))
+          end
+
+          open_frame(@ctx.message("theme.serve.try_this"), color: :green) do
+            @ctx.puts(@ctx.message("theme.serve.try_port_option"))
+          end
+
+          raise BlankAbort
+        end
+
+        def open_frame(title, color:, &block)
+          CLI::UI::Frame.open(title, color: CLI::UI.resolve_color(color), timing: false, &block)
         end
       end
     end

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -124,7 +124,7 @@ module ShopifyCLI
           start_server_and_wait_sync_files
 
           @ctx.output_captured = true
-          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+          io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
             DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
           end
           @ctx.output_captured = false

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -64,15 +64,7 @@ module ShopifyCLI
         end
 
         def test_uploads_files_on_boot
-          # Get the checksums
-          stub_request(:any, ASSETS_API_URL)
-            .to_return(status: 200, body: "{}")
-          stub_request(:any, THEMES_API_URL)
-            .to_return(status: 200, body: "{}")
-
-          start_server
-          # Wait for server to start & sync the files
-          get("/assets/bogus.css")
+          start_server_and_wait_sync_files
 
           # Should upload all theme files except the ignored files
           ignored_files = [
@@ -99,15 +91,7 @@ module ShopifyCLI
         end
 
         def test_uploads_files_on_modification
-          # Get the checksums
-          stub_request(:any, ASSETS_API_URL)
-            .to_return(status: 200, body: "{}")
-          stub_request(:any, THEMES_API_URL)
-            .to_return(status: 200, body: "{}")
-
-          start_server
-          # Wait for server to start & sync the files
-          get("/assets/bogus.css")
+          start_server_and_wait_sync_files
 
           theme_root = "#{ShopifyCLI::ROOT}/test/fixtures/theme"
 
@@ -131,26 +115,28 @@ module ShopifyCLI
         end
 
         def test_serve_assets_locally
-          stub_request(:any, ASSETS_API_URL)
-            .to_return(status: 200, body: "{}")
-          stub_request(:any, THEMES_API_URL)
-            .to_return(status: 200, body: "{}")
-
-          start_server
-          response = get("/assets/theme.css")
+          response = start_server_and_wait_sync_files
 
           refute_server_errors(response)
         end
 
-        def test_streams_hot_reload_events
-          stub_request(:any, ASSETS_API_URL)
-            .to_return(status: 200, body: "{}")
-          stub_request(:any, THEMES_API_URL)
-            .to_return(status: 200, body: "{}")
+        def test_address_already_in_use
+          start_server_and_wait_sync_files
 
-          start_server
-          # Wait for server to start
-          get("/assets/theme.css")
+          @ctx.output_captured = true
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
+          end
+          @ctx.output_captured = false
+
+          io_messages = io.join
+
+          assert_match @ctx.message("theme.serve.address_already_in_use", "http://127.0.0.1:#{@@port}"), io_messages
+          assert_match @ctx.message("theme.serve.try_port_option"), io_messages
+        end
+
+        def test_streams_hot_reload_events
+          start_server_and_wait_sync_files
 
           # Send the SSE request
           socket = TCPSocket.new("127.0.0.1", @@port)
@@ -182,6 +168,18 @@ module ShopifyCLI
             puts e.message
             puts e.backtrace
           end
+        end
+
+        def start_server_and_wait_sync_files
+          # Get the checksums
+          stub_request(:any, ASSETS_API_URL)
+            .to_return(status: 200, body: "{}")
+          stub_request(:any, THEMES_API_URL)
+            .to_return(status: 200, body: "{}")
+
+          start_server
+          # Wait for server to start & sync the files
+          get("/assets/bogus.css")
         end
 
         def refute_server_errors(response)


### PR DESCRIPTION
Fix the `theme serve` service by rescuing the `Errno::EADDRINUSE` and showing a more friendly message for users (issue: https://github.com/Shopify/shopify-cli/issues/1620).

### WHY are these changes introduced?

Before this change, `Errno::EADDRINUSE` was not being handled and the standard error was appearing for users.

### WHAT is this pull request doing?

Now, this PR handles the `Errno::EADDRINUSE` error, and shows a more friendly message for users.

### How to test your changes?

1. Run `shopify theme serve` service
2. Open another Terminal window
3. Run the `shopify theme serve` again

Here's the previous behavior:
<img width=500 src="https://user-images.githubusercontent.com/1079279/141985911-22de66f6-e7b5-4235-8ffc-c58aa064bf53.gif">

Here's how it actual behavior (with this PR applied):
<img width=500 src="https://user-images.githubusercontent.com/1079279/141985904-650db46e-b3c6-42b6-bdcb-f9a06cd954eb.gif">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.