### PR TITLE
Backport SubCommand nesting change to javy command

### DIFF
--- a/lib/project_types/script/commands/javy.rb
+++ b/lib/project_types/script/commands/javy.rb
@@ -4,7 +4,7 @@ require_relative "../../../../ext/javy/javy.rb"
 
 module Script
   class Command
-    class Javy < ShopifyCLI::SubCommand
+    class Javy < ShopifyCLI::Command::SubCommand
       hidden_feature
 
       prerequisite_task ensure_project_type: :script


### PR DESCRIPTION
### WHY are these changes introduced?

This PR https://github.com/Shopify/shopify-cli/pull/1650 moved the `SubCommand` class under `Command::SubCommand`. The PRs adding the Javy command https://github.com/Shopify/shopify-cli/pull/1675 did not have this change, so CI started to fail when the PR merged 💥 

### WHAT is this pull request doing?

Updates the reference of `SubCommand` to `Command::SubCommand`.

### How to test your changes?

Run `dev test`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.