### PR TITLE
Rename shopify/scripts-experience team to shopify/scripts-platform in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *       @shopify/core-build-learn
 *       @shopify/development-lifecycle
 
-/lib/project_types/script/ @shopify/scripts-experience
-/test/project_types/script/ @shopify/scripts-experience
+/lib/project_types/script/ @shopify/scripts-platform
+/test/project_types/script/ @shopify/scripts-platform


### PR DESCRIPTION
### WHY are these changes introduced?

The scripts-experience team in GitHub has been renamed to scripts-platform. 

### WHAT is this pull request doing?

Updates the codeowners file to use scripts-platform.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.