### PR TITLE
Fix `shopify --help` to include `extension` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
+## [Unreleased]
+### Fixed
+* [#1852](https://github.com/Shopify/shopify-cli/pull/1852): Fix `shopify --help` to include `extension` commands
+
 ## Version 2.7.3
 ### Added
 * [#1826](https://github.com/Shopify/shopify-cli/pull/1826): Support using `script.config.yml` file for script configuration

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -13,7 +13,6 @@ module Extension
   end
 
   class Command < ShopifyCLI::Command::ProjectCommand
-    hidden_feature
     autoload :ExtensionCommand, Project.project_filepath("commands/extension_command")
 
     subcommand :Create, "create", Project.project_filepath("commands/create")

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -89,15 +89,6 @@ module Extension
         assert_message_output(io: io, expected_content: @context.message("create.try_again"))
       end
 
-      def test_help_does_not_load_extension_project_type
-        io = capture_io do
-          run_create(%w(create --help))
-        end
-
-        output = io.join
-        refute_match(" extension ", output)
-      end
-
       private
 
       def run_create(arguments)


### PR DESCRIPTION
### WHY are these changes introduced?

The `extension` commands appear in the [shopify.dev](https://shopify.dev/apps/online-store/theme-app-extensions/getting-started#step-2-scaffold-and-register-a-theme-app-extension) website. However, users cannot access the help for these commands in the `shopify --help`.

### WHAT is this pull request doing?

This PR removes the `hidden_feature` call from the `Extension::Command`, and now users are able to see the `extension` commands when they execute `shopify --help`.

### How to test your changes?

Run `shopify-dev --help` and check new `extension` entry:

<img width="80%" src="https://user-images.githubusercontent.com/1079279/145573006-ad8f82af-69ec-4df5-9c22-5738ca7d78ca.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.