### PR TITLE
Abort from OptionParser errors

### DIFF
--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -29,6 +29,12 @@ module ShopifyCLI
           run_prerequisites
           cmd.call(args, command_name)
         end
+      rescue OptionParser::InvalidOption => error
+        arg = error.args.first
+        raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option", arg)
+      rescue OptionParser::MissingArgument => error
+        arg = error.args.first
+        raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.missing_argument", arg)
       end
 
       def options(&block)

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -14,6 +14,12 @@ module ShopifyCLI
         },
       },
       core: {
+        errors: {
+          option_parser: {
+            invalid_option: "The option {{command:%s}} is not supported.",
+            missing_argument: "The required argument {{command:%s}} is missing.",
+          },
+        },
         app: {
           help: <<~HELP,
           Suite of commands for developing apps. See {{command:%1$s app <command> --help}} for usage of each command.

--- a/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb
@@ -114,7 +114,9 @@ module CLI
       end
 
       def print_error_message(e)
-        $stderr.puts(format_error_message(e.message))
+        CLI::UI::Frame.open("Error", color: :red, timing: false) do
+          $stderr.puts(format_error_message(e.message))
+        end
       end
     end
   end


### PR DESCRIPTION
[Error 1](https://app.bugsnag.com/shopify/shopify-cli/errors/615df2bca7796200085185bc?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in]=2.7.0)
[Error 2](https://app.bugsnag.com/shopify/shopify-cli/errors/615c602b14a5fc000787762e?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in]=2.7.0)
[Error 3](https://app.bugsnag.com/shopify/shopify-cli/errors/615e23e3d8331a0008df58b0?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in]=2.7.0)

### WHY are these changes introduced?
Errors parsing the CLI arguments should not be reported to Bugsnag because they are not bugs.

### WHAT is this pull request doing?
I'm rescuing from them and raising them as aborts that are formatted and output to the user consistently.

### How to test your changes?
Try to run the CLI with an invalid argument: `shopify app create --invalid argument`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.