### PR TITLE
[Scripts] Support using `script.config.yml` file for script configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
+* [#1826](https://github.com/Shopify/shopify-cli/pull/1826): Support using `script.config.yml` file for script configuration
 
 ### Fixed
 * [#1823](https://github.com/Shopify/shopify-cli/pull/1823): Indicate git is unavailable; don't error out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 ## [Unreleased]
+### Added
 * [#1826](https://github.com/Shopify/shopify-cli/pull/1826): Support using `script.config.yml` file for script configuration
 
 ### Fixed

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -46,7 +46,7 @@ module Script
       autoload :PushPackage, Project.project_filepath("layers/domain/push_package")
       autoload :Metadata, Project.project_filepath("layers/domain/metadata")
       autoload :ExtensionPoint, Project.project_filepath("layers/domain/extension_point")
-      autoload :ScriptJson, Project.project_filepath("layers/domain/script_json")
+      autoload :ScriptConfig, Project.project_filepath("layers/domain/script_config")
       autoload :ScriptProject, Project.project_filepath("layers/domain/script_project")
     end
 

--- a/lib/project_types/script/graphql/app_script_set.graphql
+++ b/lib/project_types/script/graphql/app_script_set.graphql
@@ -6,7 +6,7 @@ mutation AppScriptSet(
   $force: Boolean,
   $schemaMajorVersion: String,
   $schemaMinorVersion: String,
-  $scriptJsonVersion: String!,
+  $scriptConfigVersion: String!,
   $configurationUi: Boolean!,
   $configurationDefinition: String!,
   $moduleUploadUrl: String!,
@@ -20,7 +20,7 @@ mutation AppScriptSet(
     force: $force
     schemaMajorVersion: $schemaMajorVersion
     schemaMinorVersion: $schemaMinorVersion,
-    scriptJsonVersion: $scriptJsonVersion,
+    scriptConfigVersion: $scriptConfigVersion,
     configurationUi: $configurationUi,
     configurationDefinition: $configurationDefinition,
     moduleUploadUrl: $moduleUploadUrl,

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -36,7 +36,7 @@ module Script
               )
 
               install_dependencies(ctx, language, script_name, project_creator)
-              script_project_repo.update_or_create_script_json(title: script_name)
+              script_project_repo.update_or_create_script_config(title: script_name)
               project
             end
           end

--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -36,7 +36,7 @@ module Script
               )
 
               install_dependencies(ctx, language, script_name, project_creator)
-              script_project_repo.update_or_create_script_config(title: script_name)
+              script_project_repo.update_script_config(title: script_name)
               project
             end
           end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -43,7 +43,7 @@ module Script
                 extension_point_type: package.extension_point_type,
                 force: force,
                 metadata: package.metadata,
-                script_json: package.script_json,
+                script_config: package.script_config,
                 module_upload_url: module_upload_url,
                 library: package.library,
               )

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -14,16 +14,13 @@ module Script
           end
         end
 
-        class MissingScriptJsonFieldError < ScriptProjectError
+        class MissingScriptConfigFieldError < ScriptProjectError
           attr_reader :field
           def initialize(field)
             super()
             @field = field
           end
         end
-
-        class InvalidScriptJsonDefinitionError < ScriptProjectError; end
-        class NoScriptJsonFile < ScriptProjectError; end
 
         class ScriptNotFoundError < ScriptProjectError
           attr_reader :script_name, :extension_point_type

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -7,7 +7,7 @@ module Script
         attr_reader :id,
           :uuid,
           :extension_point_type,
-          :script_json,
+          :script_config,
           :script_content,
           :compiled_type,
           :metadata,
@@ -20,7 +20,7 @@ module Script
           script_content:,
           compiled_type: nil,
           metadata:,
-          script_json:,
+          script_config:,
           library:
         )
           @id = id
@@ -29,7 +29,7 @@ module Script
           @script_content = script_content
           @compiled_type = compiled_type
           @metadata = metadata
-          @script_json = script_json
+          @script_config = script_config
           @library = library
         end
       end

--- a/lib/project_types/script/layers/domain/script_config.rb
+++ b/lib/project_types/script/layers/domain/script_config.rb
@@ -16,7 +16,6 @@ module Script
           @title = @content["title"]
           @description = @content["description"]
           @configuration_ui = @content.fetch("configurationUi", true)
-          # should this be called definition?
           @configuration = @content["configuration"]
         end
 

--- a/lib/project_types/script/layers/domain/script_config.rb
+++ b/lib/project_types/script/layers/domain/script_config.rb
@@ -3,7 +3,7 @@
 module Script
   module Layers
     module Domain
-      class ScriptJson
+      class ScriptConfig
         attr_reader :content, :version, :title, :description, :configuration_ui, :configuration
 
         REQUIRED_FIELDS = %w(version title)
@@ -16,6 +16,7 @@ module Script
           @title = @content["title"]
           @description = @content["description"]
           @configuration_ui = @content.fetch("configurationUi", true)
+          # should this be called definition?
           @configuration = @content["configuration"]
         end
 
@@ -23,7 +24,7 @@ module Script
 
         def validate_content!(content)
           REQUIRED_FIELDS.each do |field|
-            raise Errors::MissingScriptJsonFieldError, field if content[field].nil?
+            raise Errors::MissingScriptConfigFieldError, field if content[field].nil?
           end
         end
       end

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -15,7 +15,7 @@ module Script
         property! :script_name, accepts: String
         property! :language, accepts: String
 
-        property :script_json, accepts: ScriptJson
+        property :script_config, accepts: ScriptConfig
 
         def initialize(*)
           super

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -5,9 +5,9 @@ module Script
     module Infrastructure
       module Errors
         class BuildError < ScriptProjectError; end
-        class ScriptJsonSyntaxError < ScriptProjectError; end
+        class ScriptConfigSyntaxError < ScriptProjectError; end
 
-        class ScriptJsonMissingKeysError < ScriptProjectError
+        class ScriptConfigMissingKeysError < ScriptProjectError
           attr_reader :missing_keys
           def initialize(missing_keys)
             super()
@@ -15,7 +15,7 @@ module Script
           end
         end
 
-        class ScriptJsonInvalidValueError < ScriptProjectError
+        class ScriptConfigInvalidValueError < ScriptProjectError
           attr_reader :valid_input_modes
           def initialize(valid_input_modes)
             super()
@@ -23,7 +23,7 @@ module Script
           end
         end
 
-        class ScriptJsonFieldsMissingKeysError < ScriptProjectError
+        class ScriptConfigFieldsMissingKeysError < ScriptProjectError
           attr_reader :missing_keys
           def initialize(missing_keys)
             super()
@@ -31,13 +31,35 @@ module Script
           end
         end
 
-        class ScriptJsonFieldsInvalidValueError < ScriptProjectError
+        class ScriptConfigFieldsInvalidValueError < ScriptProjectError
           attr_reader :valid_types
           def initialize(valid_types)
             super()
             @valid_types = valid_types
           end
         end
+
+        class InvalidScriptConfigYmlDefinitionError < ScriptProjectError; end
+
+        class InvalidScriptJsonDefinitionError < ScriptProjectError; end
+
+        class MissingScriptConfigYmlFieldError < ScriptProjectError
+          attr_reader :field
+          def initialize(field)
+            super()
+            @field = field
+          end
+        end
+
+        class MissingScriptJsonFieldError < ScriptProjectError
+          attr_reader :field
+          def initialize(field)
+            super()
+            @field = field
+          end
+        end
+
+        class NoScriptConfigYmlFileError < ScriptProjectError; end
 
         class APILibraryNotFoundError < ScriptProjectError
           attr_reader :library_name

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -60,6 +60,7 @@ module Script
         end
 
         class NoScriptConfigYmlFileError < ScriptProjectError; end
+        class NoScriptConfigFileError < ScriptProjectError; end
 
         class APILibraryNotFoundError < ScriptProjectError
           attr_reader :library_name

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -18,7 +18,7 @@ module Script
             script_content: script_content,
             compiled_type: compiled_type,
             metadata: metadata,
-            script_json: script_project.script_json,
+            script_config: script_project.script_config,
             library: library
           )
         end
