### PR TITLE
Add a new `--live-reload-mode` parameter to the `theme serve` command

### DIFF
--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -10,6 +10,7 @@ module Theme
         parser.on("--host=HOST") { |host| flags[:host] = host.to_s }
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
+        parser.on("--live-reload-mode=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
       end
 
       def call(*)
@@ -21,6 +22,10 @@ module Theme
       rescue ShopifyCLI::Theme::DevServer::AddressBindingError
         raise ShopifyCLI::Abort,
           ShopifyCLI::Context.message("theme.serve.error.address_binding_error", ShopifyCLI::TOOL_NAME)
+      end
+
+      def self.as_reload_mode(mode)
+        ShopifyCLI::Theme::DevServer::ReloadMode.get(mode)
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -94,10 +94,16 @@ module Theme
             Usage: {{command:%s theme serve}}
 
             Options:
-              {{command:--port=PORT}} Local port to serve theme preview from
-              {{command:--poll}}      Force polling to detect file changes
-              {{command:--host=HOST}} Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--port=PORT}}             Local port to serve theme preview from.
+              {{command:--poll}}                  Force polling to detect file changes.
+              {{command:--host=HOST}}             Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--live-reload-mode=MODE}} The live reload mode switches the server behavior when a file is modified:
+                                        - {{command:fast}} Reloads page sections (default)
+                                        - {{command:full}} Always refreshes the entire page
+                                        - {{command:none}} Deactivate live reload
           HELP
+          reload_mode_is_not_valid: "The live reload mode `%s` is not valid.",
+          try_a_valid_reload_mode: "Try a valid live reload mode: %s.",
           viewing_theme: "Viewing theme…",
           syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
@@ -131,9 +137,7 @@ module Theme
             You are not authorized to edit themes on %s.
             Make sure you are a user of that store, and allowed to edit themes.
           ENSURE_USER
-          already_in_use_error: "Error",
           address_already_in_use: "The address \"%s\" is already in use.",
-          try_this: "Try this",
           try_port_option: "Use the --port=PORT option to serve the theme in a different port.",
         },
         check: {

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -44,6 +44,56 @@ module ShopifyCLI
         str = Context.messages.dig(*key_parts)
         str ? str % params : key
       end
+
+      # a wrapper around Kernel.puts to allow for easy formatting
+      #
+      # #### Parameters
+      # * `text` - a string message to output
+      def puts(*args)
+        Kernel.puts(CLI::UI.fmt(*args))
+      end
+
+      # aborts the current running command and outputs an error message:
+      # - when the `help_message` is not provided, the error message appears in
+      #   a red frame, prefixed by an ✗ icon
+      # - when the `help_message` is provided, the error message appears in a
+      #   red frame, and the help message appears in a green frame
+      #
+      # #### Parameters
+      # * `error_message` - an error message to output
+      # * `help_message` - an optional help message
+      #
+      # #### Example
+      #
+      #   ShopifyCLI::Context.abort("Execution error")
+      #   # Output:
+      #   # ┏━━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #   # ┃ ✗ Execution error
+      #   # ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #
+      #   ShopifyCLI::Context.abort("Execution error", "export EXECUTION=1")
+      #   # Output:
+      #   # ┏━━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #   # ┃ Execution error
+      #   # ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #   # ┏━━ Try this ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #   # ┃ export EXECUTION=1
+      #   # ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+      #
+      def abort(error_message, help_message = nil)
+        raise ShopifyCLI::Abort, "{{x}} #{error_message}" if help_message.nil?
+
+        frame(message("core.error"), color: :red) { self.puts(error_message) }
+        frame(message("core.try_this"), color: :green) { self.puts(help_message) }
+
+        raise ShopifyCLI::AbortSilent
+      end
+
+      private
+
+      def frame(title, color:, &block)
+        CLI::UI::Frame.open(title, color: CLI::UI.resolve_color(color), timing: false, &block)
+      end
     end
 
     # is the directory root that the current command is running in. If you want to
@@ -349,13 +399,13 @@ module ShopifyCLI
       puts "{{yellow:*}} #{text}"
     end
 
-    # a wrapper around Kernel.puts to allow for easy formatting
+    # proxy call to Context.puts.
     #
     # #### Parameters
     # * `text` - a string message to output
     #
     def puts(*args)
-      Kernel.puts(CLI::UI.fmt(*args))
+      Context.puts(*args)
     end
 
     # a wrapper around $stderr.puts to allow for easy formatting
@@ -385,14 +435,13 @@ module ShopifyCLI
       puts("{{v}} #{text}")
     end
 
-    # aborts the current running command and outputs an error message, prefixed
-    # by a red x
+    # proxy call to Context.abort.
     #
     # #### Parameters
-    # * `text` - a string message to output
-    #
-    def abort(text)
-      raise ShopifyCLI::Abort, "{{x}} #{text}"
+    # * `error_message` - an error message to output
+    # * `help_message` - an optional help message
+    def abort(error_message, help_message = nil)
+      Context.abort(error_message, help_message)
     end
 
     # outputs a message, prefixed by a red `DEBUG` tag. This will only output to

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -790,6 +790,8 @@ module ShopifyCLI
           logged_in_partner_only: "Logged into partner organization {{green:%s}}",
           logged_in_partner_and_shop: "Logged into store {{green:%s}} in partner organization {{green:%s}}",
         },
