### PR TITLE
Split discount types into two types

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -18,7 +18,15 @@ shipping_methods:
       beta: true
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
-discount_types:
+merchandise_discount_types:
+  beta: true
+  domain: 'discounts'
+  libraries:
+    typescript:
+      beta: true
+      package: "@shopify/scripts-discount-apis"
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+delivery_discount_types:
   beta: true
   domain: 'discounts'
   libraries:


### PR DESCRIPTION
### WHY are these changes introduced?

The beta script API (extension point) `discount_types` has been split into `merchandise_discount_types` and `delivery_discount_types`. This change needs to be reflected in the CLI so that it doesn't fail validations when we try to push scripts.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

I removed `discount_types` as an API and added `merchandise_discount_types` and `delivery_discount_types`.

Any existing script using `discount_types` as an API will no longer function. This API was in an early development stage and so only core developers should have scripts with this extension point. Script Service no longer recognizes this API, so the push would fail regardless of CLI validation.

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public facing.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.