@@ -34,7 +34,7 @@ module Script
             extension_point_type: script_project.extension_point_type,
             script_content: script_content,
             metadata: metadata,
-            script_json: script_project.script_json,
+            script_config: script_project.script_config,
             library: library
           )
         end

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -166,12 +166,12 @@ module Script
           class ScriptConfigYmlRepository
             include SmartProperties
             property! :ctx, accepts: ShopifyCLI::Context
-  
+
             SCRIPT_CONFIG_YML_FILENAME = "script.config.yml"
-  
+
             def get
               return nil unless ctx.file_exist?(SCRIPT_CONFIG_YML_FILENAME)
-  
+
               content = ctx.read(SCRIPT_CONFIG_YML_FILENAME)
               require "yaml"
               begin
@@ -183,35 +183,35 @@ module Script
                 from_h(hash)
               end
             end
-  
+
             def update_or_create(title:)
               hash = get&.content || {}
               hash["version"] ||= "1"
               hash["title"] = title
-  
+
               ctx.write(SCRIPT_CONFIG_YML_FILENAME, YAML.dump(hash))
-  
+
               from_h(hash)
             end
-  
+
             private
-  
+
             def from_h(hash)
               Domain::ScriptConfig.new(content: hash)
             rescue Domain::Errors::MissingScriptConfigFieldError => e
               raise Errors::MissingScriptConfigYmlFieldError, e.field
             end
           end
-  
+
           class ScriptJsonRepository
             include SmartProperties
             property! :ctx, accepts: ShopifyCLI::Context
-  
+
             SCRIPT_JSON_FILENAME = "script.json"
-  
+
             def get
               return nil unless ctx.file_exist?(SCRIPT_JSON_FILENAME)
-  
+
               content = ctx.read(SCRIPT_JSON_FILENAME)
               begin
                 hash = JSON.parse(content)
@@ -221,21 +221,21 @@ module Script
                 from_h(hash)
               end
             end
-  
+
             def update(title:)
               existing = get
               return nil if existing.nil?
               hash = existing.content
               hash["version"] ||= "1"
               hash["title"] = title
-  
+
               ctx.write(SCRIPT_JSON_FILENAME, JSON.pretty_generate(hash))
-  
+
               from_h(hash)
             end
-  
+
             private
-  
+
             def from_h(hash)
               Domain::ScriptConfig.new(content: hash)
             rescue Domain::Errors::MissingScriptConfigFieldError => e

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -177,7 +177,7 @@ module Script
             require "yaml"
             begin
               hash = YAML.load(content)
