### PR TITLE
Fix: Tunnel --PORT parameter not working in Node.js app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
+* [#1763](https://github.com/Shopify/shopify-cli/pull/1722): Fix: Tunnel --PORT parameter not working in Node.js app.
 
 ## Version 2.7.1
 ### Fixed
-* [#1722](https://github.com/Shopify/shopify-cli/pull/1722): Fix `theme serve` failing when the port is already being used
+* [#1722](https://github.com/Shopify/shopify-cli/pull/1763): Fix `theme serve` failing when the port is already being used
 * [#1751](https://github.com/Shopify/shopify-cli/pull/1751): A bug in the app creation flow that caused the CLI to abort when the form validation failed.
 * [#1750](https://github.com/Shopify/shopify-cli/pull/1750): Runtime errors in Windows' environments when the `PATHEXT` environment variable is not defined. 
 * [#1758](https://github.com/Shopify/shopify-cli/pull/1758): Fix tunnel creation for expired anonymous tunnels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
 ### Fixed
-* [#1763](https://github.com/Shopify/shopify-cli/pull/1722): Fix: Tunnel --PORT parameter not working in Node.js app.
+* [#1763](https://github.com/Shopify/shopify-cli/pull/1763): Fix: Tunnel --PORT parameter not working in Node.js app.
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
 
 ## Version 2.7.1
 ### Fixed
-* [#1722](https://github.com/Shopify/shopify-cli/pull/1763): Fix `theme serve` failing when the port is already being used
+* [#1722](https://github.com/Shopify/shopify-cli/pull/1722): Fix `theme serve` failing when the port is already being used
 * [#1751](https://github.com/Shopify/shopify-cli/pull/1751): A bug in the app creation flow that caused the CLI to abort when the form validation failed.
 * [#1750](https://github.com/Shopify/shopify-cli/pull/1750): Runtime errors in Windows' environments when the `PATHEXT` environment variable is not defined. 
 * [#1758](https://github.com/Shopify/shopify-cli/pull/1758): Fix tunnel creation for expired anonymous tunnels

--- a/lib/shopify_cli/services/app/serve/node_service.rb
+++ b/lib/shopify_cli/services/app/serve/node_service.rb
@@ -14,7 +14,7 @@ module ShopifyCLI
 
           def call
             project = ShopifyCLI::Project.current
-            url = host || ShopifyCLI::Tunnel.start(context)
+            url = host || ShopifyCLI::Tunnel.start(context, port: port)
             raise ShopifyCLI::Abort,
               context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
             project.env.update(context, :host, url)

--- a/lib/shopify_cli/services/app/serve/rails_service.rb
+++ b/lib/shopify_cli/services/app/serve/rails_service.rb
@@ -14,7 +14,7 @@ module ShopifyCLI
 
           def call
             project = ShopifyCLI::Project.current
-            url = host || ShopifyCLI::Tunnel.start(context)
+            url = host || ShopifyCLI::Tunnel.start(context, port: port)
             raise ShopifyCLI::Abort,
               context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
             project.env.update(context, :host, url)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.7.0"
+  VERSION = "2.7.1"
 end

--- a/test/shopify-cli/services/app/serve/node_service_test.rb
+++ b/test/shopify-cli/services/app/serve/node_service_test.rb
@@ -100,7 +100,6 @@ module ShopifyCLI
           end
 
           def test_call_when_port_passed
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tunnel.expects(:start).with(@context, port: 5000).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)

--- a/test/shopify-cli/services/app/serve/node_service_test.rb
+++ b/test/shopify-cli/services/app/serve/node_service_test.rb
@@ -101,6 +101,7 @@ module ShopifyCLI
 
           def test_call_when_port_passed
             ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+            ShopifyCLI::Tunnel.expects(:start).with(@context, port: 5000).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.expects(:system).with(

--- a/test/shopify-cli/services/app/serve/php_service_test.rb
+++ b/test/shopify-cli/services/app/serve/php_service_test.rb
@@ -129,6 +129,7 @@ module ShopifyCLI
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)
             ShopifyCLI::ProcessSupervision.expects(:stop).never
             ShopifyCLI::ProcessSupervision.expects(:start).with(:npm_watch, "npm run watch", force_spawn: true)
+            ShopifyCLI::Tunnel.expects(:start).with(@context, port: 5000).returns("https://example.com")
 
             @context.expects(:system).with(
               "php",

--- a/test/shopify-cli/services/app/serve/php_service_test.rb
+++ b/test/shopify-cli/services/app/serve/php_service_test.rb
@@ -123,7 +123,6 @@ module ShopifyCLI
           end
 
           def test_server_command_when_port_passed
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)

--- a/test/shopify-cli/services/app/serve/rails_service_test.rb
+++ b/test/shopify-cli/services/app/serve/rails_service_test.rb
@@ -83,6 +83,7 @@ module ShopifyCLI
 
           def test_server_command_when_port_passed
             ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
+            ShopifyCLI::Tunnel.expects(:start).with(@context, port: 5000).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")

--- a/test/shopify-cli/services/app/serve/rails_service_test.rb
+++ b/test/shopify-cli/services/app/serve/rails_service_test.rb
@@ -82,7 +82,6 @@ module ShopifyCLI
           end
 
           def test_server_command_when_port_passed
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tunnel.expects(:start).with(@context, port: 5000).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
After version 2.7.0, we no longer can use a custom port for `ngrok` tunnel. Seem like there was a missing parameter in the `node_service.rb`

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Add the `port` parameter to the tunnel start function.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
For Node.js project, assume you want to tunnel the `localhost:3000`. 
This command should work: `shopify app serve --PORT 3000`
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.