### PR TITLE
Fix ngrok installation check on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
 * [#1766](https://github.com/Shopify/shopify-cli/pull/1766): Fix `theme serve` failing with the `--host` property
 * [#1771](https://github.com/Shopify/shopify-cli/pull/1771): Fix `theme push --development --json` to output errors in the STDERR
+* [#1778](https://github.com/Shopify/shopify-cli/pull/1778): Fix ngrok installation check on Windows 
 
 ## Version 2.7.1
 ### Fixed


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1776

After installing ngrok, the CLI is checking if the executable is present, but since [this change](https://github.com/Shopify/shopify-cli/pull/1758) released with the version 2.7.1, on Windows it's looking for a `ngrok` file instead of `ngrok.exe`, causing the installation to fail.

### WHAT is this pull request doing?

Fix the executable name for Windows environments.

### How to test your changes?

`shopify app serve` on Windows

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.