### PR TITLE
Release v2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+
+## Version 2.7.4
 ### Added
 * [#1825](https://github.com/Shopify/shopify-cli/pull/1825): Support passing the connection information through arguments
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.7.3)
+    shopify-cli (2.7.4)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.9.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.7.3"
+  VERSION = "2.7.4"
 end


### PR DESCRIPTION
I'm releasing version 2.7.4 of the CLI with the following changelog:

### Added
* [#1825](https://github.com/Shopify/shopify-cli/pull/1825): Support passing the connection information through arguments

### Fixed
* [#1852](https://github.com/Shopify/shopify-cli/pull/1852): Fix `shopify --help` to include `extension` commands
* [#1853](https://github.com/Shopify/shopify-cli/pull/1853): Fix javy installation failures from MacOS universal ruby installations
* [#1851](https://github.com/Shopify/shopify-cli/pull/1851): Improve `shopify theme push --live` confirmation message to show current live theme
* [#1850](https://github.com/Shopify/shopify-cli/pull/1850): Fix `shopify extension` commands timeout when organization has too many apps
* [#1860](https://github.com/Shopify/shopify-cli/pull/1860): Fix `theme serve` hot reload when there are many tabs active