### PR TITLE
Don't fail when PATHEXT is not defined

### DIFF
--- a/vendor/deps/cli-kit/lib/cli/kit/system.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/system.rb
@@ -222,7 +222,7 @@ module CLI
         end
 
         def which(cmd, env)
-          exts = os == :windows ? env.fetch('PATHEXT').split(';') : ['']
+          exts = os == :windows ? env.fetch('PATHEXT', ['']).split(';') : ['']
           env.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |path|
             exts.each do |ext|
               exe = File.join(path, "#{cmd}#{ext}")


### PR DESCRIPTION
### WHY are these changes introduced?
The `which` method in `system.rb` uses Windows' [EXTPATH](https://www.nextofwindows.com/what-is-pathext-environment-variable-in-windows) environment variable to get the list of supported extensions for executables. Although it works for some users, others run into a runtime error because we assume the variable is always present and that's not true.

### WHAT is this pull request doing?
I'm adjusting the logic to not assume that the variable is always defined in Windows' environments.

### How to test your changes?
This is a tricky one to test because it requires a Windows' environment.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.