### PR TITLE
Fix tunnel creation for expired anonymous tunnels

### DIFF
--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -764,7 +764,7 @@ module ShopifyCLI
             Anonymized reports will be sent to Shopify.
           MESSAGE
           turned_off_message: <<~MESSAGE,
-            Turn on automatic reporting later wtih {{command:%s reporting on}}.
+            Turn on automatic reporting later with {{command:%s reporting on}}.
           MESSAGE
         },
         whoami: {

--- a/test/shopify-cli/tunnel_test.rb
+++ b/test/shopify-cli/tunnel_test.rb
@@ -4,6 +4,7 @@ module ShopifyCLI
   class TunnelTest < MiniTest::Test
     def setup
       ShopifyCLI::Tunnel.any_instance.stubs(:install)
+      ShopifyCLI::Tunnel.any_instance.stubs(:auth?).returns(false)
       super
     end
 
@@ -12,45 +13,49 @@ module ShopifyCLI
       ShopifyCLI::Tunnel.auth(@context, "token")
     end
 
-    def test_start_running_returns_url
-      ShopifyCLI::ProcessSupervision.stubs(:running?)
-        .with(:ngrok).returns(:true)
+    def test_auth_check_with_authtoken
+      ShopifyCLI::Tunnel.any_instance.unstub(:auth?)
+      File.stubs(:read).with(File.join(Dir.home, ".ngrok2/ngrok.yml")).returns("authtoken: wadus")
+
+      assert ShopifyCLI::Tunnel.auth?
+    end
+
+    def test_auth_check_without_authtoken
+      ShopifyCLI::Tunnel.any_instance.unstub(:auth?)
+      File.stubs(:read).with(File.join(Dir.home, ".ngrok2/ngrok.yml")).returns("wadus")
+      refute ShopifyCLI::Tunnel.auth?
+    end
+
+    def test_auth_check_without_config_file
+      ShopifyCLI::Tunnel.any_instance.unstub(:auth?)
+      refute ShopifyCLI::Tunnel.auth?
+    end
+
+    def test_start_running_with_account_returns_url
       with_log do
-        ShopifyCLI::Tunnel.start(@context)
+        ShopifyCLI::Tunnel.any_instance.stubs(:auth?).returns(true)
+        ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(:true)
+        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
+      end
+    end
+
+    def test_start_running_returns_url
+      with_log do
+        ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(true)
+        ShopifyCLI::ProcessSupervision.expects(:stop).with(:ngrok).returns(true)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(:ngrok, ngrok_start_command)
+          .returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
     end
 
     def test_start_not_running_starts_ngrok
       with_log do
-        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCLI::ProcessSupervision.expects(:start).with(
-          :ngrok,
-          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
+        ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:stop).with(:ngrok).returns(true)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(:ngrok, ngrok_start_command)
+          .returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
-        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
-        @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
-        assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
-      end
-    end
-
-    def test_start_running_timed_out_restarts_ngrok
-      start_time = Time.now.to_i - (60 * 60 * 9)
-      with_log(time: start_time.to_s) do
-        ShopifyCLI::ProcessSupervision.expects(:start).twice.with(
-          :ngrok,
-          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(
-          ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000, time: start_time.to_s)
-        ).then.returns(
-          ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000)
-        )
-        @context.expects(:puts).with(@context.message("core.tunnel.timed_out"))
-        ShopifyCLI::ProcessSupervision.expects(:stop)
-          .with(:ngrok).returns(true)
-        @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
-        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
         @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
         assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context)
       end
@@ -59,14 +64,11 @@ module ShopifyCLI
     def test_start_accepts_configurable_port
       configured_port = 3000
       with_log do
-        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCLI::ProcessSupervision.expects(:start).with(
-          :ngrok,
-          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false"\
-            " -log=stdout -log-level=debug #{configured_port}"
-        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
+        ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:stop).with(:ngrok).returns(true)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(:ngrok, ngrok_start_command(port: configured_port))
+          .returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(@context.message("core.tunnel.start", "https://example.ngrok.io"))
-        @context.expects(:puts).with(@context.message("core.tunnel.will_timeout", "7 hours 59 minutes"))
         @context.expects(:puts).with(@context.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
         assert_equal "https://example.ngrok.io", ShopifyCLI::Tunnel.start(@context, port: configured_port)
       end
@@ -74,11 +76,10 @@ module ShopifyCLI
 
     def test_start_displays_url_with_account
       with_log(fixture: "ngrok_account") do
-        ShopifyCLI::ProcessSupervision.stubs(:running?).returns(false)
-        ShopifyCLI::ProcessSupervision.expects(:start).with(
-          :ngrok,
-          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
+        ShopifyCLI::Tunnel.any_instance.stubs(:auth?).returns(true)
+        ShopifyCLI::ProcessSupervision.stubs(:running?).with(:ngrok).returns(false)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(:ngrok, ngrok_start_command)
+          .returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         @context.expects(:puts).with(
           @context.message("core.tunnel.start_with_account", "https://example.ngrok.io", "Tom Cruise")
         )
@@ -88,10 +89,9 @@ module ShopifyCLI
 
     def test_start_raises_error_on_ngrok_failure
       with_log(fixture: "ngrok_error") do
-        ShopifyCLI::ProcessSupervision.expects(:start).with(
-          :ngrok,
-          "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug 8081"
-        ).returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
+        ShopifyCLI::ProcessSupervision.expects(:stop).with(:ngrok).returns(true)
+        ShopifyCLI::ProcessSupervision.expects(:start).with(:ngrok, ngrok_start_command)
+          .returns(ShopifyCLI::ProcessSupervision.new(:ngrok, pid: 40000))
         assert_raises ShopifyCLI::Tunnel::NgrokError do
           ShopifyCLI::Tunnel.start(@context)
         end
@@ -180,6 +180,10 @@ module ShopifyCLI
 
     def fake_ngrok_api_response
       @ngrok_api_response ||= JSON.parse(File.read(File.join(ShopifyCLI::ROOT, "test", "fixtures", "ngrok_api.json")))
+    end
+
+    def ngrok_start_command(port: 8081)
+      "\"#{File.join(ShopifyCLI.cache_dir, "ngrok")}\" http -inspect=false -log=stdout -log-level=debug #{port}"
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1747
Fixes #952
Fixes #1742

When starting a new tunnel (used from `app serve`), we were reading from the ngrok log the remaining time of the tunnel in order to re-create it when expired. And for some reason now ngrok is not returning that duration, but always `0`, making the CLI to think that they are always expired. We have already asked ngrok about that.

### WHAT is this pull request doing?

For anonymous tunnels, always restart them when calling `start`. The disadvantage is that a new URL will be generated each time (before, the URL only changed every 2h).

This is a hotfix to prevent the current problems, but the tunnel management in general should be reviewed.

### How to test your changes?

`shopify app tunnel start`, without having a ngrok authtoken (which it's stored in `~/.ngrok2/ngrok.yml`)

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.