### PR TITLE
install javy binary on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ packaging/rpm/build
 packaging/rpm/shopify-cli.spec
 .byebug_history
 ext/shopify-extensions/shopify-extensions
-ext/javy/javy
+ext/javy/bin
 .console_history

--- a/ext/javy/javy.rb
+++ b/ext/javy/javy.rb
@@ -47,13 +47,13 @@ module Javy
       delete_outdated_installations
       install unless Installer.installed?(target: target)
     end
-  
+
     def delete_outdated_installations
       installed_binaries
         .reject { |v| v == target }
         .each { |file| File.delete(file) }
     end
-  
+
     def installed_binaries
       Dir[File.join(BIN_FOLDER, "javy-*")]
     end
@@ -101,6 +101,8 @@ module Javy
 
   Asset = Struct.new(:platform, :version, :owner, :repository, :basename, keyword_init: true) do
     def download(target:)
+      FileUtils.mkdir_p(BIN_FOLDER)
+
       Dir.chdir(File.dirname(target)) do
         File.open(File.basename(target), "wb") do |target_file|
           decompress(url.open, target_file)

--- a/test/ext/javy/javy_test.rb
+++ b/test/ext/javy/javy_test.rb
@@ -64,7 +64,7 @@ class JavyTest < Minitest::Test
     install(PlatformHelper.macos_config)
     run_build_and_expect_execution(dest: nil)
   end
-  
+
   def test_build_installs_javy_by_default
     stub_executable_download
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of Shopify/script-service#3718

We want Javy to be installed automatically at some point, but not at CLI installation because they might not use it.

### WHAT is this pull request doing?

Before the `shopify script javy` command is run, we perform an automatic check that Javy is installed. If the version is up to date, we do nothing. If it is out of date or not installed, we install the binary. 

To check the version of javy, I opted to store the version in the executable filename. This way, we can easily see if the version is out of date. 

### How to test your changes?

- Create a typescript script

1. Check that Javy is installed by default
    - Delete your javy installation at `shopify-cli/ext/javy/bin/*`
    - Run `shopify script javy --in build/index.js --out build/index.wasm` inside your script project. The command should succeed and a new javy executable should exist in `shopify-cli/ext/javy/bin/javy-v0.1.0`
2. Check that new versions of Javy are installed when the version changes
    - Rename your javy executable at `shopify-cli/ext/javy/bin/javy-v0.1.0` to `shopify-cli/ext/javy/bin/javy-v0.0.0`, to simulate that an older version is installed.
    - Run `shopify script javy --in build/index.js --out build/index.wasm`. The command should succeed. 
    - Ensure that `shopify-cli/ext/javy/bin/javy-v0.1.0` exists  and `javy-v0.0.0` was deleted.
3. Check that Javy isn't always installed, if the current version is okay
    - Turn off your wifi/internet connection
    - Run `shopify script javy --in build/index.js --out build/index.wasm`. The command should succeed.
    - Delete your javy installation at `shopify-cli/ext/javy/bin/*`
    - Run `shopify script javy --in build/index.js --out build/index.wasm`. The command should fail.

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).