### PR TITLE
Ensure correct ngrok version is downloaded for Apple M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 
 ### Fixed
+* [#1831](https://github.com/Shopify/shopify-cli/pull/1831): Ensure correct `ngrok` version is downloaded for Apple M1
 * [#1823](https://github.com/Shopify/shopify-cli/pull/1823): Indicate git is unavailable; don't error out
 * [#1807](https://github.com/Shopify/shopify-cli/pull/1807): Fix `--live` parameter, it should not imply `--allow-live` in the `theme push` command
 * [#1812](https://github.com/Shopify/shopify-cli/pull/1812): App creation with Rails 7

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -61,6 +61,7 @@ module ShopifyCLI
     # will return which operating system that the cli is running on [:mac, :linux]
     def os
       host = uname
+      return :mac_m1 if /arm64-apple-darwin/i.match(host)
       return :mac if /darwin/i.match(host)
       return :windows if /mswin|mingw|cygwin/i.match(host)
       return :linux if /linux|bsd/i.match(host)

--- a/lib/shopify_cli/tunnel.rb
+++ b/lib/shopify_cli/tunnel.rb
@@ -21,6 +21,7 @@ module ShopifyCLI
     # mapping for supported operating systems for where to download ngrok from.
     DOWNLOAD_URLS = {
       mac: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip",
+      mac_m1: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-arm64.zip",
       linux: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip",
       windows: "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip",
     }


### PR DESCRIPTION
This patch adds support for installing the proper version of
ngrok when running `shopify app serve` on M1 macs.

Specifically, this patch updates the `os` property of the shop-cli
context with a new key `mac_m1`, not just `mac`, and updates the
DOWNLOAD_URL dictionary.

Fixes #1785

### How to test your changes?

Pull down the branch, install it locally, create a new app and try to serve it..

```bash
bundle install
bundle exec shopify app create node
bundle exec shopify app serve
```

As discussed in the bug, previously the ngrok tunnel step would fail.

```bash
➜  test-m1 git:(m1-support) ✗ bundle exec shopify app serve    
⭑ You are running a development version of the CLI at:
  /Users/stevemartinelli/workspace/stevemar/shopify-cli/bin/shopify
✓ curl @ /usr/bin/curl
✓ tar @ /usr/bin/tar
✓ Installing ngrok…
✓ ngrok tunnel running at https://fd15-76-68-94-203.ngrok.io
⭑ To avoid tunnels that timeout, it is recommended to signup for a free ngrok
account at https://ngrok.com/signup. After you signup, install your
personalized authorization token using shopify [ node | rails ] tunnel auth <token>.
✓ .env saved to project root
```

### Verifying change

The new version is `arm64` based

```bash
➜  shopify-cli git:(m1-support) ✗ lipo -info ~/.cache/shopify/ngrok 
Non-fat file: /Users/stevemartinelli/.cache/shopify/ngrok is architecture: arm64
```

The old version was not

```bash
➜  test-m1 git:(m1-support) ✗ lipo -info ~/.cache/shopify_bak/ngrok
Non-fat file: /Users/stevemartinelli/.cache/shopify_bak/ngrok is architecture: x86_64
```

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.