### PR TITLE
Fix hot reload when users update many files "simultaneously"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1807](https://github.com/Shopify/shopify-cli/pull/1807): Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command
 * [#1812](https://github.com/Shopify/shopify-cli/pull/1812): App creation with Rails 7
 * [#1821](https://github.com/Shopify/shopify-cli/pull/1821): Fix Shopify hosted fonts to load via the local preview URL
+* [#1830](https://github.com/Shopify/shopify-cli/pull/1830): Fix hot reload when users update many files "simultaneously"
 
 ## Version 2.7.2
 ### Fixed

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -17,19 +17,35 @@
 
   connect();
 
+  function isRefreshRequired(files) {
+    return files.some((file) => !isCssFile(file) && !isSectionFile(file));
+  }
+
+  function refreshFile(file) {
+    if (isCssFile(file)) {
+      reloadCssFile(file);
+      return;
+    }
+
+    if (isSectionFile(file)) {
+      reloadSection(file);
+      return;
+    }
+  }
+
+  function refreshPage() {
+    console.log('[HotReload] Refreshing entire page');
+    window.location.reload();
+  }
+
   function handleUpdate(message) {
     var data = JSON.parse(message.data);
+    var modifiedFiles = data.modified;
 
-    // Assume only one file is modified at a time
-    var modified = data.modified[0];
-
-    if (isCssFile(modified)) {
-      reloadCssFile(modified)
-    } else if (isSectionFile(modified)) {
-      reloadSection(modified);
+    if (isRefreshRequired(modifiedFiles)) {
+      refreshPage();
     } else {
-      console.log(`[HotReload] Refreshing entire page`);
-      window.location.reload();
+      modifiedFiles.forEach(refreshFile);
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Some users rely on tools over their theme (like Webpack) to update multiple files in a very short period of time.

The `message.date.modified`  list may contain multiple files in that kind of scenario. However, if the first file of the list doesn't require refreshing the entire page, while the second file does, the changes from the second file are not covered by the hot reload mechanism.

### WHAT is this pull request doing?

This pull request introduces changes in the `hot-reload.js` module to analyze all modified files instead of considering only the first one (inspired by https://github.com/Shopify/shopify-cli/pull/1458).

### How to test your changes?

Download the `reproducer_remove_me.rb` [here](https://gist.github.com/karreiro/319bae3a086331b25df1b341572da248).

```bash
# Initialize a new theme
$ shopify-dev theme init my_theme

# `theme serve` it
$ cd my_theme
$ pwd
/Users/karreiro/theme # ← Keep this path in mind
$ shopify-dev theme serve

# Open a a different terminal window
# Use the path above as a parameter for the `reproducer_remove_me.rb` reproducer
$ ruby reproducer_remove_me.rb /Users/karreiro/theme/my_theme
```

Before this PR:
![Kapture 2021-12-07 at 14 52 27](https://user-images.githubusercontent.com/1079279/145054974-ee6bfd36-c210-413b-b85e-80c9e0e4f109.gif)

After this PR:
![Kapture 2021-12-07 at 14 43 55](https://user-images.githubusercontent.com/1079279/145054983-33f28d22-3523-4749-927f-170fcc1ee8ac.gif)

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.