### PR TITLE
Add env variable that lets you skip extension point validation

### DIFF
--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -11,7 +11,8 @@ module Script
             raise Infrastructure::Errors::ScriptProjectAlreadyExistsError, script_name if ctx.dir_exist?(script_name)
 
             in_new_directory_context(ctx, script_name) do
-              extension_point = ExtensionPoints.get(type: extension_point_type)
+              extension_point = ExtensionPoints.get!(type: extension_point_type)
+
               script_project_repo = Infrastructure::ScriptProjectRepository.new(ctx: ctx)
               project = script_project_repo.create(
                 script_name: script_name,

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -7,7 +7,8 @@ module Script
         def self.get!(type:)
           extension_point = get(type: type)
 
-          raise Domain::Errors::InvalidExtensionPointError, type if extension_point.is_a?(Domain::UnknownExtensionPoint) 
+          raise Domain::Errors::InvalidExtensionPointError,
+            type if extension_point.is_a?(Domain::UnknownExtensionPoint)
 
           extension_point
         end

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -4,6 +4,14 @@ module Script
   module Layers
     module Application
       class ExtensionPoints
+        def self.get!(type:)
+          extension_point = get(type: type)
+
+          raise Domain::Errors::InvalidExtensionPointError, type if extension_point.is_a?(Domain::UnknownExtensionPoint) 
+
+          extension_point
+        end
+
         def self.get(type:)
           Infrastructure::ExtensionPointRepository.new.get_extension_point(type)
         end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -15,15 +15,17 @@ module Script
             extension_point_type = script_project.extension_point_type
             extension_point = ExtensionPoints.get(type: extension_point_type)
 
-            library = case extension_point 
+            library = case extension_point
             when Domain::UnknownExtensionPoint
-              raise Domain::Errors::InvalidExtensionPointError, extension_point_type unless allow_unknown_extension_points? 
+              raise Domain::Errors::InvalidExtensionPointError,
+                extension_point_type unless allow_unknown_extension_points?
 
-              ctx.puts(ctx.message("script.application.unknown_warning", extension_point: script_project.extension_point_type))
+              ctx.puts(ctx.message("script.application.unknown_warning",
+                extension_point: script_project.extension_point_type))
 
               {
                 language: script_project.language,
-                version: DEFAULT_VERSION
+                version: DEFAULT_VERSION,
               }
             when Domain::ExtensionPoint
               library_name = extension_point.libraries.for(script_project.language)&.package

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -67,8 +67,8 @@ module Script
         def initialize(type)
           super(type, {
             "libraries" => {
-              "typescript" => {}
-            }
+              "typescript" => {},
+            },
           })
         end
       end

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -62,6 +62,16 @@ module Script
           end
         end
       end
+
+      class UnknownExtensionPoint < ExtensionPoint
+        def initialize(type)
+          super(type, {
+            "libraries" => {
+              "typescript" => {}
+            }
+          })
+        end
+      end
     end
   end
 end

--- a/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/extension_point_repository.rb
@@ -5,7 +5,11 @@ module Script
     module Infrastructure
       class ExtensionPointRepository
         def get_extension_point(type)
-          Domain::ExtensionPoint.new(type, fetch_extension_point(type))
+          config = fetch_extension_point_config(type)
+
+          return Domain::UnknownExtensionPoint.new(type) if config.nil?
+
+          Domain::ExtensionPoint.new(type, config)
         end
 
         def extension_points
@@ -20,8 +24,7 @@ module Script
 
         private
 
-        def fetch_extension_point(type)
-          raise Domain::Errors::InvalidExtensionPointError, type unless extension_point_configs[type]
+        def fetch_extension_point_config(type)
           extension_point_configs[type]
         end
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -208,6 +208,7 @@ module Script
           built: "Built",
           pushing: "Pushing",
           pushed: "Pushed",
+          unknown_warning: "{{?}} Unknown Extension Point '%{extension_point}'",
           ensure_env: {
             organization: "Partner organization {{green:%s (%s)}}.",
             organization_select: "Which partner organization do you want to use?",

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -20,9 +20,19 @@ describe Script::Layers::Application::ExtensionPoints do
   end
 
   describe ".get" do
+    it "should call the extension point repository" do
+      repo_result = mock()
+
+      extension_point_repository.expects(:get_extension_point).returns(repo_result)
+
+      assert_equal repo_result, Script::Layers::Application::ExtensionPoints.get(type: extension_point_type)
+    end
+  end
+
+  describe ".get!" do
     describe "when extension point exists" do
       it "should return a valid extension point" do
-        ep = Script::Layers::Application::ExtensionPoints.get(type: extension_point_type)
+        ep = Script::Layers::Application::ExtensionPoints.get!(type: extension_point_type)
         assert_equal extension_point, ep
       end
     end
@@ -30,7 +40,7 @@ describe Script::Layers::Application::ExtensionPoints do
     describe "when extension point does not exist" do
       it "should raise InvalidExtensionPointError" do
         assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) do
-          Script::Layers::Application::ExtensionPoints.get(type: "invalid")
+          Script::Layers::Application::ExtensionPoints.get!(type: "invalid")
         end
       end
     end
