### PR TITLE
[scripts] use RUBY_PLATFORM instead of RbConfig to check platform details for Javy installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
+
+## [Unreleased]
+### Fixed
+* [#1853](https://github.com/Shopify/shopify-cli/pull/1853): Fix javy installation failures from MacOS universal ruby installations
 ## Version 2.7.3
 ### Added
 * [#1826](https://github.com/Shopify/shopify-cli/pull/1826): Support using `script.config.yml` file for script configuration

--- a/ext/javy/javy.rb
+++ b/ext/javy/javy.rb
@@ -1,4 +1,3 @@
-require "rbconfig"
 require "open-uri"
 require "zlib"
 require "open3"
@@ -162,9 +161,9 @@ module Javy
     end
   end
 
-  Platform = Struct.new(:ruby_config) do
-    def initialize(ruby_config = RbConfig::CONFIG)
-      super(ruby_config)
+  Platform = Struct.new(:ruby_platform) do
+    def initialize(ruby_platform = RUBY_PLATFORM)
+      super(ruby_platform)
     end
 
     def to_s
@@ -172,7 +171,7 @@ module Javy
     end
 
     def os
-      case ruby_config.fetch("host_os")
+      case ruby_platform
       when /linux/
         "linux"
       when /darwin/
@@ -183,10 +182,10 @@ module Javy
     end
 
     def cpu
-      case ruby_config.fetch("host_cpu")
-      when "x64", "x86_64"
+      case ruby_platform
+      when /x64/, /x86_64/
         "x86_64"
-      when "arm"
+      when /arm/
         "arm"
       else
         raise InstallationError.cpu_unsupported

--- a/test/ext/javy/javy_test.rb
+++ b/test/ext/javy/javy_test.rb
@@ -154,6 +154,12 @@ class JavyTest < Minitest::Test
       assert_equal "javy", platform.format_executable_path("javy")
     end
 
+    def test_recognizes_underlying_cpu_in_universal_distributions
+      platform = Javy::Platform.new(PlatformHelper.macos_universal_config)
+      assert_equal "arm-macos", platform.to_s
+      assert_equal "javy", platform.format_executable_path("javy")
+    end
+
     def test_recognizes_windows
       platform = Javy::Platform.new(PlatformHelper.windows_config)
       assert_equal "x86_64-windows", platform.to_s
@@ -220,6 +226,10 @@ class JavyTest < Minitest::Test
       ruby_config(os: "darwin20.3.0", cpu: "arm")
     end
 
+    def self.macos_universal_config
+      ruby_config(os: "darwin20.3.0", cpu: "universal.arm64")
+    end
+
     def self.windows_config
       ruby_config(os: "mingw32", cpu: "x64")
     end
@@ -229,10 +239,7 @@ class JavyTest < Minitest::Test
     end
 
     def self.ruby_config(os:, cpu:)
-      {
-        "host_os" => os,
-        "host_cpu" => cpu,
-      }
+      "#{cpu}-#{os}"
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Mac machines come preinstalled with a universal distribution of Ruby created by Apple that includes both arm64 and x86 binaries, and will use the appropriate one depending on the cpu of the machine. There is a bug (or a confusing feature?) in the distribution with the use of `RbConfig`. No matter what CPU you're on (intel or M1) the `RbConfig` sets the `host_cpu` field to `x86`. The current approach to installing Javy checks this variable and downloads the appropriate binary, but if you're on an M1 machine, that means we download the binary for Intel machines. When you install a new version of ruby with chruby/vrm/brew, then this problem disappears. However, Javy should work out of the box. 

### WHAT is this pull request doing?

Instead of using `RbConfig::CONFIG`, use `RUBY_PLATFORM` constant. This constant reports the host machine cpu, even when using a universal distribution. For arm it reports `universal.arm64-darwin<version>` and for x86 it reports `universal.x86_64-darwin<version>`. I am currently downloading linux and windows VMs to verify that it works there, but there should be no problems as there is code out there that does the same thing.

### How to test your changes?

Ideally, you would test this on M1 and Intel machines. I have tested on both myself, though.

1. Check your ruby installation
    - Open a ruby console and check `RUBY_PLATFORM`. It should give you the details on if you're using a universal distribution or a platform specific one. 
    - You can also check `which ruby` in the shell. `/usr/bin/ruby` indicates that you're using the default system ruby install. 
2. Change which ruby version you want to use
    - To use the default system ruby (universal installation)
        - If you have not manually changed your ruby version with chruby/rvm/brew, navigate to a folder outside of any ruby dev project and follow step 1. to check your installation.
        - If that doesn't work, try running `chruby_use 2.7.1`. 
        - If that also doesn't work and you've installed custom versions of ruby already yourself, you may have to update your $PATH to use `/usr/bin/ruby`. 
     - To use an arch specific installation of ruby:
        - The easiest way is to go into the `shopify-cli` directory and run `dev up`. This will install ruby 2.7.5. To use this ruby version, create a `temp/` folder in the repo and create your scripts there.
3. Create a new typscript script
4. Run `npm run prebuild` to compile the TS into JS
5. Run `shopify script javy -i build/index.js -o build/index.wasm`
6. Verify that a new WASM file was created at `build/index.wasm`

### My 🎩 
<details>
<summary>Using a universal installation on M1</summary>
<br>
<img src=https://user-images.githubusercontent.com/28009669/146032205-d4daebec-981b-43ae-a938-25263054e5bb.png />

</details>

<details>
<summary>Using an arm installation on M1</summary>
<br>
<img src=https://user-images.githubusercontent.com/28009669/146031687-9c11e5a3-1af1-45e5-a01e-c108e45d0268.png />
</details>

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).