### PR TITLE
Fix crash when using deprecated Script API

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -56,8 +56,15 @@ module Script
           end
         end
 
+        class DeprecatedEPError < ScriptProjectError
+          attr_reader(:extension_point)
+          def initialize(extension_point)
+            super()
+            @extension_point = extension_point
+          end
+        end
+
         class DependencyInstallError < ScriptProjectError; end
-        class DeprecatedEPError < ScriptProjectError; end
         class EmptyResponseError < ScriptProjectError; end
         class InvalidResponseError < ScriptProjectError; end
         class ForbiddenError < ScriptProjectError; end

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -74,7 +74,7 @@ module Script
           }
         when Layers::Infrastructure::Errors::DeprecatedEPError
           {
-            cause_of_error: ShopifyCLI::Context.message("script.error.deprecated_ep", e.ep),
+            cause_of_error: ShopifyCLI::Context.message("script.error.deprecated_ep", e.extension_point),
             help_suggestion: ShopifyCLI::Context.message("script.error.deprecated_ep_cause"),
           }
         when Layers::Domain::Errors::InvalidExtensionPointError

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -281,6 +281,13 @@ describe Script::UI::ErrorHandler do
           should_call_display_and_raise
         end
       end
+
+      describe "when DeprecatedEPError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::DeprecatedEPError.new("some_api") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Creating a new script project with a deprecated Script API (a.k.a
extension point) would crash:

```
$ shopify script create --language=typescript --name="new-project" \
  --extension-point=payment_filter

✗ An unexpected error occured.
	To submit an issue include the stack trace.
```

The error is a `NoMethodError` for `DeprecatedEPError#ep`.
This commit fixes that.

### How to test your changes?

Run the above command, see it crash on `main`, and not crash with this branch.

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ -> Is this worth a CHANGELOG entry given Scripts is in beta, and the enrollments are close? My 2¢: not worth the noise.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~I've included any post-release steps in the section above.~