### PR TITLE
Allow javy to be called outside script commands

### DIFF
--- a/lib/project_types/script/commands/javy.rb
+++ b/lib/project_types/script/commands/javy.rb
@@ -7,8 +7,6 @@ module Script
     class Javy < ShopifyCLI::Command::SubCommand
       hidden_feature
 
-      prerequisite_task ensure_project_type: :script
-
       options do |parser, flags|
         parser.on("--in=IN") { |in_file| flags[:in_file] = in_file }
         parser.on("--out=OUT") { |out_file| flags[:out_file] = out_file }

--- a/test/project_types/script/commands/javy_test.rb
+++ b/test/project_types/script/commands/javy_test.rb
@@ -12,7 +12,6 @@ module Script
       def setup
         super
         @context = TestHelpers::FakeContext.new
-        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
       end
 
       def test_calls_javy_and_succeeds


### PR DESCRIPTION
### WHY are these changes introduced?

To support calling Javy in our API toolchain, we want to call the CLI's Javy command. This is so that the API toolchain users don't need to have Javy installed themselves. However, the command currently can only be run in script projects. Repos that use the API toolchain are not script projects, so calling the command currently raises an error. 

### WHAT is this pull request doing?

Allows Javy to be called outside of a script project.

### How to test your changes?

1. Create a script project
2. Remove the `.shopify-cli.yml` file. This is the file that tells you what project type you are in.
3. Assert that `shopify script push` fails because you are not in a script project.
4. Assert that `shopify script javy -i build/index.js -o build/index.wasm` succeeds. 

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).