### PR TITLE
Fix `theme serve` failing with the `--host` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 ### Fixed
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
+* [#1766](https://github.com/Shopify/shopify-cli/pull/1766): Fix `theme serve` failing with the `--host` property
 
 ## Version 2.7.1
 ### Fixed

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -15,7 +15,7 @@ module Theme
       def call(*)
         flags = options.flags.dup
         host = flags[:host] || DEFAULT_HTTP_HOST
-        ShopifyCLI::Theme::DevServer.start(@ctx, ".", http_bind: host, **flags) do |syncer|
+        ShopifyCLI::Theme::DevServer.start(@ctx, ".", host: host, **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
       rescue ShopifyCLI::Theme::DevServer::AddressBindingError

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -24,7 +24,7 @@ module ShopifyCLI
       class << self
         attr_accessor :ctx
 
-        def start(ctx, root, http_bind: "127.0.0.1", port: 9292, poll: false)
+        def start(ctx, root, host: "127.0.0.1", port: 9292, poll: false)
           @ctx = ctx
           theme = DevelopmentTheme.new(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
@@ -36,7 +36,7 @@ module ShopifyCLI
           @app = LocalAssets.new(ctx, @app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, ignore_filter: ignore_filter)
           stopped = false
-          address = "http://#{http_bind}:#{port}"
+          address = "http://#{host}:#{port}"
 
           theme.ensure_exists!
 
@@ -70,7 +70,7 @@ module ShopifyCLI
           watcher.start
           WebServer.run(
             @app,
-            BindAddress: http_bind,
+            BindAddress: host,
             Port: port,
             Logger: logger,
             AccessLog: [],
@@ -83,7 +83,7 @@ module ShopifyCLI
         rescue Errno::EADDRINUSE
           abort_address_already_in_use(address)
         rescue Errno::EADDRNOTAVAIL
-          raise AddressBindingError, "Error binding to the address #{http_bind}."
+          raise AddressBindingError, "Error binding to the address #{host}."
         end
 
         def stop

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -11,7 +11,7 @@ module Theme
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST)
+          .with(context, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
 
         Theme::Command::Serve.new(context).call
       end
@@ -20,7 +20,7 @@ module Theme
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST)
+          .with(context, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
           .raises(ShopifyCLI::Theme::DevServer::AddressBindingError)
 
         assert_raises ShopifyCLI::Abort do
@@ -30,17 +30,17 @@ module Theme
 
       def test_can_specify_bind_address
         context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", http_bind: "0.0.0.0")
+        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", host: "0.0.0.0")
 
         command = Theme::Command::Serve.new(context)
-        command.options.flags[:http_bind] = "0.0.0.0"
+        command.options.flags[:host] = "0.0.0.0"
         command.call
       end
 
       def test_can_specify_port
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
-          http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST, port: 9293)
+          host: Theme::Command::Serve::DEFAULT_HTTP_HOST, port: 9293)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:port] = 9293
@@ -50,7 +50,7 @@ module Theme
       def test_can_specify_poll
         context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
-          http_bind: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)
+          host: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)
 
         command = Theme::Command::Serve.new(context)
         command.options.flags[:poll] = true


### PR DESCRIPTION
Fix `theme serve` failing with the `--host` property (https://github.com/Shopify/shopify-cli/issues/1765) by renaming the parameters from `http_bind` to `host`.
 
### WHY are these changes introduced?

This was failing because we were calling `DevServer#start` in the `theme/commands/serve.rb` file with the `**flags` and the names were different.

### WHAT is this pull request doing?

This PR renames parameters from `http_bind` to `host`.

### How to test your changes?

```
shopify theme serve --host=0.0.0.0
```

Here's the previous behavior:
<img width=500 src="https://user-images.githubusercontent.com/1079279/142185137-b033d620-8fce-4a66-8d12-3b72a1e6d0fb.gif">

Here's how it actual behavior (with this PR applied):
<img width=500 src="https://user-images.githubusercontent.com/1079279/142185263-b44d63f6-91da-452c-8e2e-444de450b669.gif">

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.