### PR TITLE
Refactored the hot-reload.js module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
 ### Fixed
+* [#1799](https://github.com/Shopify/shopify-cli/pull/1799): `hot-reload.js` complete refactor to fix invalid section id, and add new client JavaScript events.
 * [#1763](https://github.com/Shopify/shopify-cli/pull/1763): Fix: Tunnel --PORT parameter not working in Node.js app.
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
 * [#1766](https://github.com/Shopify/shopify-cli/pull/1766): Fix `theme serve` failing with the `--host` property

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -1,16 +1,16 @@
 (() => {
-  class SectionReloadEvent extends Event {
+  class SectionReloadEvent extends CustomEvent {
     constructor(filename, name, id) {
-      super('shopify:hot:section', { bubbles: true, cancelable: false });
+      super('shopify:section:hotreload', { bubbles: true, cancelable: false });
       this.filename = filename;
       this.name = name;
       this.id = id;
     }
   }
 
-  class StylesheetReloadEvent extends Event {
+  class StylesheetReloadEvent extends CustomEvent {
     constructor(filename, links) {
-      super('shopify:hot:stylesheet', { bubbles: true, cancelable: false });
+      super('shopify:stylesheet:hotreload', { bubbles: true, cancelable: false });
       this.filename = filename;
       this.links = links;
     }
@@ -97,7 +97,7 @@
   }
 
   // Handler for when event messages are received.
-  const hotReloadHandleMesage = (message) => {
+  const hotReloadHandleMessage = (message) => {
     var data = JSON.parse(message.data);
 
     // Assume only one file is modified at a time
@@ -117,11 +117,11 @@
   const hotReloadConnect = () => {
     const eventSource = new EventSource('/hot-reload');
 
-    eventSource.onmessage = hotReloadHandleMesage;
+    eventSource.onmessage = hotReloadHandleMessage;
     eventSource.onopen = () => console.log('[HotReload] SSE connected.');
     eventSource.onclose = () => {
       console.log('[HotReload] SSE closed. Attempting to reconnect...');
-      setTimeout(connect, 5000);
+      setTimeout(hotReloadConnect, 5000);
     };
     eventSource.onerror = () => eventSource.close();
   }

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -1,93 +1,131 @@
 (() => {
-  function connect() {
-    const eventSource = new EventSource('/hot-reload');
-
-    eventSource.onmessage = handleUpdate;
-
-    eventSource.onopen = () => console.log('[HotReload] SSE connected.');
-
-    eventSource.onclose = () => {
-      console.log('[HotReload] SSE closed. Attempting to reconnect...');
-
-      setTimeout(connect, 5000);
+  class SectionReloadEvent extends Event {
+    constructor(filename, name, id) {
+      super('shopify:hot:section', { bubbles: true, cancelable: false });
+      this.filename = filename;
+      this.name = name;
+      this.id = id;
     }
-
-    eventSource.onerror = () => eventSource.close();
   }
 
-  connect();
+  class StylesheetReloadEvent extends Event {
+    constructor(filename, links) {
+      super('shopify:hot:stylesheet', { bubbles: true, cancelable: false });
+      this.filename = filename;
+      this.links = links;
+    }
+  }
 
-  function handleUpdate(message) {
+  // Extracts the sections name from a given filename.
+  const sectionGetNameFromFilename = (filename) => {
+    return filename.split('/').pop().replace('.liquid', '');
+  }
+
+  // Queries all sections on the page that use a given name.
+  const sectionGetElementsForName = (name) => {
+    return document.querySelectorAll(`[id^='shopify-section'][id$='${name}']`);
+  }
+
+  // Returns the sections ID from the HTML element itself.
+  const sectionGetIdFromElement = (element) => {
+    return element.id.replace(/shopify-section-/g, '');
+  }
+
+  // Validates whether or not a filename can be used to reload any section.
+  const hotReloadSectionIsValid = (filename) => {
+    return (
+      filename.startsWith('sections/') &&
+      sectionGetElementsForName(sectionGetNameFromFilename(filename)).length > 0
+    );
+  }
+
+  // Reloads all sections that make use of a changed section file.
+  const hotReloadSection = (filename) => {
+    const name = sectionGetNameFromFilename(filename);
+    const sections = sectionGetElementsForName(name);
+
+    return Promise.all([ ...sections ].map(async element => {
+      const id = sectionGetIdFromElement(element);
+      const url = new URL(window.location.href);
+      url.searchParams.append('section_id', id || name);
+
+      try {
+        const response = await fetch(url);
+        if (response.headers.get('x-templates-from-params') == '1') {
+          const html = await response.text();
+          const parent = element.parentElement || document.documentElement;
+
+          // Replace contents
+          element.outerHTML = html;
+
+          // Dispatch event.
+          const evt = new SectionReloadEvent(filename, name, id);
+          parent.dispatchEvent(evt);
+          console.log(`[HotReload] Reloaded ${id} section`);
+        } else {
+          window.location.reload();
+          console.log(`[HotReload] Hot-reloading not supported, fully reloading ${id} section`);
+        }
+      } catch (e) {
+        console.log(`[HotReload] Failed to reload ${id} section: ${e.message}`);
+      }
+    }));
+  }
+
+  // Validates if a filename is a CSS file or not.
+  const hotReloadIsCssFile = (filename) => filename.endsWith('.css');
+
+  // Reload a given CSS file.
+  const hotReloadCssFile = (filename) => {
+    // Find all stylesheets starting with /assets (locally-served only) and containing the filename.
+    const links = document.querySelectorAll(`link[href^="/assets"][href*="${filename}"][rel="stylesheet"]`);
+    if (!links.length) {
+      console.log(`[HotReload] Could not find link for stylesheet ${filename}`);
+      return;
+    }
+
+    // Update their link refs
+    links.forEach(link => {
+      link.href = new URL(link.href).pathname + `?v=${Date.now()}`;
+    });
+
+    // Dispatch event.
+    document.documentElement.dispatchEvent(new StylesheetReloadEvent(
+      filename, links
+    ));
+    console.log(`[HotReload] Reloaded stylesheet`, filename);
+  }
+
+  // Handler for when event messages are received.
+  const hotReloadHandleMesage = (message) => {
     var data = JSON.parse(message.data);
 
     // Assume only one file is modified at a time
     var modified = data.modified[0];
 
-    if (isCssFile(modified)) {
-      reloadCssFile(modified)
-    } else if (isSectionFile(modified)) {
-      reloadSection(modified);
+    if (hotReloadIsCssFile(modified)) {
+      hotReloadCssFile(modified)
+    } else if (hotReloadSectionIsValid(modified)) {
+      hotReloadSection(modified);
     } else {
       console.log(`[HotReload] Refreshing entire page`);
       window.location.reload();
     }
   }
 
-  function isCssFile(filename) {
-    return filename.endsWith('.css');
+  // Method to begin connecting to the hot reload source.
+  const hotReloadConnect = () => {
+    const eventSource = new EventSource('/hot-reload');
+
+    eventSource.onmessage = hotReloadHandleMesage;
+    eventSource.onopen = () => console.log('[HotReload] SSE connected.');
+    eventSource.onclose = () => {
+      console.log('[HotReload] SSE closed. Attempting to reconnect...');
+      setTimeout(connect, 5000);
+    };
+    eventSource.onerror = () => eventSource.close();
   }
 
-  function reloadCssFile(filename) {
-    // Find a stylesheet link starting with /assets (locally-served only) containing the filename
-    let link = document.querySelector(`link[href^="/assets"][href*="${filename}"][rel="stylesheet"]`);
-
-    if (!link) {
-      console.log(`[HotReload] Could not find link for stylesheet ${filename}`);
-    } else {
-      link.href = new URL(link.href).pathname + `?v=${Date.now()}`;
-      console.log(`[HotReload] Reloaded stylesheet ${filename}`);
-    }
-  }
-
-  function isSectionFile(filename) {
-    return new Section(filename).valid();
-  }
-
-  function reloadSection(filename) {
-    new Section(filename).refresh();
-  }
-
-  class Section {
-    constructor(filename) {
-      this.filename = filename;
-      this.name = filename.split('/').pop().replace('.liquid', '');
-      this.element = document.querySelector(`[id^='shopify-section'][id$='${this.name}']`);
-    }
-
-    valid() {
-      return this.filename.startsWith('sections/') && this.element;
-    }
-
-    async refresh() {
-      var url = new URL(window.location.href);
-      url.searchParams.append('section_id', this.name);
-
-      try {
-        const response = await fetch(url);
-        if (response.headers.get('x-templates-from-params') == '1') {
-          const html = await response.text();
-          this.element.outerHTML = html;
-
-          console.log(`[HotReload] Reloaded ${this.name} section`);
-        } else {
-          window.location.reload()
-
-          console.log(`[HotReload] Hot-reloading not supported, fully reloading ${this.name} section`);
-        }
-
-      } catch (e) {
-        console.log(`[HotReload] Failed to reload ${this.name} section: ${e.message}`);
-      }
-    }
-  }
+  // Connect to the event target.
+  hotReloadConnect();
 })();


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Refer to https://github.com/Shopify/shopify-cli/pull/1796

- Hot reload works on the sections filename, not the ID, causing it to reference the wrong section
- Hot reload was only reloading a single instance of any given section
- Hot reload was only reloading a single instance of any given CSS file
- Code was a bit messy, using classes to achieve what functions could.

Additionally, the section reload was running on `.outerHTML` of the containing section element (and subsequently removed it from the DOM). Some weak references to this old element within the Section class may have caused undefined behavior.

### WHAT is this pull request doing?
- Completely refactored `hot-reload.js`
- Switched to functional design rather than class based
- Hot reload section fetch is using each sections' ID rather than the name of the section.
- Hot reload section is querying all matching sections, rather than a single section element.
- Hot reload CSS is querying all matching CSS sheets, rather than a single element.
- Added new custom events that will fire from the hot reload so that JS can subscribe to events
- No longer relying on classes or maintaining references to the overwritten section HTML element(s).

### How to test your changes?
Run a normal theme serve and perform standard hot-reload tests, mostly;
- Test for static section reload (those rendered with `{% section 'filename' %}`)
- Test for dynamic section reload (those included within `templates/*.json` and/or `template/index.*`)
- Test for CSS reloading when modified locally
- Test for custom events `shopify:hot:section` and `shopify:hot:stylesheet` being triggered during hot reloading.
- Test for multiple sections sharing a given filename to hot reload as expected
- Test for multiple instances of a given stylesheet to hot reload correctly.

### Post-release steps
- Update theme CLI documentation to include the new hot events that non-production JS can subscribe to, e.g. for disposing of event listeners.
- Bring more attention within official documentation to how the section IDs are unique per instance within the `templates/*.json`  and `settings_data.json`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.