### PR TITLE
Fix `ShopifyCLI::Theme::DevServer::CdnFonts` class to support any font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1812](https://github.com/Shopify/shopify-cli/pull/1812): App creation with Rails 7
 * [#1821](https://github.com/Shopify/shopify-cli/pull/1821): Fix Shopify hosted fonts to load via the local preview URL
 * [#1830](https://github.com/Shopify/shopify-cli/pull/1830): Fix hot reload when users update many files "simultaneously"
+* [#1837](https://github.com/Shopify/shopify-cli/pull/1837): Fix `ShopifyCLI::Theme::DevServer::CdnFonts` class to support any font
 
 ## Version 2.7.2
 ### Fixed

--- a/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn_fonts.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     module DevServer
       class CdnFonts
         FONTS_PATH = "/fonts"
-        FONTS_CDN = "https://fonts.shopifycdn.com/assistant"
+        FONTS_CDN = "https://fonts.shopifycdn.com"
         FONTS_REGEX = %r{#{FONTS_CDN}}
 
         def initialize(app, theme:)

--- a/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn_fonts_test.rb
@@ -7,7 +7,7 @@ module ShopifyCLI
   module Theme
     module DevServer
       class CdnFontsTest < Minitest::Test
-        def test_replace_local_fonts_in_reponse_body
+        def test_replace_local_assistant_n4_font_in_reponse_body
           original_html = <<~HTML
             <html>
               <head>
@@ -18,7 +18,25 @@ module ShopifyCLI
           expected_html = <<~HTML
             <html>
               <head>
-                <link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+                <link rel="preload" as="font" href="/fonts/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_replace_local_firasans_n4_font_in_reponse_body
+          original_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="https://fonts.shopifycdn.com/fira_sans/firasans_n4.1b65c27c1439cf29ece2163ea4a810840646dbdc.woff?&hmac=67f25fee11d74ab8def16edf19d274a09843e99443cbf63edc49aecf070d7ec8" type="font/woff2" crossorigin="">
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <link rel="preload" as="font" href="/fonts/fira_sans/firasans_n4.1b65c27c1439cf29ece2163ea4a810840646dbdc.woff?&hmac=67f25fee11d74ab8def16edf19d274a09843e99443cbf63edc49aecf070d7ec8" type="font/woff2" crossorigin="">
               </head>
             </html>
           HTML
@@ -36,7 +54,7 @@ module ShopifyCLI
           expected_html = <<~HTML
             <html>
               <head>
-                <link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin=""><link rel="preload" as="font" href="/fonts/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
+                <link rel="preload" as="font" href="/fonts/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin=""><link rel="preload" as="font" href="/fonts/assistant/assistant_n4.bcd3d09dcb631dec5544b8fb7b154ff234a44630.woff2?hmac=0a2e92d6956b1312ef7d59f4850549a6e43a908ccf24df47f07b0b4c6da5837d" type="font/woff2" crossorigin="">
               </head>
             </html>
           HTML
@@ -64,7 +82,7 @@ module ShopifyCLI
             })
             .to_return(status: 200, body: expected_body, headers: {})
 
-          response = serve(path: "/fonts/font.123.woff2?hmac=456")
+          response = serve(path: "/fonts/assistant/font.123.woff2?hmac=456")
           actual_body = response.body
 
           assert_equal expected_body, actual_body
@@ -78,7 +96,7 @@ module ShopifyCLI
             })
             .to_return(status: 404, body: "Not found", headers: {})
 
-          response = serve(path: "/fonts/missing.123.woff2?hmac=456")
+          response = serve(path: "/fonts/assistant/missing.123.woff2?hmac=456")
 
           assert_equal(404, response.status)
           assert_equal("Not found", response.body)


### PR DESCRIPTION
### WHY are these changes introduced?

The https://github.com/Shopify/shopify-cli/pull/1821 PR fixes the font issue for the **Assistant** font, but other fonts were failing because of the `ShopifyCLI::Theme::DevServer::CdnFonts` regex as miss including the `/assistant` suffix.

### WHAT is this pull request doing?

Now, the regex does not include the **Assistant** font suffix anymore.

### How to test your changes?

1. Go to the theme directory
2. Update the `config/settings_data.json` file with a different font (e.g., `fira_sans_n9`)
3. Run `shopify theme serve` service
4. Open the http://127.0.0.1:9292
5. Check the fonts are now loading as expected

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/1079279/145399305-e7647c3f-062c-46e8-82da-d65d0dca4013.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.