+        error: "Error",
+        try_this: "Try this",
       },
     }.freeze
   end

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -15,9 +15,23 @@
     eventSource.onerror = () => eventSource.close();
   }
 
-  connect();
+  function reloadMode() {
+    var namespace = window.__SHOPIFY_DEV_MODE_ENV__;
+    return namespace.mode;
+  }
+
+  function isFullReloadMode(){
+    return reloadMode() === "full";
+  }
+
+  function isReloadModeActive(){
+    return reloadMode() !== "none";
+  }
 
   function isRefreshRequired(files) {
+    if (isFullReloadMode()) {
+      return true;
+    }
     return files.some((file) => !isCssFile(file) && !isSectionFile(file));
   }
 
@@ -118,5 +132,9 @@
         console.log(`[HotReload] Failed to reload ${this.name} section: ${e.message}`);
       }
     }
+  }
+
+  if (isReloadModeActive()) {
+    connect();
   }
 })();

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -4,10 +4,11 @@ module ShopifyCLI
   module Theme
     module DevServer
       class HotReload
-        def initialize(ctx, app, theme:, watcher:, ignore_filter: nil)
+        def initialize(ctx, app, theme:, watcher:, mode:, ignore_filter: nil)
           @ctx = ctx
           @app = app
           @theme = theme
+          @mode = mode
           @streams = SSE::Streams.new
           @watcher = watcher
           @watcher.add_observer(self, :notify_streams_of_file_change)
@@ -48,10 +49,25 @@ module ShopifyCLI
 
         def inject_hot_reload_javascript(body)
           hot_reload_js = ::File.read("#{__dir__}/hot-reload.js")
-          hot_reload_script = "<script>\n#{hot_reload_js}</script>"
+          hot_reload_script = [
+            "<script>",
+            params_js,
+            hot_reload_js,
+            "</script>",
+          ].join("\n")
+
           body = body.join.gsub("</body>", "#{hot_reload_script}\n</body>")
 
           [body]
+        end
+
+        def params_js
+          env = { mode: @mode }
+          <<~JS
+            (() => {
+              window.__SHOPIFY_DEV_MODE_ENV__ = #{env.to_json};
+            })();
+          JS
         end
 
         def create_stream

