### PR TITLE
Add marketplace option to app create node command

### DIFF
--- a/lib/shopify_cli/commands/app/create/node.rb
+++ b/lib/shopify_cli/commands/app/create/node.rb
@@ -13,6 +13,7 @@ module ShopifyCLI
             parser.on("--store-domain=MYSHOPIFYDOMAIN") { |url| flags[:store_domain] = url }
             parser.on("--type=APPTYPE") { |type| flags[:type] = type }
             parser.on("--verbose") { flags[:verbose] = true }
+            parser.on("--marketplace") { flags[:marketplace] = true }
           end
 
           def call(*)
@@ -22,6 +23,7 @@ module ShopifyCLI
               store_domain: options.flags[:store_domain],
               type: options.flags[:type],
               verbose: !options.flags[:verbose].nil?,
+              marketplace: !options.flags[:marketplace].nil?,
               context: @ctx
             )
           end

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -85,6 +85,7 @@ module ShopifyCLI
                     {{command:--name=NAME}} App name. Any string.
                     {{command:--organization-id=ID}} Partner organization ID. Must be an existing organization.
                     {{command:--store-domain=MYSHOPIFYDOMAIN }} Development store URL. Must be an existing development store.
+                    {{command:--marketplace }} Creates a marketplace app.
               HELP
               error: {
                 node_required: "node is required to create an app project. Download at https://nodejs.org/en/download.",

--- a/lib/shopify_cli/services/app/create/node_service.rb
+++ b/lib/shopify_cli/services/app/create/node_service.rb
@@ -5,15 +5,16 @@ module ShopifyCLI
     module App
       module Create
         class NodeService < BaseService
-          attr_reader :context, :name, :organization_id, :store_domain, :type, :verbose
+          attr_reader :context, :name, :organization_id, :store_domain, :type, :verbose, :marketplace
 
-          def initialize(name:, organization_id:, store_domain:, type:, verbose:, context:)
+          def initialize(name:, organization_id:, store_domain:, type:, verbose:, marketplace:, context:)
             @name = name
             @organization_id = organization_id
             @store_domain = store_domain
             @type = type
             @verbose = verbose
             @context = context
+            @marketplace = marketplace
             super()
           end
 
@@ -132,6 +133,10 @@ module ShopifyCLI
             ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-node.git", name)
 
             context.root = File.join(context.root, name)
+
+            if @marketplace
+              context.capture2e("git", "-C", context.root, "checkout", "922ec7f8a62d7601e2caa27d34e5b803d257cef4")
+            end
 
             set_npm_config
             ShopifyCLI::JsDeps.install(context, verbose)


### PR DESCRIPTION
### WHY are these changes introduced?
* the marketplace kit team created a set of [tutorials](https://shopify.dev/marketplaces/getting-started/get-started-with-shopify-marketplace-kit) that build on the boilerplate app generated using `shopify app create node` 
* that app boilerplate has since been updated and the tutorials are no longer aligned with the app generated from the CLI
* we need a marketplace specific option for app creation via the CLI, so we can ensure the tutorials work with the app generated via the CLI. in the future we plan on cloning a separate repo for marketplace apps, instead of checking out an old commit.

### WHAT is this pull request doing?
* add a new `--marketplace` option to the `shopify app create node` command
* if this flag is provided, checkout the [appropriate commit](https://github.com/Shopify/shopify-app-node/commit/922ec7f8a62d7601e2caa27d34e5b803d257cef4) in the boilerplate app repo that aligns the tutorials 
* the option to the help message for the `app create node` command

### How to test your changes?
* checkout this branch 
* run `dev up`
* run the following command `bundle exec shopify-dev app create node --marketplace`
* follow the prompts for a public app 
* verify that the node app created is consistent with main branch at the [time of the old commit](https://github.com/Shopify/shopify-app-node/tree/922ec7f8a62d7601e2caa27d34e5b803d257cef4)
* run the following command `bundle exec shopify-dev app create node` 
* follow the prompts for a public app 
* verify that a node app is created is consistent with the current state of the main branch 

### Post-release steps
* update the dev docs to include the new command option in the [marketplace requirements section](https://shopify.dev/marketplaces/getting-started/get-started-with-shopify-marketplace-kit#requirements)


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.