-            rescue Psych::SyntaxError => e
+            rescue Psych::SyntaxError
               raise Errors::InvalidScriptConfigYmlDefinitionError
             else
               raise Errors::InvalidScriptConfigYmlDefinitionError unless hash.is_a?(Hash)
@@ -216,7 +216,7 @@ module Script
             content = ctx.read(SCRIPT_JSON_FILENAME)
             begin
               hash = JSON.parse(content)
-            rescue JSON::ParserError => e
+            rescue JSON::ParserError
               raise Errors::InvalidScriptJsonDefinitionError
             else
               from_h(hash)

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -159,7 +159,7 @@ module Script
           private
 
           def update_hash(hash:, title:)
-            hash["version"] ||= "1"
+            hash["version"] ||= "2"
             hash["title"] = title
           end
 

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -189,10 +189,21 @@ module Script
           end
 
           # to be implemented by subclasses
-          def filename; end
-          def file_content_to_hash(file_content); end
-          def hash_to_file_content(hash); end
-          def missing_field_error; end
+          def filename
+            raise NotImplementedError
+          end
+
+          def file_content_to_hash(file_content)
+            raise NotImplementedError
+          end
+
+          def hash_to_file_content(hash)
+            raise NotImplementedError
+          end
+
+          def missing_field_error
+            raise NotImplementedError
+          end
         end
 
         class ScriptConfigYmlRepository < ScriptConfigRepository

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -162,85 +162,85 @@ module Script
           def json_repository
             @json_repository ||= ScriptJsonRepository.new(ctx: ctx)
           end
-        end
 
-        class ScriptConfigYmlRepository
-          include SmartProperties
-          property! :ctx, accepts: ShopifyCLI::Context
-
-          SCRIPT_CONFIG_YML_FILENAME = "script.config.yml"
-
-          def get
-            return nil unless ctx.file_exist?(SCRIPT_CONFIG_YML_FILENAME)
-
-            content = ctx.read(SCRIPT_CONFIG_YML_FILENAME)
-            require "yaml"
-            begin
-              hash = YAML.load(content)
-            rescue Psych::SyntaxError
-              raise Errors::InvalidScriptConfigYmlDefinitionError
-            else
-              raise Errors::InvalidScriptConfigYmlDefinitionError unless hash.is_a?(Hash)
+          class ScriptConfigYmlRepository
+            include SmartProperties
+            property! :ctx, accepts: ShopifyCLI::Context
+  
+            SCRIPT_CONFIG_YML_FILENAME = "script.config.yml"
+  
+            def get
+              return nil unless ctx.file_exist?(SCRIPT_CONFIG_YML_FILENAME)
+  
+              content = ctx.read(SCRIPT_CONFIG_YML_FILENAME)
+              require "yaml"
+              begin
+                hash = YAML.load(content)
+              rescue Psych::SyntaxError
+                raise Errors::InvalidScriptConfigYmlDefinitionError
+              else
+                raise Errors::InvalidScriptConfigYmlDefinitionError unless hash.is_a?(Hash)
+                from_h(hash)
+              end
+            end
+  
+            def update_or_create(title:)
+              hash = get&.content || {}
+              hash["version"] ||= "1"
+              hash["title"] = title
+  
+              ctx.write(SCRIPT_CONFIG_YML_FILENAME, YAML.dump(hash))
+  
               from_h(hash)
             end
-          end
-
-          def update_or_create(title:)
-            hash = get&.content || {}
-            hash["version"] ||= "1"
-            hash["title"] = title
-
-            ctx.write(SCRIPT_CONFIG_YML_FILENAME, YAML.dump(hash))
-
-            from_h(hash)
-          end
-
-          private
-
-          def from_h(hash)
-            Domain::ScriptConfig.new(content: hash)
-          rescue Domain::Errors::MissingScriptConfigFieldError => e
-            raise Errors::MissingScriptConfigYmlFieldError, e.field
-          end
-        end
-
-        class ScriptJsonRepository
-          include SmartProperties
-          property! :ctx, accepts: ShopifyCLI::Context
-
-          SCRIPT_JSON_FILENAME = "script.json"
-
-          def get
-            return nil unless ctx.file_exist?(SCRIPT_JSON_FILENAME)
-
-            content = ctx.read(SCRIPT_JSON_FILENAME)
-            begin
-              hash = JSON.parse(content)
-            rescue JSON::ParserError
-              raise Errors::InvalidScriptJsonDefinitionError
-            else
-              from_h(hash)
+  
+            private
+  
+            def from_h(hash)
+              Domain::ScriptConfig.new(content: hash)
+            rescue Domain::Errors::MissingScriptConfigFieldError => e
+              raise Errors::MissingScriptConfigYmlFieldError, e.field
             end
           end
