### PR TITLE
Stop checking the format of a script project's build script command

### DIFF
--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -23,7 +23,6 @@ module Script
                   ctx.puts("\n{{red:#{e.message}}}")
                 end
                 errors = [
-                  Infrastructure::Errors::InvalidBuildScriptError,
                   Infrastructure::Errors::BuildScriptNotFoundError,
                   Infrastructure::Errors::WebAssemblyBinaryNotFoundError,
                 ]

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -109,7 +109,6 @@ module Script
         class ScriptProjectAlreadyExistsError < ScriptProjectError; end
         class TaskRunnerNotFoundError < ScriptProjectError; end
         class BuildScriptNotFoundError < ScriptProjectError; end
-        class InvalidBuildScriptError < ScriptProjectError; end
 
         class WebAssemblyBinaryNotFoundError < ScriptProjectError
           def initialize

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -98,10 +98,6 @@ module Script
 
             raise Errors::BuildScriptNotFoundError,
               "Build script not found" if build_script.nil?
-
-            unless build_script.start_with?("shopify-scripts")
-              raise Errors::InvalidBuildScriptError, "Invalid build script"
-            end
           end
 
           def bytecode

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -100,10 +100,6 @@ module Script
 
             raise Errors::BuildScriptNotFoundError,
               "Build script not found" if build_script.nil?
-
-            unless build_script.start_with?("javy")
-              raise Errors::InvalidBuildScriptError, "Invalid build script"
-            end
           end
 
           def bytecode

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -115,8 +115,6 @@ module Script
           script_repush_cause: "A version of this script already exists on the app.",
           script_repush_help: "Use {{cyan:--force}} to replace the existing script.",
 
-          invalid_build_script: "The root package.json contains an invalid build command that " \
-                                "is needed to compile your script to WebAssembly.",
           build_script_not_found: "The root package.json is missing the build command that " \
                                   "is needed to compile your script to WebAssembly.",
           # rubocop:disable Layout/LineLength

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -201,11 +201,6 @@ module Script
             cause_of_error: ShopifyCLI::Context.message("script.error.build_script_not_found"),
             help_suggestion: ShopifyCLI::Context.message("script.error.build_script_suggestion"),
           }
-        when Layers::Infrastructure::Errors::InvalidBuildScriptError
-          {
-            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_build_script"),
-            help_suggestion: ShopifyCLI::Context.message("script.error.build_script_suggestion"),
-          }
         when Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.web_assembly_binary_not_found"),

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -90,7 +90,6 @@ describe Script::Layers::Application::BuildScript do
       end
 
       [
-        Script::Layers::Infrastructure::Errors::InvalidBuildScriptError,
         Script::Layers::Infrastructure::Errors::BuildScriptNotFoundError,
         Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError,
       ].each do |e|

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -39,14 +39,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
       end
     end
 
-    it "should raise an error if the build script is not compliant" do
-      package_json[:scripts][:build] = ""
-      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
-      assert_raises(Script::Layers::Infrastructure::Errors::InvalidBuildScriptError) do
-        subject
-      end
-    end
-
     it "should raise an error if the generated web assembly is not found" do
       ctx.write("package.json", JSON.generate(package_json))
       ctx

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -28,14 +28,6 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
       end
     end
 
-    it "should raise an error if the build script is not compliant" do
-      package_json[:scripts][:build] = ""
-      File.expects(:read).with("package.json").once.returns(JSON.generate(package_json))
-      assert_raises(Script::Layers::Infrastructure::Errors::InvalidBuildScriptError) do
-        subject
-      end
-    end
-
     it "should raise an error if the generated web assembly is not found" do
       ctx.write("package.json", JSON.generate(package_json))
       ctx


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we check the format of the npm build script command before allowing the script to be built. This is problematic because this prevents us from changing this command in the future, or prevents partners from having the flexibility to change their dev environment to suit their own needs.

### WHAT is this pull request doing?

As discussed on slack, we will remove this check on the format of the npm build script and the associated error class. 

### How to test your changes?

1. Create a new script. 
2. Change the `build` script command in your new package.json file. If you're using TS, you can change this to be `shopify script javy ...` instead of `javy ...`. 
3. Run `shopify script push`. The script should build and push successfully. 

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).