### PR TITLE
Remove Deprecated Script APIs

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,29 +1,3 @@
-discount:
-  deprecated: true
-  libraries:
-    assemblyscript:
-      package: "@shopify/extension-point-as-discount"
-unit_limit_per_order:
-  beta: true
-  libraries:
-    assemblyscript:
-      package: "@shopify/extension-point-as-unit-limit-per-order"
-payment_filter:
-  deprecated: true
-  libraries:
-    assemblyscript:
-      package: "@shopify/extension-point-as-payment-filter"
-shipping_filter:
-  deprecated: true
-  libraries:
-    assemblyscript:
-      package: "@shopify/extension-point-as-shipping-filter"
-tax_filter:
-  beta: true
-  libraries:
-    assemblyscript:
-      repo: "https://github.com/Shopify/extension-points.git"
-      package: "@shopify/extension-point-as-tax-filter"
 payment_methods:
   domain: 'checkout'
   libraries:

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -157,7 +157,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when InvalidLanguageError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::InvalidLanguageError.new("ruby", "discount") }
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidLanguageError.new("ruby", "payment_methods") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The extension points YAML file should be cleaned up to not allow creating/working with deprecated Script APIs anymore.

Related to https://github.com/Shopify/script-service/issues/3869

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Before 
![Screen Shot 2021-11-22 at 12 46 36 PM](https://user-images.githubusercontent.com/23390518/142910314-ca48af5c-b65e-425d-b32c-9ff5f09296cd.png)

After
![Screen Shot 2021-11-22 at 12 46 58 PM](https://user-images.githubusercontent.com/23390518/142910324-87012bba-1517-43e1-9b1c-35f0adfa0f39.png)

Removes APIs from .yml file. 

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

`shopify-dev config feature scripts_beta_extension_points --enable`
`shopify-dev script create`

This should enable the beta extension points and show a list of the updated APIs.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.