-
-          def update(title:)
-            existing = get
-            return nil if existing.nil?
-            hash = existing.content
-            hash["version"] ||= "1"
-            hash["title"] = title
-
-            ctx.write(SCRIPT_JSON_FILENAME, JSON.pretty_generate(hash))
-
-            from_h(hash)
-          end
-
-          private
-
-          def from_h(hash)
-            Domain::ScriptConfig.new(content: hash)
-          rescue Domain::Errors::MissingScriptConfigFieldError => e
-            raise Errors::MissingScriptJsonFieldError, e.field
+  
+          class ScriptJsonRepository
+            include SmartProperties
+            property! :ctx, accepts: ShopifyCLI::Context
+  
+            SCRIPT_JSON_FILENAME = "script.json"
+  
+            def get
+              return nil unless ctx.file_exist?(SCRIPT_JSON_FILENAME)
+  
+              content = ctx.read(SCRIPT_JSON_FILENAME)
+              begin
+                hash = JSON.parse(content)
+              rescue JSON::ParserError
+                raise Errors::InvalidScriptJsonDefinitionError
+              else
+                from_h(hash)
+              end
+            end
+  
+            def update(title:)
+              existing = get
+              return nil if existing.nil?
+              hash = existing.content
+              hash["version"] ||= "1"
+              hash["title"] = title
+  
+              ctx.write(SCRIPT_JSON_FILENAME, JSON.pretty_generate(hash))
+  
+              from_h(hash)
+            end
+  
+            private
+  
+            def from_h(hash)
+              Domain::ScriptConfig.new(content: hash)
+            rescue Domain::Errors::MissingScriptConfigFieldError => e
+              raise Errors::MissingScriptJsonFieldError, e.field
+            end
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -17,7 +17,7 @@ module Script
           extension_point_type:,
           force: false,
           metadata:,
-          script_json:,
+          script_config:,
           module_upload_url:,
           library:
         )
@@ -25,14 +25,14 @@ module Script
           variables = {
             uuid: uuid,
             extensionPointName: extension_point_type.upcase,
-            title: script_json.title,
-            description: script_json.description,
+            title: script_config.title,
+            description: script_config.description,
             force: force,
             schemaMajorVersion: metadata.schema_major_version.to_s, # API expects string value
             schemaMinorVersion: metadata.schema_minor_version.to_s, # API expects string value
-            scriptJsonVersion: script_json.version,
-            configurationUi: script_json.configuration_ui,
-            configurationDefinition: script_json.configuration&.to_json,
+            scriptConfigVersion: script_config.version,
+            configurationUi: script_config.configuration_ui,
+            configurationDefinition: script_config.configuration&.to_json,
             moduleUploadUrl: module_upload_url,
             library: {
               language: library[:language],
@@ -47,19 +47,19 @@ module Script
           if user_errors.any? { |e| e["tag"] == "already_exists_error" }
             raise Errors::ScriptRepushError, uuid
           elsif (e = user_errors.any? { |err| err["tag"] == "configuration_definition_syntax_error" })
-            raise Errors::ScriptJsonSyntaxError
+            raise Errors::ScriptConfigSyntaxError
           elsif (e = user_errors.find { |err| err["tag"] == "configuration_definition_missing_keys_error" })
-            raise Errors::ScriptJsonMissingKeysError, e["message"]
+            raise Errors::ScriptConfigMissingKeysError, e["message"]
           elsif (e = user_errors.find { |err| err["tag"] == "configuration_definition_invalid_value_error" })
-            raise Errors::ScriptJsonInvalidValueError, e["message"]
+            raise Errors::ScriptConfigInvalidValueError, e["message"]
           elsif (e = user_errors.find do |err|
                    err["tag"] == "configuration_definition_schema_field_missing_keys_error"
                  end)
-            raise Errors::ScriptJsonFieldsMissingKeysError, e["message"]
+            raise Errors::ScriptConfigFieldsMissingKeysError, e["message"]
           elsif (e = user_errors.find do |err|
                    err["tag"] == "configuration_definition_schema_field_invalid_value_error"
                  end)
-            raise Errors::ScriptJsonFieldsInvalidValueError, e["message"]
+            raise Errors::ScriptConfigFieldsInvalidValueError, e["message"]
           elsif user_errors.find { |err| %w(not_use_msgpack_error schema_version_argument_error).include?(err["tag"]) }
             raise Domain::Errors::MetadataValidationError
           else

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -47,14 +47,20 @@ module Script
           invalid_language_cause: "Invalid language %s.",
           invalid_language_help: "Allowed values: %s.",
 
+          missing_script_config_yml_field_cause: "The script.config.yml file is missing the required %s field.",
+          missing_script_config_yml_field_help: "Add the field and try again.",
+
           missing_script_json_field_cause: "The script.json file is missing the required %s field.",
           missing_script_json_field_help: "Add the field and try again.",
 
           invalid_script_json_definition_cause: "The script.json file contains invalid JSON.",
           invalid_script_json_definition_help: "Fix the errors and try again.",
 
-          no_script_json_file_cause: "The script.json file is missing.",
-          no_script_json_file_help: "Create this file and try again.",
+          invalid_script_config_yml_definition_cause: "The script.config.yml file contains invalid YAML.",
+          invalid_script_config_yml_definition_help: "Fix the errors and try again.",
+
+          no_script_config_yml_file_cause: "The script.config.yml file is missing.",
+          no_script_config_yml_file_help: "Create this file and try again.",
 
           configuration_syntax_error_cause: "The script.json is not formatted properly.",
           configuration_syntax_error_help: "Fix the errors and try again.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -103,32 +103,47 @@ module Script
             cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause"),
             help_suggestion: ShopifyCLI::Context.message("script.error.metadata_not_found_help"),
           }
-        when Layers::Domain::Errors::MissingScriptJsonFieldError
-          {
-            cause_of_error: ShopifyCLI::Context.message("script.error.missing_script_json_field_cause", e.field),
-            help_suggestion: ShopifyCLI::Context.message("script.error.missing_script_json_field_help"),
-          }
-        when Layers::Domain::Errors::InvalidScriptJsonDefinitionError
-          {
-            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_cause"),
-            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_help"),
-          }
-        when Layers::Domain::Errors::NoScriptJsonFile
-          {
-            cause_of_error: ShopifyCLI::Context.message("script.error.no_script_json_file_cause"),
-            help_suggestion: ShopifyCLI::Context.message("script.error.no_script_json_file_help"),
-          }
         when Layers::Infrastructure::Errors::BuildError
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.build_error_cause"),
             help_suggestion: ShopifyCLI::Context.message("script.error.build_error_help"),
           }
