### PR TITLE
Script connect

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -13,6 +13,7 @@ module Script
     hidden_feature(feature_set: :script_project)
     subcommand :Create, "create", Project.project_filepath("commands/create")
     subcommand :Push, "push", Project.project_filepath("commands/push")
+    subcommand :Connect, "connect", Project.project_filepath("commands/connect")
     subcommand :Javy, "javy", Project.project_filepath("commands/javy")
   end
   ShopifyCLI::Commands.register("Script::Command", "script")
@@ -24,6 +25,7 @@ module Script
     autoload :AskScriptUuid, Project.project_filepath("forms/ask_script_uuid")
     autoload :RunAgainstShopifyOrg, Project.project_filepath("forms/run_against_shopify_org")
     autoload :Create, Project.project_filepath("forms/create")
+    autoload :Connect, Project.project_filepath("forms/connect")
     autoload :ScriptForm, Project.project_filepath("forms/script_form")
   end
 

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -7,7 +7,6 @@ module Script
 
       def call(_args, _)
         Layers::Application::ConnectApp.call(ctx: @ctx, force: true)
-        @ctx.done(@ctx.message("connect.connected", form.app.title, form.registration.title))
       end
 
       def self.help

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Script
+  class Command
+    class Connect < ShopifyCLI::Command::SubCommand
+      prerequisite_task :ensure_authenticated
+      prerequisite_task ensure_project_type: :script
+
+      def call(_args, _)
+        Layers::Application::ConnectApp.call(ctx: @ctx, force: true)
+        @ctx.done(@ctx.message("connect.connected", form.app.title, form.registration.title))
+      end
+
+      def self.help
+        ShopifyCLI::Context.new.message("connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
+      end
+    end
+  end
+end

--- a/lib/project_types/script/forms/ask_script_uuid.rb
+++ b/lib/project_types/script/forms/ask_script_uuid.rb
@@ -3,12 +3,17 @@
 module Script
   module Forms
     class AskScriptUuid < ShopifyCLI::Form
+
       attr_reader :uuid
       def ask
         scripts = @xargs
+        if scripts.empty?
+          raise ShopifyCLI::Abort, ctx.message("script.error.no_scripts_found_in_app")
+        end
 
-        return if scripts.empty? ||
-          !CLI::UI::Prompt.confirm(ctx.message("script.application.ensure_env.ask_connect_to_existing_script"))
+        if !CLI::UI::Prompt.confirm(ctx.message("script.application.ensure_env.ask_connect_to_existing_script"))
+          raise ShopifyCLI::AbortSilent
+        end
 
         @uuid =
           CLI::UI::Prompt.ask(ctx.message("script.application.ensure_env.ask_which_script_to_connect_to")) do |handler|

--- a/lib/project_types/script/layers/application/connect_app.rb
+++ b/lib/project_types/script/layers/application/connect_app.rb
@@ -7,10 +7,11 @@ module Script
     module Application
       class ConnectApp
         class << self
-          def call(ctx:)
+          def call(ctx:, force: false)
             script_project_repo = Layers::Infrastructure::ScriptProjectRepository.new(ctx: ctx)
             script_project = script_project_repo.get
-            return false if script_project.env_valid?
+
+            return false if script_project.env_valid? && !force
 
             if ShopifyCLI::Shopifolk.check && Forms::RunAgainstShopifyOrg.ask(ctx, nil, nil).response
               ShopifyCLI::Shopifolk.act_as_shopify_organization

--- a/lib/project_types/script/layers/application/connect_app.rb
+++ b/lib/project_types/script/layers/application/connect_app.rb
@@ -38,7 +38,7 @@ module Script
             extension_point_type = script_project.extension_point_type
             scripts = script_service.get_app_scripts(extension_point_type: extension_point_type)
 
-            uuid = Forms::AskScriptUuid.ask(ctx, scripts, nil).uuid
+            uuid = Forms::AskScriptUuid.ask(ctx, scripts, nil)&.uuid
 
             script_project_repo.create_env(
               api_key: app["apiKey"],

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -173,7 +173,13 @@ module Script
 
           script_pushed: "{{v}} Script pushed to app (API key: %{api_key}).",
         },
-
+        connect: {
+          connected: "Project now connected to {{green:%s: %s}}",
+          help: <<~HELP,
+            {{command:%s script connect}}: Connects an existing script to Shopify CLI. Creates a config file.
+              Usage: {{command:%s script connect}}
+          HELP
+        },
         javy: {
           help: <<~HELP,
             Compile the JavaScript code into WebAssembly.

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -138,6 +138,7 @@ module Script
 
           language_library_for_api_not_found_cause: "Script can’t be pushed because the %{language} library for API %{api} is missing.",
           language_library_for_api_not_found_help: "Make sure extension_point.yml contains the correct API library.",
+          no_scripts_found_in_app: "The selected apps have no scripts. Please, create them first on the partners' dashboard."
         },
 
         create: {

--- a/lib/shopify_cli/form.rb
+++ b/lib/shopify_cli/form.rb
@@ -15,6 +15,8 @@ module ShopifyCLI
         rescue ShopifyCLI::Abort => err
           ctx.puts(err.message)
           nil
+        rescue ShopifyCLI::AbortSilent
+          nil
         end
       end
 

--- a/test/project_types/script/forms/ask_script_uuid_test.rb
+++ b/test/project_types/script/forms/ask_script_uuid_test.rb
@@ -15,9 +15,8 @@ describe Script::Forms::AskScriptUuid do
 
     describe("when asking script connection") do
       describe("when there are no scripts") do
-        it("should not prompt the user to confirm if they want to replace existing scripts") do
-          CLI::UI::Prompt.expects(:confirm).never
-          CLI::UI::Prompt.expects(:ask).never
+        it("should abort") do
+          context.expects(:puts).with(context.message("script.error.no_scripts_found_in_app"))
           subject
         end
       end
@@ -56,7 +55,7 @@ describe Script::Forms::AskScriptUuid do
               .with(context.message("script.application.ensure_env.ask_which_script_to_connect_to"))
               .never
 
-            assert_nil subject.uuid
+            assert_nil subject
           end
         end
       end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli-planning/issues/78

### WHY are these changes introduced?
As part of the effort to add support for token-based authentication for CI/CD workflows, I'm adding a new command, `shopify script push` that creates a local `.env` file with the script metadata that's necessary for setting up the CD pipeline.

### WHAT is this pull request doing?

Add a new `shopify script connect` command.

### How to test your changes?

1. Create a new payment method script with `shopify script create`.
2. `cd` into the script directory.
3. Run `shopify script connect`.
4. Select an app with a script created, and then select the script from the prompt.
5. The command should create a `.env` with all the script metadata. 

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.