### PR TITLE
Add YARN environment variable to replace npm list

### DIFF
--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -49,10 +49,21 @@ module Script
           end
 
           def library_version(library_name)
+            return yarn_library_version(library_name) if ENV["YARN"] == "1"
+
             output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)
+          end
+
+          def yarn_library_version(library_name)
+            yarn_list = JSON.parse(`yarn list --json`)
+            dependencies = yarn_list["data"]["trees"]
+
+            api_library = dependencies.select { |dependency| dependency["name"].start_with?("@shopify") }[0]
+
+            api_library["name"].split("@")[-1]
           end
 
           private


### PR DESCRIPTION
### WHY are these changes introduced?

We automatically read the version of a script by checking the package.json via `npm list`.

`npm list` performs a series of validations on top of just parsing the package.json file. When the project fails validation, it returns an error code as well as information on dependencies and their versions. We have previously built a system which parsed that error output to get dependency information. However our method for parsing the error output is unreliable, since at times `npm list` will return 2 concatenated hashes.

When a project is using yarn instead of npm, `npm list` will often fail.

### WHAT is this pull request doing?

Rather than diving deeper into trying to parse npm's error output, I've instead added a yarn option accessible via an environment variable. This will be more reliable for yarn projects.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.