### PR TITLE
Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
+## [Unreleased]
+### Fixed
+* [#1807](https://github.com/Shopify/shopify-cli/pull/1807): Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command
+
 ## Version 2.7.2
 ### Fixed
 * [#1763](https://github.com/Shopify/shopify-cli/pull/1763): Fix: Tunnel --PORT parameter not working in Node.js app.

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -50,8 +50,7 @@ module Theme
           form.theme
         end
 
-        is_confirm_required = !options.flags[:allow_live] && !options.flags[:live]
-        if theme.live? && is_confirm_required
+        if theme.live? && !options.flags[:allow_live]
           return unless CLI::UI::Prompt.confirm(@ctx.message("theme.push.live"))
         end
 

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -52,7 +52,7 @@ module Theme
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
-        CLI::UI::Prompt.expects(:confirm).never
+        CLI::UI::Prompt.expects(:confirm).returns(true)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 


### PR DESCRIPTION
### WHY are these changes introduced?

We reconsidered [this change](https://github.com/Shopify/shopify-cli/pull/1798#discussion_r758367619) considering [@ADTC feedback](https://github.com/Shopify/shopify-cli/issues/1647#issuecomment-982674668).

### WHAT is this pull request doing?

Now, the `--live` parameter does not imply `--allow-live` in the `theme push` command anymore.

### How to test your changes?

Run `shopify theme push --live` and see the confirmation message:
 
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/1079279/144093312-b09e449a-5cea-4ee8-adca-ec4df23ba97a.png">

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.