--- a/lib/shopify_cli/theme/dev_server/reload_mode.rb
+++ b/lib/shopify_cli/theme/dev_server/reload_mode.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class ReloadMode
+        FULL = :full
+        FAST = :fast
+        NONE = :none
+
+        class << self
+          def default
+            FAST
+          end
+
+          def get(enum)
+            values.find { |v| v == enum.to_sym } || raise_error(enum)
+          end
+
+          def values
+            constants(false).map { |c| const_get(c) }
+          end
+
+          private
+
+          def raise_error(enum)
+            error_message = ShopifyCLI::Context.message("theme.serve.reload_mode_is_not_valid", enum)
+            help_message = ShopifyCLI::Context.message("theme.serve.try_a_valid_reload_mode", valid_reload_modes)
+
+            ShopifyCLI::Context.abort(error_message, help_message)
+          end
+
+          def valid_reload_modes
+            values.map { |v| "`#{v}`" }.join(", ")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -15,8 +15,55 @@ module ShopifyCLI
       expected_stderr = /^$/
 
       assert_output(expected_stdout, expected_stderr) do
+        Context.puts("info message")
+      end
+    end
+
+    def test_proxy_puts
+      expected_stdout = /info message/
+      expected_stderr = /^$/
+
+      assert_output(expected_stdout, expected_stderr) do
         @ctx.puts("info message")
       end
+    end
+
+    def test_abort
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+        Context.abort("error message")
+      end
+
+      io = io.join
+      assert_match(/error message/, io)
+    end
+
+    def test_abort_proxy
+      io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+        @ctx.abort("error message")
+      end
+
+      io = io.join
+      assert_match(/error message/, io)
+    end
+
+    def test_abort_with_help_message
+      io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
+        Context.abort("error message", "help message")
+      end
+
+      io = io.join
+      assert_match(/error message/, io)
+      assert_match(/help message/, io)
+    end
+
+    def test_abort_proxy_with_help_message
+      io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
+        @ctx.abort("error message", "help message")
+      end
+
+      io = io.join
+      assert_match(/error message/, io)
+      assert_match(/help message/, io)
     end
 
     def test_error

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -14,6 +14,7 @@ module ShopifyCLI
           @theme = Theme.new(@ctx, root: root)
           @syncer = stub("Syncer", enqueue_uploads: true)
           @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer)
+          @mode = "test"
         end
 
         def test_hot_reload_js_injected_if_html_request
@@ -26,16 +27,24 @@ module ShopifyCLI
             </html>
           HTML
 
+          params_js = <<~JS
+            (() => {
+              window.__SHOPIFY_DEV_MODE_ENV__ = {"mode":"test"};
+            })();
+          JS
+
           reload_js = ::File.read(
             ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload.js", ShopifyCLI::ROOT)
           )
-          reload_script = "<script>\n#{reload_js}</script>"
+
+          injected_script = "<script>\n#{params_js}\n#{reload_js}\n</script>"
+
           expected_html = <<~HTML
             <html>
               <head></head>
               <body>
                 <h1>Hello</h1>
-              #{reload_script}
+              #{injected_script}
             </body>
             </html>
           HTML
@@ -67,7 +76,7 @@ module ShopifyCLI
             .with(JSON.generate(modified: modified))
 
           app = -> { [200, {}, []] }
-          HotReload.new(@ctx, app, theme: @theme, watcher: @watcher)
+          HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
 
           @watcher.changed
           @watcher.notify_observers(modified, [], [])
@@ -87,6 +96,7 @@ module ShopifyCLI
             @ctx, app,
             theme: @theme,
             watcher: @watcher,
+            mode: @mode,
             ignore_filter: ignore_filter
           )
 
@@ -100,7 +110,7 @@ module ShopifyCLI
           app = lambda do |_env|
             [200, headers, [response_body]]
           end
-          stack = HotReload.new(@ctx, app, theme: @theme, watcher: @watcher)
+          stack = HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
           request = Rack::MockRequest.new(stack)
           request.get(path).body
         end

