### PR TITLE
Fix "DEPRECATED: Use assert_nil if expecting nil" message

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -67,6 +67,7 @@ module Extension
             Usage: {{command:%s extension build}}
         HELP
         frame_title: "Building extension with: %s…",
+        build_failure_message: "Failed to build extension code.",
       },
       register: {
         help: <<~HELP,

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -49,6 +49,7 @@ module Extension
         Messages::MessageLoading.expects(:load_current_type_messages).returns(@fake_override_messages).once
 
         loaded_messages = Messages::MessageLoading.load
+        refute_nil loaded_messages[:build][:build_failure_message]
         assert_equal Messages::MESSAGES[:build][:build_failure_message], loaded_messages[:build][:build_failure_message]
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

I've noticed the following warning message in the test suite:

```
DEPRECATED: Use assert_nil if expecting nil from /Users/karreiro/src/github.com/Shopify/shopify-
  cli/test/project_types/extension/messages/message_loading_test.rb:54. This will fail in Minitest 6.
```

It started happening when we removed the `"build.build_failure_message"`. However, we still use it in production (`Extension::Command::Build`) and on tests (`Extension::Messages::MessageLoadingTest`).

### WHAT is this pull request doing?

This PR brings the `"build.build_failure_message"` message back.

### How to test your changes?

Run `rake test` or check one of the following CI jobs:
- `Tests with Ruby 3.0.2 on macos-11`
- `Tests with Ruby 3.0.2 on ubuntu-20.04`
- `Tests with Ruby 2.6.6 on macos-10.15`
- `Tests with Ruby 2.6.6 on ubuntu-20.04`
- `Tests with Ruby 2.6.6 on ubuntu-18.04`
- `Tests with Ruby 2.7.1 on ubuntu-20.04`

The `"DEPRECATED: Use assert_nil if expecting nil [...]"` warning message should not appear anymore.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.