-        when Layers::Infrastructure::Errors::ScriptJsonSyntaxError
+        when Layers::Infrastructure::Errors::InvalidScriptConfigYmlDefinitionError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_script_config_yml_definition_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_script_config_yml_definition_help"),
+          }
+        when Layers::Infrastructure::Errors::InvalidScriptJsonDefinitionError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.invalid_script_json_definition_help"),
+          }
+        when Layers::Infrastructure::Errors::MissingScriptConfigYmlFieldError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.missing_script_config_yml_field_cause", e.field),
+            help_suggestion: ShopifyCLI::Context.message("script.error.missing_script_config_yml_field_help"),
+          }
+        when Layers::Infrastructure::Errors::MissingScriptConfigYmlFieldError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.missing_script_config_yml_field_cause", e.field),
+            help_suggestion: ShopifyCLI::Context.message("script.error.missing_script_config_yml_field_help"),
+          }
+        when Layers::Infrastructure::Errors::MissingScriptJsonFieldError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.missing_script_json_field_cause", e.field),
+            help_suggestion: ShopifyCLI::Context.message("script.error.missing_script_json_field_help"),
+          }
+        when Layers::Infrastructure::Errors::NoScriptConfigYmlFileError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.no_script_config_yml_file_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.no_script_config_yml_file_help"),
+          }
+        when Layers::Infrastructure::Errors::ScriptConfigSyntaxError
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.configuration_syntax_error_cause"),
             help_suggestion: ShopifyCLI::Context.message("script.error.configuration_syntax_error_help"),
           }
-        when Layers::Infrastructure::Errors::ScriptJsonMissingKeysError
+        when Layers::Infrastructure::Errors::ScriptConfigMissingKeysError
           {
             cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_missing_keys_error_cause",
@@ -136,7 +151,7 @@ module Script
             ),
             help_suggestion: ShopifyCLI::Context.message("script.error.configuration_missing_keys_error_help"),
           }
-        when Layers::Infrastructure::Errors::ScriptJsonInvalidValueError
+        when Layers::Infrastructure::Errors::ScriptConfigInvalidValueError
           {
             cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_invalid_value_error_cause",
@@ -144,7 +159,7 @@ module Script
             ),
             help_suggestion: ShopifyCLI::Context.message("script.error.configuration_invalid_value_error_help"),
           }
-        when Layers::Infrastructure::Errors::ScriptJsonFieldsMissingKeysError
+        when Layers::Infrastructure::Errors::ScriptConfigFieldsMissingKeysError
           {
             cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_schema_field_missing_keys_error_cause",
@@ -154,7 +169,7 @@ module Script
               "script.error.configuration_definition_schema_field_missing_keys_error_help"
             ),
           }
