### PR TITLE
Update dpkg and rpm

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -9,9 +9,9 @@ up:
   - ruby: 2.7.5
   - homebrew:
       - dpkg:
-          version: 1.20.9
+          version: 1.21.1
       - rpm:
-          version: 4.16.1.3
+          version: 4.17.0
   - bundler
   - docker
 


### PR DESCRIPTION
### WHY are these changes introduced?
While investigating M1-related issues running `dev up`, I realize there are more recent versions of the Homebrew packages we depend on for bundling the CLI for distribution.

### WHAT is this pull request doing?
I'm updating them to the latest available version.

### How to test your changes?
1. Check out the branch.
2. Run `dev up`.
3. Run `bundle exec rake package`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.