### PR TITLE
fix: make new properties in ScriptProjectRepository not required

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -6,8 +6,8 @@ module Script
       class ScriptProjectRepository
         include SmartProperties
         property! :ctx, accepts: ShopifyCLI::Context
-        property! :directory, accepts: String
-        property! :initial_directory, accepts: String
+        property :directory, accepts: String
+        property :initial_directory, accepts: String
 
         MUTABLE_ENV_VALUES = %i(uuid)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up to Fix https://github.com/Shopify/shopify-cli/pull/1795

### WHAT is this pull request doing?

The linked PR added some properties and made them required.
However, these values are only really required for the `script create` command.
The PR therefore fails on other steps, such as `script push` and `script connect`.

In order to fix quickly, this PR makes these properties not-required.
We can revisit this later if we feel these fields should instead be required, but have a sensible default.

### How to test your changes?

`shopify script create`
`shopify script push`
`shopify script connect`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.