### PR TITLE
Fix typo in package name

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -24,7 +24,7 @@ merchandise_discount_types:
   libraries:
     typescript:
       beta: true
-      package: "@shopify/scripts-discount-apis"
+      package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
 delivery_discount_types:
   beta: true
@@ -32,5 +32,5 @@ delivery_discount_types:
   libraries:
     typescript:
       beta: true
-      package: "@shopify/scripts-discount-apis"
+      package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"


### PR DESCRIPTION
### WHY are these changes introduced?

During a previous PR this beta API was given the wrong api package name, causing issues when we tried to extract the package version.

### WHAT is this pull request doing?

This pull request is correcting that error with the correct package name.

I've verified that it now can extract the version number.el free to remove this section.

### Update checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.