### PR TITLE
[fix] Fix ID used for section hot reloading

### DIFF
--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -62,6 +62,7 @@
       this.filename = filename;
       this.name = filename.split('/').pop().replace('.liquid', '');
       this.element = document.querySelector(`[id^='shopify-section'][id$='${this.name}']`);
+      this.id = this.element.id.replace(/shopify-section-/g, '');
     }
 
     valid() {
@@ -70,7 +71,7 @@
 
     async refresh() {
       var url = new URL(window.location.href);
-      url.searchParams.append('section_id', this.name);
+      url.searchParams.append('section_id', this.id || this.name);
 
       try {
         const response = await fetch(url);
@@ -80,7 +81,7 @@
 
           console.log(`[HotReload] Reloaded ${this.name} section`);
         } else {
-          window.location.reload()
+          window.location.reload();
 
           console.log(`[HotReload] Hot-reloading not supported, fully reloading ${this.name} section`);
         }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

HotReload was incorrectly referring to the sections filename during the section fetch.

### WHAT is this pull request doing?

Extrapolate the sections ID from the containing div to be used when running a section fetch.
As per; https://shopify.dev/api/section-rendering#find-section-ids

### How to test your changes?
1. Run a shopify-cli theme watch
2. Make changes to the Liquid of a section and save.
3. Refer to the network request GET parameter for the section ID.

### Update checklist

- [] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [✅] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [✅] I've left the version number as is (we'll handle incrementing this when releasing).
- [✅] I've included any post-release steps in the section above.