### PR TITLE
Fix `theme push --development --json` to output errors in the STDERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1763](https://github.com/Shopify/shopify-cli/pull/1763): Fix: Tunnel --PORT parameter not working in Node.js app.
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
 * [#1766](https://github.com/Shopify/shopify-cli/pull/1766): Fix `theme serve` failing with the `--host` property
+* [#1771](https://github.com/Shopify/shopify-cli/pull/1771): Fix `theme push --development --json` to output errors in the STDERR
 
 ## Version 2.7.1
 ### Fixed

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -357,6 +357,15 @@ module ShopifyCLI
       Kernel.puts(CLI::UI.fmt(*args))
     end
 
+    # a wrapper around $stderr.puts to allow for easy formatting
+    #
+    # #### Parameters
+    # * `text` - a string message to output
+    #
+    def error(*args)
+      $stderr.puts(CLI::UI.fmt(*args))
+    end
+
     # a wrapper around Kernel.warn to allow for easy formatting
     #
     # #### Parameters

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -362,8 +362,8 @@ module ShopifyCLI
     # #### Parameters
     # * `text` - a string message to output
     #
-    def error(*args)
-      $stderr.puts(CLI::UI.fmt(*args))
+    def error(text)
+      $stderr.puts(CLI::UI.fmt(text))
     end
 
     # a wrapper around Kernel.warn to allow for easy formatting

--- a/lib/shopify_cli/theme/syncer/error_reporter.rb
+++ b/lib/shopify_cli/theme/syncer/error_reporter.rb
@@ -32,7 +32,7 @@ module ShopifyCLI
             @delayed_errors << error_message
           else
             @has_any_error = true
-            @ctx.puts(error_message)
+            @ctx.error(error_message)
           end
         end
 

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -10,6 +10,24 @@ module ShopifyCLI
       @ctx = Context.new
     end
 
+    def test_puts
+      expected_stdout = /info message/
+      expected_stderr = /^$/
+
+      assert_output(expected_stdout, expected_stderr) do
+        @ctx.puts("info message")
+      end
+    end
+
+    def test_error
+      expected_stdout = /^$/
+      expected_stderr = /error message/
+
+      assert_output(expected_stdout, expected_stderr) do
+        @ctx.error("error message")
+      end
+    end
+
     def test_write_writes_to_file_in_project
       @ctx.root = Dir.mktmpdir
       @ctx.write(".env", "foobar")

--- a/test/shopify-cli/theme/syncer/error_reporter_test.rb
+++ b/test/shopify-cli/theme/syncer/error_reporter_test.rb
@@ -50,7 +50,7 @@ module ShopifyCLI
         end
 
         def test_has_any_error_when_an_error_was_reported
-          @error_reporter.report_error("error 1")
+          capture_io { @error_reporter.report_error("error 1") }
           assert(@error_reporter.has_any_error?)
         end
       end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -194,6 +194,7 @@ module ShopifyCLI
       def test_theme_files_are_pending_during_upload
         file = @theme.static_asset_files.first
 
+        @ctx.expects(:error).once
         @syncer.enqueue_updates([file])
         assert_includes(@syncer.pending_updates, file)
 
@@ -206,7 +207,7 @@ module ShopifyCLI
         @syncer.start_threads
 
         file = @theme.static_asset_files.first
-        @ctx.expects(:puts).once
+        @ctx.expects(:error).once
         ShopifyCLI::AdminAPI.expects(:rest_request).raises(RuntimeError.new("oops"))
 
         @syncer.enqueue_updates([file])
@@ -420,7 +421,7 @@ module ShopifyCLI
             "message", response: mock(body: response_body)
           ))
 
-        @ctx.expects(:puts).with(<<~EOS.chomp)
+        @ctx.expects(:error).with(<<~EOS.chomp)
           {{red:ERROR}} {{blue:update sections/footer.liquid}}:
             An error
             Then some
@@ -445,7 +446,7 @@ module ShopifyCLI
             "exception message", response: mock(body: response_body)
           ))
 
-        @ctx.expects(:puts).with(<<~EOS.chomp)
+        @ctx.expects(:error).with(<<~EOS.chomp)
           {{red:ERROR}} {{blue:update sections/footer.liquid}}:
             exception message
         EOS
@@ -472,7 +473,7 @@ module ShopifyCLI
             "message", response: mock(body: response_body)
           ))
 
-        @ctx.expects(:puts).never
+        @ctx.expects(:error).never
 
         @syncer.delay_errors!
         @syncer.enqueue_updates([file])
@@ -481,7 +482,7 @@ module ShopifyCLI
         # Assert @ctx.puts was not called
         mocha_verify
 
-        @ctx.expects(:puts).with(<<~EOS.chomp)
+        @ctx.expects(:error).with(<<~EOS.chomp)
           {{red:ERROR}} {{blue:update sections/footer.liquid}}:
             An error
             Then some


### PR DESCRIPTION
This PR is the second (and final) part of the https://github.com/Shopify/shopify-cli/issues/1353 fix.

When users perform a `theme push --development --json` operation and get errors, only the JSON should be outputted to STDOUT, and the errors should be outputted to STDERR. Thus, users can build scripts on top of `theme push` operations.

### WHY are these changes introduced?

These changes improve the `ShopifyCLI::Theme::Syncer::ErrorReporter` to output the errors at the STDERR level.

### WHAT is this pull request doing?

This PR introduces the `ShopifyCLI::Context#error` method, a wrapper around `$stderr.puts`. Which is similar to the `ShopifyCLI::Context#puts` that wraps `Kernel#puts`/`$stdout.puts`.

The `ShopifyCLI::Theme::Syncer::ErrorReporter` uses that to report errors at the STDERR level.

### How to test your changes?

Run the following command to get the `preview_url`:
```
shopify theme push --development --json | jq -r '.theme.preview_url'
```

Here's the previous behavior:
<img width=500 src="https://user-images.githubusercontent.com/1079279/142394752-a2555d68-e11c-4842-87fa-d8aa370905ab.png">

Here's how it actual behavior (with this PR applied):
<img width=500 src="https://user-images.githubusercontent.com/1079279/142394789-09749c3e-a68c-4bc0-8708-726b0c6ab896.png">

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.