--- a/test/shopify-cli/theme/dev_server/reload_mode.rb
+++ b/test/shopify-cli/theme/dev_server/reload_mode.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class ReloadModeTest < Minitest::Test
+        def test_default
+          assert_equal :fast, ReloadMode.default
+        end
+
+        def test_get
+          assert_equal :full, ReloadMode.get("full")
+        end
+
+        def test_get_when_enum_values_does_not_exist
+          stub_context_messages
+
+          io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
+            ReloadMode.get("other")
+          end
+
+          io = io.join
+          assert_match(/Error/, io)
+          assert_match(/error message/, io)
+          assert_match(/Try this/, io)
+          assert_match(/help message/, io)
+        end
+
+        def test_values
+          expected_values = [:fast, :full, :none]
+          actual_values = ReloadMode.values.sort
+
+          assert_equal expected_values, actual_values
+        end
+
+        private
+
+        def stub_context_messages
+          stub_message.with("core.error").returns("Error")
+          stub_message.with("core.try_this").returns("Try this")
+          stub_message.with("theme.serve.reload_mode_is_not_valid", "other").returns("error message")
+          stub_message.with("theme.serve.try_a_valid_reload_mode", anything).returns("help message")
+        end
+
+        def stub_message
+          ShopifyCLI::Context.stubs(:message)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ _This PR is open as a draft and will be converted to a regular one when we define the final terminology of the new parameter and its values._


### WHY are these changes introduced?

Some users prefer to fully the reload page **(I)** when a file is modified, instead of relying on the hot reload mechanism that updates sections individually **(II)**. Also, other users have their own tooling for refreshing the page, so they need to deactivate any refresh mechanism **(III)** entirely.

This PR introduces the `--live-reload-mode` with three modes: **I) full**, **II) fast** (default), and **III) none**.

<img width="1212" alt="help" src="https://user-images.githubusercontent.com/1079279/146947539-dd0f5927-835a-48c3-9d6f-1120fa1cb2b3.png">


### WHAT is this pull request doing?

#### Main change

The new parameter (`--live-reload-mode`) in the `Theme::Command::Serve` has three valid values:
- `fast` - it's the current approach
- `full` - every time users perform a file change, the page is refreshed entirely
- `none` - the page is never automatically updated (the `hot-reload.js#connect` function is never called)

The `ShopifyCLI::Theme::DevServer::ReloadMode` class works like an enum and validates the parameter value when the `Serve` command calls `ReloadMode.get`.

The `mode` value is injected into the page with the `hot-reload.js` at the `ShopifyCLI::Theme::DevServer::HotReload` level. So, the parameter controls how the page refreshes in the client-side.


#### ShopifyCLI::Context change

Following the [error/try-this convention](https://user-images.githubusercontent.com/51347120/141354793-57a07455-5972-44a4-be86-ca6cd075a547.png) introduced [here](https://github.com/Shopify/shopify-cli/pull/1722), this PR introduces the `ShopifyCLI::Context.abort(error_message, help_message = nil)` API.

Now the `abort` API has an optional help message, which appears in the **Try this** frame.

### How to test your changes?

Run `shopify theme serve --live-reload-mode=<MODE>` with different reload modes and notice how the page behaves differently for each one:

- `shopify theme serve --live-reload-mode=fast`
![fast](https://user-images.githubusercontent.com/1079279/146951600-4669a215-224b-4258-b98a-96a088fd90f8.gif)

- `shopify theme serve --live-reload-mode=full`
![full](https://user-images.githubusercontent.com/1079279/146951691-c50da535-1602-4a87-a707-959e5f926036.gif)

- `shopify theme serve --live-reload-mode=none`
![none-2](https://user-images.githubusercontent.com/1079279/146951754-284fc742-1bb2-40e8-9edc-0c1ff03e1836.gif)

- `shopify theme serve` (fast as the default)
![fast-default](https://user-images.githubusercontent.com/1079279/146951660-e3e6688d-1707-4d9d-9a99-c5889ba13332.gif)

- `shopify theme serve --live-reload-mode=other`
<img width="80%" alt="error" src="https://user-images.githubusercontent.com/1079279/146951819-0cddc0e9-ba2a-4ffe-bff1-801dd7e0f6ce.png">


### Post-release steps

Update documentation with `shopify theme serve` parameters: [shopify.dev/themes/tools/cli/theme-commands#serve](https://shopify.dev/themes/tools/cli/theme-commands#serve).


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.