### PR TITLE
Use error_handler class to print error messages from connect script command

### DIFF
--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -7,6 +7,8 @@ module Script
 
       def call(_args, _)
         Layers::Application::ConnectApp.call(ctx: @ctx, force: true, strict: true)
+      rescue StandardError => e
+        UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.connect.error.operation_failed"))
       end
 
       def self.help

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -187,6 +187,9 @@ module Script
             {{command:%s script connect}}: Connects an existing script to an app.
               Usage: {{command:%s script connect}}
           HELP
+          error: {
+            operation_failed: "Couldn't connect script to app.",
+          },
         },
         javy: {
           help: <<~HELP,

--- a/test/project_types/script/commands/connect_test.rb
+++ b/test/project_types/script/commands/connect_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+module Script
+  module Commands
+    class ConnectTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+      include TestHelpers::FakeFS
+
+      def setup
+        super
+        ShopifyCLI::Core::Monorail.stubs(:log).yields
+        @context = TestHelpers::FakeContext.new
+        ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
+        ShopifyCLI::Tasks::EnsureProjectType.stubs(:call).with(@context, :script).returns(true)
+      end
+
+      def test_calls_connect_app
+        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, force: true, strict: true)
+        perform_command
+      end
+
+      def test_calls_error_handler_when_exception_is_raised
+        Script::Layers::Application::ConnectApp.expects(:call).raises(StandardError)
+
+        UI::ErrorHandler.expects(:pretty_print_and_raise).with do |_error, args|
+          assert_equal args[:failed_op], @context.message("script.connect.error.operation_failed")
+        end
+
+        perform_command
+      end
+
+      private
+
+      def perform_command
+        run_cmd("script connect")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Script commands usually use the ErrorHandler class defined in the scripts code to determine what error messages to display based on the exceptions class when exceptions occur during application calls. 

The connect command does not currently do that, which means that users may run into stacktrace errors instead of proper error message defined in the ErrorHandler. Note though that if the ErrorHandler does not have a defined error message, it will still print the stacktrace like before.

### WHAT is this pull request doing?

- Calls `UI::ErrorHandler.pretty_print_and_raise` in the new script connect command.
- Adds a unit test for the connect command class. Since this is a unit test and not integration, we follow the convention of `expect`ing and `stub`bing external services. 

### How to test your changes?

You can try to throw an error and make sure that an error message gets printed properly. One example error class that has a defined message is `Script::Errors::NoExistingOrganizationsError`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).