### PR TITLE
Improved extension build output

### DIFF
--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -33,7 +33,7 @@ module Extension
 
         @ctx.puts(output)
       rescue => error
-        @ctx.abort(error.message)
+        raise ShopifyCLI::Abort, error.message
       end
 
       def run_legacy_flow

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -24,21 +24,16 @@ module Extension
       private
 
       def run_new_flow(project)
-        Tasks::RunExtensionCommand.new(
+        output = Tasks::RunExtensionCommand.new(
           type: project.specification_identifier.downcase,
           command: "build",
           config_file_name: specification_handler.server_config_file,
           context: @ctx,
         ).call
 
-        @ctx.puts(@ctx.message("build.build_success_message"))
+        @ctx.puts(output)
       rescue => error
-        if error.message.include?("no such file or directory")
-          @ctx.abort(@ctx.message("build.directory_not_found"))
-        else
-          @ctx.debug(error)
-          @ctx.abort(@ctx.message("build.build_failure_message"))
-        end
+        @ctx.abort(error.message)
       end
 
       def run_legacy_flow

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -67,9 +67,6 @@ module Extension
             Usage: {{command:%s extension build}}
         HELP
         frame_title: "Building extension with: %s…",
-        build_failure_message: "Failed to build extension code.",
-        build_success_message: "Build was successful!",
-        directory_not_found: "Build directory not found.",
       },
       register: {
         help: <<~HELP,

--- a/lib/project_types/extension/models/development_server.rb
+++ b/lib/project_types/extension/models/development_server.rb
@@ -33,8 +33,8 @@ module Extension
       end
 
       def build(server_config)
-        _, error, status = CLI::Kit::System.capture3(executable, "build", "-", stdin_data: server_config.to_yaml)
-        return if status.success?
+        output, error, status = CLI::Kit::System.capture3(executable, "build", "-", stdin_data: server_config.to_yaml)
+        return output if status.success?
         raise DevelopmentServerError, error
       end
 

--- a/test/project_types/extension/models/development_server_test.rb
+++ b/test/project_types/extension/models/development_server_test.rb
@@ -32,9 +32,10 @@ module Extension
 
           CLI::Kit::System.expects(:capture3)
             .with(@development_server.executable, "build", "-", stdin_data: server_config.to_yaml)
-            .returns(["", nil, mock(success?: true)])
+            .returns(["some output", nil, mock(success?: true)])
 
-          @development_server.build(server_config)
+          output = @development_server.build(server_config)
+          assert_equal "some output", output
         end
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

To provide more information during `shopify extension build`. Instead of using generic messages to report the build status, we now output the messages returned from ESBuild.

### WHAT is this pull request doing?

The new error and success messages look as follows.

**Error case**

<img width="495" alt="Screen Shot 2021-11-16 at 10 21 41 AM" src="https://user-images.githubusercontent.com/77060/142018574-2a2f9637-f2bd-4b4c-b0b2-11e76a5b9466.png">

**Success case**

<img width="487" alt="Screen Shot 2021-11-16 at 10 22 12 AM" src="https://user-images.githubusercontent.com/77060/142018577-3f99bc4c-1338-4b56-910e-6cd1f8315391.png">

### How to test your changes?

1. Enable the development server beta
    ```
    shopify config feature extension_server_beta --enable
    ```
2. Create a new extension
    ```
    shopify extension create
    ```
3. Run extension build and observe the new output
    ```
    shopify extension build
    ```

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~~I've included any post-release steps in the section above.~~
