### PR TITLE
Indicate git is unavailable; don't error out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 
 ### Fixed
+* [#1823](https://github.com/Shopify/shopify-cli/pull/1823): Indicate git is unavailable; don't error out
 * [#1807](https://github.com/Shopify/shopify-cli/pull/1807): Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command
 * [#1812](https://github.com/Shopify/shopify-cli/pull/1812): App creation with Rails 7
 ## Version 2.7.2

--- a/lib/shopify_cli/git.rb
+++ b/lib/shopify_cli/git.rb
@@ -8,6 +8,8 @@ module ShopifyCLI
       def available?(ctx)
         _output, status = ctx.capture2e("git", "status")
         status.success?
+      rescue Errno::ENOENT # git is not installed
+        false
       end
 
       ##

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -31,6 +31,14 @@ module ShopifyCLI
       refute(ShopifyCLI::Git.available?(@context))
     end
 
+    def test_available_returns_false_if_git_not_available_and_raises
+      @context.expects(:capture2e)
+        .with("git", "status")
+        .raises(Errno::ENOENT, "No such file or directory - git")
+
+      refute(ShopifyCLI::Git.available?(@context))
+    end
+
     def test_branches_returns_master_if_no_branches_exist
       @context.expects(:capture2e)
         .with("git", "branch", "--list", "--format=%(refname:short)")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This solves a number of issues of the form of https://github.com/Shopify/shopify-cli/issues/1782

Sometimes git is necessary; other times it's just a nice-to-have. When we make API calls, we use git to [check the CLI sha](https://github.com/Shopify/shopify-cli/blob/bb3f891f3a035c439555621ecaf2cbfa80ac1789/lib/shopify_cli/api.rb#L111). While it would be nice to have, we can live without it when it's unavailable; it's not worth the DX impact. Hence, we already introduced the `ShopifyCLI::Git::available?` method.

However, this method doesn't check properly, as the underlying `Open3::capture2e` will raise an error if the underlying executable isn't available at all. (For other errors, it will actually return output and a process status as expected.) This has resulted in cryptic errors when git isn't available on the system and the user just wants to make an API call.

On my local system, intentionally making a typo to demonstrate an unavailable executable:

```ruby
[2] pry(main)> Open3.capture2e('git status')
=> ["On branch git-available-fix\nnothing to commit, working tree clean\n",
 #<Process::Status: pid 69095 exit 0>]
[3] pry(main)> Open3.capture2e('jit status')
Errno::ENOENT: No such file or directory - jit
from /opt/rubies/2.7.1/lib/ruby/2.7.0/open3.rb:213:in `spawn'
```

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds a `rescue` for the case that the `git` executable isn't present. This is OK because the purpose of the `available?` method is only used [where we don't absolutely require git](https://github.com/Shopify/shopify-cli/blob/bb3f891f3a035c439555621ecaf2cbfa80ac1789/lib/shopify_cli/git.rb#L33-L35).

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. Have a system where `git` isn't installed
2. Run any command (e.g. login) that makes an API call

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).