### PR TITLE
update instructions for tunnel auth token

### DIFF
--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -725,7 +725,7 @@ module ShopifyCLI
           signup_suggestion: <<~MESSAGE,
             {{*}} To avoid tunnels that timeout, it is recommended to signup for a free ngrok
             account at {{underline:https://ngrok.com/signup}}. After you signup, install your
-            personalized authorization token using {{command:%s [ node | rails ] tunnel auth <token>}}.
+            personalized authorization token using {{command:%s app tunnel auth <token>}}.
           MESSAGE
           start: "{{v}} ngrok tunnel running at {{underline:%s}}",
           start_with_account: "{{v}} ngrok tunnel running at {{underline:%s}}, with account %s",


### PR DESCRIPTION
### WHY are these changes introduced?

When running `shopify app serve`, the prompt shown for signing up for ngrok uses outdated instructions

![](https://screenshot.click/15-20-nn73h-oleaf.png)

The command today is `shopify app tunnel auth <token>` Source: https://shopify.dev/apps/tools/cli/app#tunnel

### WHAT is this pull request doing?

Changes the message prompt.

### How to test your changes?

Before you start: Have no `authtoken` token already at `.ngrok2/ngrok.yml`; otherwise you won't see the prompt

* Create a new app project with `shopify app create node`
* Once the folder is created, run `shopify app serve` 
* 
 You should see the prompt to make a new account along with instructions on the command to run.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.