### PR TITLE
Improve `shopify theme push --live` confirmation message to show current live theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
+## [Unreleased]
+### Fixed
+* [#1851](https://github.com/Shopify/shopify-cli/pull/1851): Improve `shopify theme push --live` confirmation message to show current live theme
+
 ## Version 2.7.3
 ### Added
 * [#1826](https://github.com/Shopify/shopify-cli/pull/1826): Support using `script.config.yml` file for script configuration

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -51,7 +51,9 @@ module Theme
         end
 
         if theme.live? && !options.flags[:allow_live]
-          return unless CLI::UI::Prompt.confirm(@ctx.message("theme.push.live"))
+          question = @ctx.message("theme.push.live")
+          question += @ctx.message("theme.push.theme", theme.name, theme.id) if options.flags[:live]
+          return unless CLI::UI::Prompt.confirm(question)
         end
 
         ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root)

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -74,6 +74,7 @@ module Theme
           push: "Pushing theme files to Shopify",
           select: "Select theme to push to",
           live: "Are you sure you want to push to your live theme?",
+          theme: "\n  Theme: {{blue:%s #%s}} {{green:[live]}}",
           theme_not_found: "Theme #%s doesn't exist",
           done: <<~DONE,
             {{green:Your theme was pushed successfully}}

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -52,7 +52,11 @@ module Theme
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
-        CLI::UI::Prompt.expects(:confirm).returns(true)
+        CLI::UI::Prompt
+          .expects(:confirm)
+          .with("Are you sure you want to push to your live theme?\n  " \
+                "Theme: {{blue:Test theme #1234}} {{green:[live]}}")
+          .returns(true)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
@@ -77,7 +81,10 @@ module Theme
 
         @theme.expects(:live?).returns(true)
 
-        CLI::UI::Prompt.expects(:confirm).returns(true)
+        CLI::UI::Prompt
+          .expects(:confirm)
+          .with("Are you sure you want to push to your live theme?")
+          .returns(true)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 


### PR DESCRIPTION
### WHY are these changes introduced?

When users execute `shopify theme push --live`, they do not know which theme is being used as live (https://github.com/Shopify/shopify-cli/pull/1807#issuecomment-982857030, https://github.com/Shopify/shopify-cli/issues/1809).

### WHAT is this pull request doing?

Now, when users push a theme with the `--live` parameter, the confirmation message shows the live theme name and ID.

### How to test your changes?

Run `shopify theme push --live` and noticed the current live theme name and ID appears:

<img width="75%" alt="Screenshot 2021-12-13 at 23 41 16" src="https://user-images.githubusercontent.com/1079279/145962139-ff3e1078-246a-4c58-98a8-d75f6b460a98.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.