### PR TITLE
Fix Shopify hosted fonts to load via the local preview URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#1807](https://github.com/Shopify/shopify-cli/pull/1807): Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command
 * [#1812](https://github.com/Shopify/shopify-cli/pull/1812): App creation with Rails 7
+* [#1821](https://github.com/Shopify/shopify-cli/pull/1821): Fix Shopify hosted fonts to load via the local preview URL
+
 ## Version 2.7.2
 ### Fixed
 * [#1763](https://github.com/Shopify/shopify-cli/pull/1763): Fix: Tunnel --PORT parameter not working in Node.js app.

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -34,7 +34,7 @@ module ShopifyCLI
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)
-          @app = CdnFonts.new(ctx, @app, theme: theme)
+          @app = CdnFonts.new(@app, theme: theme)
           @app = LocalAssets.new(ctx, @app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, ignore_filter: ignore_filter)
           stopped = false

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -3,6 +3,7 @@ require_relative "development_theme"
 require_relative "ignore_filter"
 require_relative "syncer"
 
+require_relative "dev_server/cdn_fonts"
 require_relative "dev_server/hot_reload"
 require_relative "dev_server/header_hash"
 require_relative "dev_server/local_assets"
@@ -33,6 +34,7 @@ module ShopifyCLI
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)
+          @app = CdnFonts.new(ctx, @app, theme: theme)
           @app = LocalAssets.new(ctx, @app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, ignore_filter: ignore_filter)
           stopped = false

--- a/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
@@ -8,8 +8,7 @@ module ShopifyCLI
         FONTS_CDN = "https://fonts.shopifycdn.com/assistant"
         FONTS_REGEX = %r{#{FONTS_CDN}}
 
-        def initialize(ctx, app, theme:)
-          @ctx = ctx
+        def initialize(app, theme:)
           @app = app
           @theme = theme
         end

--- a/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class CdnFonts
+        FONTS_PATH = "/fonts"
+        FONTS_CDN = "https://fonts.shopifycdn.com/assistant"
+        FONTS_REGEX = %r{#{FONTS_CDN}}
+
+        def initialize(ctx, app, theme:)
+          @ctx = ctx
+          @app = app
+          @theme = theme
+        end
+
+        def call(env)
+          path = env["PATH_INFO"]
+
+          # Serve from fonts CDN
+          return serve_font(env) if path.start_with?(FONTS_PATH)
+
+          # Proxy the request, and replace the URLs in the response
+          status, headers, body = @app.call(env)
+          body = replace_font_urls(body)
+          [status, headers, body]
+        end
+
+        private
+
+        def serve_font(env)
+          parameters = %w(PATH_INFO QUERY_STRING REQUEST_METHOD rack.input)
+          path, query, method, body_stream = *env.slice(*parameters).values
+
+          uri = fonts_cdn_uri(path, query)
+
+          response = Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
+            req_class = Net::HTTP.const_get(method.capitalize)
+            req = req_class.new(uri)
+            req.initialize_http_header(fonts_cdn_headers)
+            req.body_stream = body_stream
+            http.request(req)
+          end
+
+          [
+            response.code.to_s,
+            {
+              "Content-Type" => response.content_type,
+              "Content-Length" => response.content_length.to_s,
+            },
+            [response.body],
+          ]
+        end
+
+        def fonts_cdn_headers
+          {
+            "Referer" => "https://#{@theme.shop}",
+            "Transfer-Encoding" => "chunked",
+          }
+        end
+
+        def fonts_cdn_uri(path, query)
+          uri = URI.join("#{FONTS_CDN}/", path.gsub(%r{^#{FONTS_PATH}\/}, ""))
+          uri.query = query.split("&").last
+          uri
+        end
+
+        def replace_font_urls(body)
+          [body.join.gsub(FONTS_REGEX, FONTS_PATH)]
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+require "rack/mock"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class CdnFontsTest < Minitest::Test
+        def test_replace_local_fonts_in_reponse_body
+          original_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="https://fonts.shopifycdn.com/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_replace_local_fonts_on_same_line
+          original_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="https://fonts.shopifycdn.com/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin=""><link rel="preload" as="font" href="https://fonts.shopifycdn.com/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin=""><link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_dont_replace_other_assets
+          original_html = <<~HTML
+            <html>
+              <head>
+                <script src="https://cdn.shopify.com/s/trekkie.storefront.9f320156b58d74db598714aa83b6a5fbab4d4efb.min.js"></script>
+              </head>
+            </html>
+          HTML
+          assert_equal(original_html, serve(original_html).body)
+        end
+
+        def test_serve_font_from_fonts_cdn
+          expected_body = "<FONT_FILE_FROM_CDN>"
+
+          stub_request(:get, "https://fonts.shopifycdn.com/assistant/font.123.woff2?hmac=456")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 200, body: expected_body, headers: {})
+
+          response = serve(path: "/fonts/font.123.woff2?hmac=456")
+          actual_body = response.body
+
+          assert_equal expected_body, actual_body
+        end
+
+        def test_404_on_missing_cdn_fonts
+          stub_request(:get, "https://fonts.shopifycdn.com/assistant/missing.123.woff2?hmac=456")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 404, body: "Not found", headers: {})
+
+          response = serve(path: "/fonts/missing.123.woff2?hmac=456")
+
+          assert_equal(404, response.status)
+          assert_equal("Not found", response.body)
+        end
+
+        private
+
+        def serve(response_body = "", path: "/")
+          app = lambda do |_env|
+            [200, {}, [response_body]]
+          end
+          stack = CdnFonts.new(ctx, app, theme: theme)
+          request = Rack::MockRequest.new(stack)
+          request.get(path)
+        end
+
+        def ctx
+          @ctx ||= TestHelpers::FakeContext.new(root: root)
+        end
+
+        def root
+          @root ||= ShopifyCLI::ROOT + "/test/fixtures/theme"
+        end
+
+        def theme
+          return @theme if @theme
+          @theme = Theme.new(ctx, root: root)
+          @theme.stubs(shop: "my-test-shop.myshopify.com")
+          @theme
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
@@ -90,13 +90,9 @@ module ShopifyCLI
           app = lambda do |_env|
             [200, {}, [response_body]]
           end
-          stack = CdnFonts.new(ctx, app, theme: theme)
+          stack = CdnFonts.new(app, theme: theme)
           request = Rack::MockRequest.new(stack)
           request.get(path)
-        end
-
-        def ctx
-          @ctx ||= TestHelpers::FakeContext.new(root: root)
         end
 
         def root
@@ -105,7 +101,7 @@ module ShopifyCLI
 
         def theme
           return @theme if @theme
-          @theme = Theme.new(ctx, root: root)
+          @theme = Theme.new(nil, root: root)
           @theme.stubs(shop: "my-test-shop.myshopify.com")
           @theme
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Fonts were not loading because the Shopify fonts CDN expects a valid HTTP referer header.

### WHAT is this pull request doing?

This PR introduces changes in the `ShopifyCLI::Theme::DevServer` to request fonts from the CDN with the expected headers and serve them locally.

### How to test your changes?

1. Run `shopify theme serve` service
2. Open the http://127.0.0.1:9292
3. Check the fonts are now loading as expected

Before this PR:
<img width="500" alt="before" src="https://user-images.githubusercontent.com/1079279/144583725-fbc7bb0d-a1f6-4b61-b58d-7febd587f5fb.png">

After this PR:
<img width="500" alt="after" src="https://user-images.githubusercontent.com/1079279/144583740-2bea2ac1-880d-4cbd-bb25-09142aeabb35.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.