### PR TITLE
Fix `rails new` command for Rails 7

### DIFF
--- a/lib/project_types/rails/commands/create.rb
+++ b/lib/project_types/rails/commands/create.rb
@@ -156,10 +156,10 @@ module Rails
 
         CLI::UI::Frame.open(@ctx.message("rails.create.generating_app", name)) do
           new_command = %w(rails new)
+          new_command << name
           new_command += DEFAULT_RAILS_FLAGS
           new_command << "--database=#{db}"
           new_command += options.flags[:rails_opts].split unless options.flags[:rails_opts].nil?
-          new_command << name
 
           syscall(new_command)
         end

--- a/lib/shopify_cli/services/app/create/rails_service.rb
+++ b/lib/shopify_cli/services/app/create/rails_service.rb
@@ -159,10 +159,10 @@ module ShopifyCLI
 
             CLI::UI::Frame.open(context.message("core.app.create.rails.generating_app", name)) do
               new_command = %w(rails new)
+              new_command << name
               new_command += DEFAULT_RAILS_FLAGS
               new_command << "--database=#{db}"
               new_command += rails_opts.split unless rails_opts.nil?
-              new_command << name
 
               syscall(new_command)
             end

--- a/test/shopify-cli/services/app/create/rails_service_test.rb
+++ b/test/shopify-cli/services/app/create/rails_service_test.rb
@@ -51,7 +51,7 @@ module ShopifyCLI
             ::Rails::Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
             ::Rails::Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
             ::Rails::Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
-            expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 test-app))
+            expect_command(%W(#{gem_path}/bin/rails new test-app --skip-spring --database=sqlite3))
             expect_command(%W(#{gem_path}/bin/bundle install),
               chdir: File.join(@context.root, "test-app"))
             expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
@@ -103,7 +103,7 @@ module ShopifyCLI
             ::Rails::Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
             ::Rails::Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
             ::Rails::Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
-            expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=postgresql test-app))
+            expect_command(%W(#{gem_path}/bin/rails new test-app --skip-spring --database=postgresql))
             expect_command(%W(#{gem_path}/bin/bundle install),
               chdir: File.join(@context.root, "test-app"))
             expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),
@@ -151,7 +151,7 @@ module ShopifyCLI
             ::Rails::Ruby.expects(:version).returns(Semantic::Version.new("2.5.0"))
             ::Rails::Gem.expects(:install).with(@context, "rails", "<6.1").returns(true)
             ::Rails::Gem.expects(:install).with(@context, "bundler", "~>2.0").returns(true)
-            expect_command(%W(#{gem_path}/bin/rails new --skip-spring --database=sqlite3 --edge -J test-app))
+            expect_command(%W(#{gem_path}/bin/rails new test-app --skip-spring --database=sqlite3 --edge -J))
             expect_command(%W(#{gem_path}/bin/bundle install),
               chdir: File.join(@context.root, "test-app"))
             expect_command(%W(#{gem_path}/bin/rails generate shopify_app --new-shopify-cli-app),


### PR DESCRIPTION
### WHY are these changes introduced?

Spring is no longer bundled by default in Rails 7. Creating an app
with `rails new --skip-spring app_name` will create a `--skip-spring`
directory.



For context, Spring was removed in this commit:
https://github.com/rails/rails/commit/21c9732fae9ce0fff7adf0da610d26eeedfc3076

### WHAT is this pull request doing?

This commit fixes that by putting the app name first. In my testing,
`rails new` ignores the extra flag it doesn't understand, so it should
work on both Rails 6 and Rails 7.

### How to test your changes?
```
gem instal rails --pre
shopify app create rails
```

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.