### PR TITLE
Add `--live` option to the `theme pull` and the `theme push` commands

### DIFF
--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -9,6 +9,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
+        parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-x", "--ignore=PATTERN") do |pattern|
           flags[:ignores] ||= []
           flags[:ignores] << pattern
@@ -21,6 +22,8 @@ module Theme
 
         theme = if (theme_id = options.flags[:theme_id])
           ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
+        elsif options.flags[:live]
+          ShopifyCLI::Theme::Theme.live(@ctx, root: root)
         else
           form = Forms::Select.ask(
             @ctx,

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -10,6 +10,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
+        parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-u", "--unpublished") { flags[:unpublished] = true }
         parser.on("-j", "--json") { flags[:json] = true }
@@ -27,6 +28,8 @@ module Theme
 
         theme = if (theme_id = options.flags[:theme_id])
           ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
+        elsif options.flags[:live]
+          ShopifyCLI::Theme::Theme.live(@ctx, root: root)
         elsif options.flags[:development]
           theme = ShopifyCLI::Theme::DevelopmentTheme.new(@ctx, root: root)
           theme.ensure_exists!

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -58,6 +58,7 @@ module Theme
 
               Options:
                 {{command:-i, --themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+                {{command:-l, --live}}            Push to your remote live theme, and update your live store.
                 {{command:-d, --development}}     Push to your remote development theme, and create it if needed.
                 {{command:-u, --unpublished}}     Create a new unpublished theme and push to it.
                 {{command:-n, --nodelete}}        Runs the push command without deleting remote files from Shopify.
@@ -181,6 +182,7 @@ module Theme
 
             Options:
               {{command:-i, --themeid=THEMEID}} The Theme ID. Must be an existing theme on your store.
+              {{command:-l, --live}}            Pull theme files from your remote live theme.
               {{command:-n, --nodelete}}        Runs the pull command without deleting local files.
 
             Run without options to select theme from a list.

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -43,6 +43,27 @@ module Theme
         @command.call([], "pull")
       end
 
+      def test_pull_live_theme
+        ShopifyCLI::Theme::Theme.expects(:live)
+          .with(@ctx, root: ".")
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:live] = true
+        @command.call([], "pull")
+      end
+
       def test_pull_pass_nodelete_to_syncer
         ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -46,6 +46,27 @@ module Theme
         @command.call([], "push")
       end
 
+      def test_push_to_live
+        ShopifyCLI::Theme::Theme.expects(:live)
+          .with(@ctx, root: ".")
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:live] = true
+        @command.call([], "push")
+      end
+
       def test_push_to_live_theme
         ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -7,9 +7,9 @@ module ShopifyCLI
     class ThemeTest < Minitest::Test
       def setup
         super
-        root = ShopifyCLI::ROOT + "/test/fixtures/theme"
-        @ctx = TestHelpers::FakeContext.new(root: root)
-        @theme = Theme.new(@ctx, root: root, id: "123")
+        @root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+        @ctx = TestHelpers::FakeContext.new(root: @root)
+        @theme = Theme.new(@ctx, root: @root, id: "123")
       end
 
       def test_static_assets
@@ -106,6 +106,89 @@ module ShopifyCLI
         ensure
           ::File.delete(new_file.path) if new_file.exist?
         end
+      end
+
+      def test_all
+        mock_themes_json
+
+        expected_ids = [4, 3, 5, 1]
+        expected_names = %w(Export Development Venture Dawn)
+        expected_roles = %w(unpublished development unpublished live)
+
+        themes = Theme.all(@ctx, root: @root)
+
+        assert_equal 4, themes.size
+        assert_equal expected_ids, themes.map(&:id)
+        assert_equal expected_names, themes.map(&:name)
+        assert_equal expected_roles, themes.map(&:role)
+      end
+
+      def test_live
+        mock_themes_json
+
+        theme = Theme.live(@ctx, root: @root)
+
+        assert_equal 1, theme.id
+        assert_equal "Dawn", theme.name
+        assert_equal "live", theme.role
+        assert theme.live?
+      end
+
+      private
+
+      def mock_themes_json
+        AdminAPI.stubs(:get_shop_or_abort).returns("shop.myshopify.com")
+        AdminAPI.stubs(:rest_request).returns([
+          200,
+          {
+            "themes" => [
+              {
+                "id" => 1,
+                "name" => "Dawn",
+                "created_at" => "2021-01-01T12:30:59+01:00",
+                "updated_at" => "2021-01-02T12:30:59+01:00",
+                "role" => "main",
+                "theme_store_id" => 2,
+                "previewable" => true,
+                "processing" => false,
+                "admin_graphql_api_id" => "gid://shopify/Theme/7",
+              },
+              {
+                "id" => 5,
+                "name" => "Venture",
+                "created_at" => "2021-01-03T12:30:59+01:00",
+                "updated_at" => "2021-01-04T12:30:59+01:00",
+                "role" => "unpublished",
+                "theme_store_id" => 6,
+                "previewable" => true,
+                "processing" => false,
+                "admin_graphql_api_id" => "gid://shopify/Theme/8",
+              },
+              {
+                "id" => 3,
+                "name" => "Development",
+                "created_at" => "2021-01-05T12:30:59+01:00",
+                "updated_at" => "2021-01-06T12:30:59+01:00",
+                "role" => "development",
+                "theme_store_id" => nil,
+                "previewable" => true,
+                "processing" => false,
+                "admin_graphql_api_id" => "gid://shopify/Theme/9",
+              },
+              {
+                "id" => 4,
+                "name" => "Export",
+                "created_at" => "2021-01-07T12:30:59+01:00",
+                "updated_at" => "2021-01-08T12:30:59+01:00",
+                "role" => "unpublished",
+                "theme_store_id" => nil,
+                "previewable" => true,
+                "processing" => false,
+                "admin_graphql_api_id" => "gid://shopify/Theme/10",
+              },
+            ],
+          },
+        ])
       end
     end
   end


### PR DESCRIPTION
Add `--live` option to the `theme pull` and the `theme push` commands: https://github.com/Shopify/shopify-cli/issues/1647.

### WHY are these changes introduced?

In the `theme pull/theme push` commands, the `--live` option allows users to interact and update the live theme smoothly. Instead of relying on the `-i=THEME_ID`.

### WHAT is this pull request doing?

This PR introduces the new `--live` option in the `Theme::Command::Pull`, and the `Theme::Command::Push` commands. Both of them rely on the new `ShopifyCLI::Theme::Theme::live` method to get the live theme.

`ShopifyCLI::Theme::Theme::live` is similar to the `ShopifyCLI::Theme::Theme::all` method. I've considered re-using the `all` method (`all.find(&:live?)`, which works too), but building only the live theme seems fairer than mapping/sorting the whole list of themes.

### How to test your changes?

Run the following commands for checking the impact of the new option on `theme push`:

```bash
shopify theme push --live
shopify theme push --l
shopify theme push --h
```

Run the following commands for checking the impact of the new option on `theme pull`:
```bash
shopify theme pull --live
shopify theme pull --l
shopify theme pull --h
```

<img width="1302" alt="Screenshot 2021-11-25 at 16 44 18" src="https://user-images.githubusercontent.com/1079279/143473165-9ad19831-38d6-408d-b830-f08db45040da.png">

<details><summary>Click here to check more screenshots</summary>
<img width="1302" alt="Screenshot 2021-11-25 at 16 44 52" src="https://user-images.githubusercontent.com/1079279/143473194-2766532a-2c5d-4a6a-8086-f616fc05cf4f.png">
<img width="1202" alt="Screenshot 2021-11-25 at 17 24 16" src="https://user-images.githubusercontent.com/1079279/143477420-087a6ea8-96b8-456a-b4a3-d04dacc5f681.png">
</details>

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.