@@ -72,14 +82,6 @@ describe Script::Layers::Application::ExtensionPoints do
     let(:type) { extension_point_type }
     subject { Script::Layers::Application::ExtensionPoints.languages(type: type) }
 
-    describe "when ep does not exist" do
-      let(:type) { "imaginary" }
-
-      it "should raise InvalidExtensionPointError" do
-        assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) { subject }
-      end
-    end
-
     describe "when beta language flag is enabled" do
       before do
         ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once
@@ -105,14 +107,6 @@ describe Script::Layers::Application::ExtensionPoints do
     let(:type) { extension_point_type }
     let(:language) { "assemblyscript" }
     subject { Script::Layers::Application::ExtensionPoints.supported_language?(type: type, language: language) }
-
-    describe "when ep does not exist" do
-      let(:type) { "imaginary" }
-
-      it "should raise InvalidExtensionPointError" do
-        assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) { subject }
-      end
-    end
 
     describe "when beta language flag is enabled" do
       before do

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -21,7 +21,7 @@ describe Script::Layers::Application::ExtensionPoints do
 
   describe ".get" do
     it "should call the extension point repository" do
-      repo_result = mock()
+      repo_result = mock
 
       extension_point_repository.expects(:get_extension_point).returns(repo_result)
 

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -125,7 +125,7 @@ describe Script::Layers::Application::PushScript do
 
       describe "When unknown extension points have been allowed" do
         before do
-          Script::Layers::Application::PushScript.expects(:allow_unknown_extension_points?).returns(true) 
+          Script::Layers::Application::PushScript.expects(:allow_unknown_extension_points?).returns(true)
         end
 
         it "should prepare and push the script with mock library information" do
@@ -147,7 +147,7 @@ describe Script::Layers::Application::PushScript do
             script_project: script_project,
             library: {
               language: script_project.language,
-              version: Script::Layers::Application::PushScript::DEFAULT_VERSION
+              version: Script::Layers::Application::PushScript::DEFAULT_VERSION,
             }
           )
           capture_io { subject }

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -21,10 +21,8 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
     describe "when the extension point does not exist" do
       let(:bogus_extension) { "bogus" }
 
-      it "should raise InvalidExtensionPointError" do
-        assert_raises(Script::Layers::Domain::Errors::InvalidExtensionPointError) do
-          subject.get_extension_point(bogus_extension)
-        end
+      it "should return an unknown extension point" do
+        assert Script::Layers::Domain::UnknownExtensionPoint.new(bogus_extension), subject.get_extension_point(bogus_extension)
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/extension_point_repository_test.rb
@@ -22,7 +22,8 @@ describe Script::Layers::Infrastructure::ExtensionPointRepository do
       let(:bogus_extension) { "bogus" }
 
       it "should return an unknown extension point" do
-        assert Script::Layers::Domain::UnknownExtensionPoint.new(bogus_extension), subject.get_extension_point(bogus_extension)
+        assert Script::Layers::Domain::UnknownExtensionPoint.new(bogus_extension),
+          subject.get_extension_point(bogus_extension)
       end
     end
   end

--- a/test/project_types/script/test_helpers/fake_extension_point_repository.rb
+++ b/test/project_types/script/test_helpers/fake_extension_point_repository.rb
@@ -24,7 +24,7 @@ module TestHelpers
       if @cache.key?(type)
         @cache[type]
       else
-        raise Script::Layers::Domain::Errors::InvalidExtensionPointError, type
+        Script::Layers::Domain::UnknownExtensionPoint.new(type)
       end
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/script-service/issues/3966

Working with new or renamed extension points currently requires us to merge code into the shopify-cli repository. This slows down our ability to quickly prototype and iterate on APIs in local development environments. **It also requires us to publicly include the name of the extension point, because shopify-cli is a public repo**.

### WHAT is this pull request doing?

Adding a new domain concept: `UnknownExtensionPoint`. This object is returned by the extension point repository when a script has an extension point that doesn't match anything in the `extension_points.yml` file. `UnknownExtensionPoint` inherits from `ExtensionPoint`, and populates the `ExtensionPoint` fields with mock data that'll allow you to push your script to a local copy of our services.

When calling `ExtensionPoints.get` you receive either an `ExtensionPoint` or an `UnknownExtensionPoint`. `ExtensionPoints.get!` has the same behaviour that `ExtensionPoints.get` used to have, in that it will throw an exception if the name is not found.

In the push command, when we receive an `UnknownExtensionPoint` and the `ALLOW_UNKNOWN_EXTENSION_POINTS` environment flag is set, we allow the push to continue.

With just this PR, the push request will fail once we reach Script Service. [This PR](https://github.com/Shopify/script-service/pull/4021) once merged will allow you to register prototype extension points in script service with a rake task. **Once both these PRs are merged we will be able to prototype new extension points in our development environments without making any code changes to `script-service` or `shopify-cil`.**

### How to test your changes?

It's a little involved at the moment. Until [this PR](https://github.com/Shopify/script-service/pull/4021) is merged, let's just discuss whether the change is acceptable at a high level.

### Post-release steps

No steps required.

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public facing
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.