-        when Layers::Infrastructure::Errors::ScriptJsonFieldsInvalidValueError
+        when Layers::Infrastructure::Errors::ScriptConfigFieldsInvalidValueError
           {
             cause_of_error: ShopifyCLI::Context.message(
               "script.error.configuration_schema_field_invalid_value_error_cause",

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -124,7 +124,7 @@ describe Script::Layers::Application::CreateScript do
         context.dir_exist?(script_name)
       end
 
-      it "should update the script.config.yml file" do
+      it "should update the script configuration file" do
         subject
 
         script_config = script_project_repository.get.script_config

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -7,7 +7,6 @@ describe Script::Layers::Application::CreateScript do
 
   let(:script_name) { "path" }
   let(:compiled_type) { "wasm" }
-  let(:script_json_filename) { "script.json" }
 
   let(:extension_point_repository) { TestHelpers::FakeExtensionPointRepository.new }
   let(:script_project_repository) { TestHelpers::FakeScriptProjectRepository.new }
@@ -125,12 +124,12 @@ describe Script::Layers::Application::CreateScript do
         context.dir_exist?(script_name)
       end
 
-      it "should update the script.json file" do
+      it "should update the script.config.yml file" do
         subject
 
-        script_json = script_project_repository.get.script_json
-        assert_equal script_name, script_json.title
-        assert_equal "1", script_json.version
+        script_config = script_project_repository.get.script_config
+        assert_equal script_name, script_config.title
+        assert_equal "1", script_config.version
       end
     end
 

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -6,7 +6,7 @@ describe Script::Layers::Domain::PushPackage do
   let(:uuid) { "uuid" }
   let(:extension_point_type) { "discount" }
   let(:script_id) { "id" }
-  let(:script_json) { { "version" => "1", "title" => "title" } }
+  let(:script_config) { { "version" => "1", "title" => "title" } }
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
@@ -25,7 +25,7 @@ describe Script::Layers::Domain::PushPackage do
       id: id,
       uuid: uuid,
       extension_point_type: extension_point_type,
-      script_json: script_json,
+      script_config: script_config,
       script_content: script_content,
       compiled_type: compiled_type,
       metadata: metadata,
@@ -42,7 +42,7 @@ describe Script::Layers::Domain::PushPackage do
       assert_equal id, subject.id
       assert_equal uuid, subject.uuid
       assert_equal extension_point_type, subject.extension_point_type
-      assert_equal script_json, subject.script_json
+      assert_equal script_config, subject.script_config
       assert_equal script_content, subject.script_content
       assert_equal compiled_type, subject.compiled_type
       assert_equal metadata, subject.metadata

--- a/test/project_types/script/layers/domain/script_config_test.rb
+++ b/test/project_types/script/layers/domain/script_config_test.rb
@@ -2,7 +2,7 @@
 
 require "project_types/script/test_helper"
 
-describe Script::Layers::Domain::ScriptJson do
+describe Script::Layers::Domain::ScriptConfig do
   let(:content) do
     {
       "version" => "1",
@@ -13,10 +13,10 @@ describe Script::Layers::Domain::ScriptJson do
     }
   end
 
-  subject { Script::Layers::Domain::ScriptJson.new(content: content) }
+  subject { Script::Layers::Domain::ScriptConfig.new(content: content) }
 
   describe "#initialize" do
-    it "constructs a ScriptJson" do
+    it "constructs a ScriptConfig" do
       assert_equal("1", subject.version)
       assert_equal("Some Title", subject.title)
       assert_equal("Some Description", subject.description)

--- a/test/project_types/script/layers/domain/script_project_test.rb
+++ b/test/project_types/script/layers/domain/script_project_test.rb
@@ -8,8 +8,8 @@ describe Script::Layers::Domain::ScriptProject do
   let(:extension_point_type) { "discount" }
   let(:script_name) { "foo_script" }
   let(:language) { "assemblyscript" }
-  let(:script_json) { Script::Layers::Domain::ScriptJson.new(content: script_json_content) }
-  let(:script_json_content) do
+  let(:script_config) { Script::Layers::Domain::ScriptConfig.new(content: script_config_content) }
+  let(:script_config_content) do
     {
       "version" => "1",
       "title" => script_name,
@@ -26,7 +26,7 @@ describe Script::Layers::Domain::ScriptProject do
         extension_point_type: extension_point_type,
         script_name: script_name,
         language: language,
-        script_json: script_json,
+        script_config: script_config,
       }
     end
     let(:args) { all_args }
@@ -47,7 +47,7 @@ describe Script::Layers::Domain::ScriptProject do
         assert_equal extension_point_type, subject.extension_point_type
         assert_equal script_name, subject.script_name
         assert_equal language, subject.language
-        assert_equal script_json, subject.script_json
+        assert_equal script_config, subject.script_config
       end
     end
 
@@ -60,12 +60,12 @@ describe Script::Layers::Domain::ScriptProject do
         assert_equal extension_point_type, subject.extension_point_type
         assert_equal script_name, subject.script_name
         assert_equal language, subject.language
-        assert_nil subject.script_json
+        assert_nil subject.script_config
       end
     end
 
     describe "when required properties are missing" do
-      let(:args) { all_args.slice(:env, :script_json) }
+      let(:args) { all_args.slice(:env, :script_config) }
 
       it "should raise" do
         assert_raises(SmartProperties::InitializationError) { subject }

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -79,7 +79,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     let(:script_config) { "script.config.yml" }
     let(:script_config_content) do
       {
-        "version" => "1",
+        "version" => "2",
         "title" => script_name,
         "configuration" => {
           "type": "single",
@@ -212,7 +212,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     let(:uuid) { "uuid" }
     let(:updated_uuid) { "updated_uuid" }
     let(:script_config) { "script.config.yml" }
-    let(:script_config_content) { { "version" => "1", "title" => script_name }.to_json }
+    let(:script_config_content) { { "version" => "2", "title" => script_name }.to_json }
     let(:env) { ShopifyCLI::Resources::EnvFile.new(api_key: "123", secret: "foo", extra: env_extra) }
     let(:env_extra) { { "uuid" => "original_uuid", "something" => "else" } }
     let(:valid_config) do
@@ -317,8 +317,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         assert script_config.configuration_ui
         assert_equal new_title, script_config.title
         assert_equal new_title, file_content["title"]
-        assert_equal "1", file_content["version"]
-        assert_equal "1", script_config.version
+        assert_equal "2", file_content["version"]
+        assert_equal "2", script_config.version
 
         assert_nil script_config.content["description"]
         assert_nil file_content["description"]
@@ -332,7 +332,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       let(:initial_description) { "my description" }
       let(:script_config_content) do
         {
-          "version" => "1",
+          "version" => "2",
           "title" => initial_title,
           "description" => initial_description,
           "configuration" => {
@@ -376,7 +376,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       let(:initial_description) { "my description" }
       let(:script_config_content) do
         {
-          "version" => "1",
+          "version" => "2",
           "title" => initial_title,
           "description" => initial_description,
           "configuration" => {
@@ -419,7 +419,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
   describe "ScriptConfigYmlRepository" do
     let(:instance) { Script::Layers::Infrastructure::ScriptProjectRepository::ScriptConfigYmlRepository.new(ctx: ctx) }
-    let(:version) { "1" }
+    let(:version) { "2" }
     let(:title) { "title" }
     let(:content) { { "version" => version, "title" => title }.to_yaml }
 
@@ -496,7 +496,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
   describe "ScriptJsonRepository" do
     let(:instance) { Script::Layers::Infrastructure::ScriptProjectRepository::ScriptJsonRepository.new(ctx: ctx) }
-    let(:version) { "1" }
+    let(:version) { "2" }
     let(:title) { "title" }
     let(:content) { { "version" => version, "title" => title }.to_json }
     let(:script_config_filename) { "script.json" }

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -428,7 +428,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "returns nil" do
-          assert_nil(subject)
+          assert_nil subject
         end
       end
 
@@ -464,6 +464,10 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         describe "when content is valid yaml" do
           it "returns the entity" do
             assert_equal version, subject.version
+            assert_equal title, subject.title
+            assert_nil subject.description
+            assert subject.configuration_ui
+            assert_nil subject.configuration
           end
         end
       end
@@ -475,9 +479,15 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "creates a ScriptConfig" do
-          refute_nil(subject)
-          assert_equal(new_title, subject.title)
-          assert_equal(version, subject.version)
+          assert_equal new_title, subject.title
+          assert_equal version, subject.version
+        end
+
+        it "creates the file" do
+          subject
+          file_content = YAML.load(File.read(script_config_filename))
+          assert_equal version, file_content["version"]
+          assert_equal new_title, file_content["title"]
         end
       end
 
@@ -487,8 +497,18 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         end
 
         it "updates the ScriptConfig" do
-          assert_equal(new_title, subject.title)
-          assert_equal(version, subject.version)
+          assert_equal version, subject.version
+          assert_equal new_title, subject.title
+          assert_nil subject.description
+          assert subject.configuration_ui
+          assert_nil subject.configuration
+        end
+
+        it "updates the file" do
+          subject
+          file_content = YAML.load(File.read(script_config_filename))
+          assert_equal version, file_content["version"]
+          assert_equal new_title, file_content["title"]
         end
       end
     end
@@ -506,7 +526,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "returns nil" do
-          assert_nil(subject)
+          assert_nil subject
         end
       end
 
@@ -542,6 +562,10 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         describe "when content is valid yaml" do
           it "returns the entity" do
             assert_equal version, subject.version
+            assert_equal title, subject.title
+            assert_nil subject.description
+            assert subject.configuration_ui
+            assert_nil subject.configuration
           end
         end
       end
@@ -553,7 +577,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "returns nil" do
-          assert_nil(subject)
+          assert_nil subject
         end
       end
 
@@ -563,8 +587,18 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         end
 
         it "updates the ScriptConfig" do
-          assert_equal(new_title, subject.title)
-          assert_equal(version, subject.version)
+          assert_equal version, subject.version
+          assert_equal new_title, subject.title
+          assert_nil subject.description
+          assert subject.configuration_ui
+          assert_nil subject.configuration
+        end
+
+        it "updates the file" do
+          subject
+          file_content = JSON.parse(File.read(script_config_filename))
+          assert_equal version, file_content["version"]
+          assert_equal new_title, file_content["title"]
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -11,14 +11,14 @@ describe Script::Layers::Infrastructure::ScriptService do
   let(:schema_major_version) { "1" }
   let(:schema_minor_version) { "0" }
   let(:use_msgpack) { true }
-  let(:script_json) do
-    Script::Layers::Domain::ScriptJson.new(content: expected_script_json_content)
+  let(:script_config) do
+    Script::Layers::Domain::ScriptConfig.new(content: expected_script_config_content)
   end
   let(:script_name) { "script name" }
-  let(:script_json_version) { "1" }
+  let(:script_config_version) { "1" }
   let(:expected_description) { "some description" }
   let(:expected_configuration_ui) { true }
-  let(:expected_script_json_version) { "1" }
+  let(:expected_script_config_version) { "1" }
   let(:expected_configuration) do
     {
       "type" => "single",
@@ -33,9 +33,9 @@ describe Script::Layers::Infrastructure::ScriptService do
       ],
     }
   end
-  let(:expected_script_json_content) do
+  let(:expected_script_config_content) do
     {
-      "version" => expected_script_json_version,
+      "version" => expected_script_config_version,
       "title" => script_name,
       "description" => expected_description,
       "configuration" => expected_configuration,
@@ -71,7 +71,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           schema_minor_version,
           use_msgpack,
         ),
-        script_json: script_json,
+        script_config: script_config,
         module_upload_url: url,
         library: library
       )

--- a/test/project_types/script/test_helpers/fake_push_package_repository.rb
+++ b/test/project_types/script/test_helpers/fake_push_package_repository.rb
@@ -21,7 +21,7 @@ module TestHelpers
         script_content: script_content,
         compiled_type: compiled_type,
         metadata: metadata,
-        script_json: script_project.script_json,
+        script_config: script_project.script_config,
         library: library
       )
     end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -36,9 +36,9 @@ module TestHelpers
       @project
     end
 
-    def update_or_create_script_config(title:)
+    def update_script_config(title:)
       script_config = fake_script_config_repo
-        .update_or_create(title: title)
+        .update!(title: title)
 
       @project.script_config = script_config
       @project
@@ -59,14 +59,15 @@ module TestHelpers
         @cache = Script::Layers::Domain::ScriptConfig.new(content: content)
       end
 
-      def update_or_create(title:)
-        hash = @cache&.content || {}
+      def update!(title:)
+        hash = get!.content
         hash["title"] = title
 
         @cache = Script::Layers::Domain::ScriptConfig.new(content: hash)
       end
 
-      def get
+      def get!
+        raise Script::Layers::Infrastructure::Errors::NoScriptConfigFileError if @cache.nil?
         @cache
       end
     end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -7,7 +7,7 @@ module TestHelpers
     end
 
     def create(script_name:, extension_point_type:, language:, env: nil)
-      script_json = fake_script_json_repo.create({ version: 1, title: script_name }.to_json)
+      script_config = fake_script_config_repo.create({ "version" => 1, "title" => script_name })
 
       @project = Script::Layers::Domain::ScriptProject.new(
         id: "/#{script_name}",
@@ -15,7 +15,7 @@ module TestHelpers
         script_name: script_name,
         extension_point_type: extension_point_type,
         language: language,
-        script_json: script_json
+        script_config: script_config
       )
     end
 
@@ -36,38 +36,34 @@ module TestHelpers
       @project
     end
 
-    def update_or_create_script_json(title:)
-      script_json = fake_script_json_repo
+    def update_or_create_script_config(title:)
+      script_config = fake_script_config_repo
         .update_or_create(title: title)
 
-      @project.script_json = script_json
+      @project.script_config = script_config
       @project
     end
 
     private
 
-    def fake_script_json_repo
-      @fake_script_json_repo ||= FakeScriptJsonRepository.new
+    def fake_script_config_repo
+      @fake_script_config_repo ||= FakeScriptConfigRepository.new
     end
 
-    class FakeScriptJsonRepository
+    class FakeScriptConfigRepository
       def initialize
         @cache = nil
       end
 
       def create(content)
-        @cache = Script::Layers::Domain::ScriptJson.new(
-          content: JSON.parse(content),
-        )
+        @cache = Script::Layers::Domain::ScriptConfig.new(content: content)
       end
 
       def update_or_create(title:)
-        json = @cache&.content || {}
-        json["title"] = title
+        hash = @cache&.content || {}
+        hash["title"] = title
 
-        @cache = Script::Layers::Domain::ScriptJson.new(
-          content: json,
-        )
+        @cache = Script::Layers::Domain::ScriptConfig.new(content: hash)
       end
 
       def get

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -170,15 +170,36 @@ describe Script::UI::ErrorHandler do
         end
       end
 
-      describe "when InvalidScriptJsonDefinitionError" do
-        let(:err) { Script::Layers::Domain::Errors::InvalidScriptJsonDefinitionError.new("filename") }
+      describe "when InvalidScriptConfigYmlDefinitionError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidScriptConfigYmlDefinitionError.new("filename") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
-      describe "when NoScriptJsonFile" do
-        let(:err) { Script::Layers::Domain::Errors::NoScriptJsonFile.new("filename") }
+      describe "when InvalidScriptJsonDefinitionError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidScriptJsonDefinitionError.new("filename") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when MissingScriptConfigYmlFieldError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::MissingScriptConfigYmlFieldError.new("field") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when MissingScriptJsonFieldError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::MissingScriptJsonFieldError.new("field") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when NoScriptConfigYmlFileError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::NoScriptConfigYmlFileError.new("filename") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
@@ -212,36 +233,36 @@ describe Script::UI::ErrorHandler do
         end
       end
 
-      describe "when ScriptJsonSyntaxError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptJsonSyntaxError.new }
+      describe "when ScriptConfigSyntaxError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigSyntaxError.new }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
-      describe "when ScriptJsonMissingKeysError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptJsonMissingKeysError.new("keys") }
+      describe "when ScriptConfigMissingKeysError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigMissingKeysError.new("keys") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
-      describe "when ScriptJsonInvalidValueError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptJsonInvalidValueError.new("input modes") }
+      describe "when ScriptConfigInvalidValueError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigInvalidValueError.new("input modes") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
-      describe "when ScriptJsonFieldsMissingKeysError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptJsonFieldsMissingKeysError.new("keys") }
+      describe "when ScriptConfigFieldsMissingKeysError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigFieldsMissingKeysError.new("keys") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
       end
 
-      describe "when ScriptJsonFieldsInvalidValueError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::ScriptJsonFieldsInvalidValueError.new("types") }
+      describe "when ScriptConfigFieldsInvalidValueError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigFieldsInvalidValueError.new("types") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/3729

<!--
  Context about the problem that’s being addressed.
-->
As explained in the issue, we want to more closely align with other teams like UI Extensions.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Adds support for using a `script.config.yml` file for encoding Script configuration. If the `script.config.yml` is not present but a `script.json` is, we will use that.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
#### See that `script.json` still works
1. Create a new script with `shopify script create` and select `shipping-methods` API and TypeScript language
2. See that `script.json` has the right title (what you entered as the name of the script)
3. Update the `script.json` to have some fields
4. Push the script with `shopify script push`
5. See the configuration fields when trying to enable the customization on your shop in the shipping settings

#### See that `script.config.json` works
1. Create a new script with `shopify script create --branch=ap/script-config-yml` and select `shipping-methods` API and TypeScript language
2. See that the `script.config.yml` has the right title (what you entered as the name of the script)
3. Update the `script.config.yml` to have some fields
4. Push the script with `shopify script push`
5. See the configuration fields when trying to enable the customization on your shop in the shipping settings

#### See that no configuration file raises error
1. Remove the `script.json` or `script.config.yml` from one of the above script projects you created
2. Try to push the script with `shopify script push`
3. See an error message that a `script.config.yml` file must be present

#### See that removing required fields raises error
1. Remove the `title` or `version` field from the `script.json` or `script.config.yml` from one of the above script projects you created
2. Try to push the script with `shopify script push`
3. See an error message that the configuration file is missing the field you removed


### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.