### PR TITLE
Ensure RunExtensionCommand receives context

### DIFF
--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -28,6 +28,7 @@ module Extension
           type: project.specification_identifier.downcase,
           command: "build",
           config_file_name: specification_handler.server_config_file,
+          context: @ctx,
         ).call
 
         @ctx.puts(@ctx.message("build.build_success_message"))

--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -13,7 +13,7 @@ module Extension
       property  :resource_url, accepts: String
       property! :store, accepts: String
       property! :title, accepts: String
-      property! :tunnel_url, accepts: String
+      property :tunnel_url, accepts: String
       property! :type, accepts: String
 
       def self.call(*args)

--- a/lib/project_types/extension/tasks/run_extension_command.rb
+++ b/lib/project_types/extension/tasks/run_extension_command.rb
@@ -15,7 +15,7 @@ module Extension
 
       property! :command, accepts: SUPPORTED_COMMANDS
       property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
-      property :context, accepts: ShopifyCLI::Context
+      property! :context, accepts: ShopifyCLI::Context
       property :config_file_name, accepts: String
       property :port, accepts: Integer, default: 39351
       property :resource_url, accepts: String

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -47,7 +47,12 @@ module Extension
 
         Models::DevelopmentServerRequirements.expects(:supported?).with(type).returns(true)
 
-        command = Tasks::RunExtensionCommand.new(type: type.downcase, command: "build", config_file_name: config_file)
+        command = Tasks::RunExtensionCommand.new(
+          type: type.downcase,
+          command: "build",
+          config_file_name: config_file,
+          context: @context
+        )
         Tasks::RunExtensionCommand.expects(:new).returns(command) do |cmd|
           cmd.expects(:call)
         end

--- a/test/project_types/extension/tasks/run_extension_command_test.rb
+++ b/test/project_types/extension/tasks/run_extension_command_test.rb
@@ -32,7 +32,8 @@ module Extension
             root_dir: "test",
             template: "javascript",
             type: "checkout_ui_extension",
-            command: "create"
+            command: "create",
+            context: context,
           ).call
         end
       end
@@ -62,7 +63,8 @@ module Extension
             root_dir: "test",
             template: "javascript",
             type: "checkout_ui_extension",
-            command: "build"
+            command: "build",
+            context: context,
           ).call
         end
       end
@@ -90,7 +92,8 @@ module Extension
             root_dir: "test",
             template: "javascript",
             type: "checkout_ui_extension",
-            command: "serve"
+            command: "serve",
+            context: context,
           ).call
         end
       end
@@ -115,7 +118,8 @@ module Extension
           template: "javascript",
           type: "checkout_ui_extension",
           command: "build",
-          config_file_name: "test"
+          config_file_name: "test",
+          context: context,
         ).call
       end
 
@@ -138,6 +142,10 @@ module Extension
           user: Models::ServerConfig::User.new,
           development: development
         )
+      end
+
+      def context
+        TestHelpers::FakeContext.new
       end
     end
   end


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Ensure extensions can be build using the new extension development server.

### WHAT is this pull request doing?

Make RunExtensionCommand#context a required property to ensure that the context is allways passed down the stack.;

### How to test your changes?

Build an extension with the new extension development server and see it succeed (as opposed to fail before)


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~~I've included any post-release steps in the section above.~~
