### PR TITLE
Add theme (`-t`/`--theme=NAME_OR_ID`) parameter to `theme push`/`theme pull` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1900](https://github.com/Shopify/shopify-cli/pull/1900): Add `-d'/`--development` flag to Shopify theme pull command
 * [#1896](https://github.com/Shopify/shopify-cli/pull/1896): Release Typescript options for payment_methods and shipping_methods scripts.
 
+### Added
+* [#1877](https://github.com/Shopify/shopify-cli/pull/1877): Add theme (`-t`/`--theme=THEME`) parameter to `theme push`/`theme pull` commands
+
 ## Version 2.8.0
 ### Fixed
 * [#1879](https://github.com/Shopify/shopify-cli/pull/1879): Disambiguate -s as store option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1896](https://github.com/Shopify/shopify-cli/pull/1896): Release Typescript options for payment_methods and shipping_methods scripts.
 
 ### Added
-* [#1877](https://github.com/Shopify/shopify-cli/pull/1877): Add theme (`-t`/`--theme=THEME`) parameter to `theme push`/`theme pull` commands
+* [#1877](https://github.com/Shopify/shopify-cli/pull/1877): Add theme (`-t`/`--theme=NAME_OR_ID`) parameter to `theme push`/`theme pull` commands
 
 ## Version 2.8.0
 ### Fixed

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -9,7 +9,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
-        parser.on("-t", "--themename=THEMENAME") { |theme_name| flags[:theme_name] = theme_name }
+        parser.on("-t", "--theme=THEME") { |theme| flags[:theme] = theme }
         parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-x", "--ignore=PATTERN") do |pattern|
@@ -47,14 +47,14 @@ module Theme
 
       private
 
-      def find_theme(root, theme_id: nil, theme_name: nil, live: nil, development: nil, **_args)
+      def find_theme(root, theme_id: nil, theme: nil, live: nil, development: nil, **_args)
         if theme_id
           return ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         end
 
-        if theme_name
-          theme = ShopifyCLI::Theme::Theme.find_by(@ctx, name: theme_name, root: root)
-          return theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", theme_name))
+        if theme
+          selected_theme = ShopifyCLI::Theme::Theme.find_by_identifier(@ctx, root: root, identifier: theme)
+          return selected_theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", theme))
         end
 
         if live

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -9,7 +9,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
-        parser.on("-t", "--theme=THEME") { |theme| flags[:theme] = theme }
+        parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
         parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-x", "--ignore=PATTERN") do |pattern|
@@ -49,6 +49,7 @@ module Theme
 
       def find_theme(root, theme_id: nil, theme: nil, live: nil, development: nil, **_args)
         if theme_id
+          @ctx.warn(@ctx.message("theme.pull.deprecated_themeid"))
           return ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         end
 

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -10,7 +10,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
-        parser.on("-t", "--themename=THEMENAME") { |theme_name| flags[:theme_name] = theme_name }
+        parser.on("-t", "--theme=THEME") { |theme| flags[:theme] = theme }
         parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-u", "--unpublished") { flags[:unpublished] = true }
@@ -70,7 +70,7 @@ module Theme
 
       private
 
-      def find_theme(root, theme_id: nil, theme_name: nil, live: nil, development: nil, unpublished: nil, **_args)
+      def find_theme(root, theme_id: nil, theme: nil, live: nil, development: nil, unpublished: nil, **_args)
         if theme_id
           return ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         end
@@ -80,21 +80,21 @@ module Theme
         end
 
         if development
-          theme = ShopifyCLI::Theme::DevelopmentTheme.new(@ctx, root: root)
-          theme.ensure_exists!
-          return theme
+          new_theme = ShopifyCLI::Theme::DevelopmentTheme.new(@ctx, root: root)
+          new_theme.ensure_exists!
+          return new_theme
         end
 
         if unpublished
-          name = theme_name || ask_theme_name
-          theme = ShopifyCLI::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
-          theme.create
-          return theme
+          name = theme || ask_theme_name
+          new_theme = ShopifyCLI::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
+          new_theme.create
+          return new_theme
         end
 
-        if theme_name
-          theme = ShopifyCLI::Theme::Theme.find_by(@ctx, name: theme_name, root: root)
-          return theme || @ctx.abort(@ctx.message("theme.push.theme_not_found", theme_name))
+        if theme
+          selected_theme = ShopifyCLI::Theme::Theme.find_by_identifier(@ctx, root: root, identifier: theme)
+          return selected_theme || @ctx.abort(@ctx.message("theme.push.theme_not_found", theme))
         end
 
         select_theme(root)

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -10,7 +10,7 @@ module Theme
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
-        parser.on("-t", "--theme=THEME") { |theme| flags[:theme] = theme }
+        parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
         parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-u", "--unpublished") { flags[:unpublished] = true }
@@ -72,6 +72,7 @@ module Theme
 
       def find_theme(root, theme_id: nil, theme: nil, live: nil, development: nil, unpublished: nil, **_args)
         if theme_id
+          @ctx.warn(@ctx.message("theme.push.deprecated_themeid"))
           return ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         end
 

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -57,15 +57,15 @@ module Theme
               Usage: {{command:%s theme push [ ROOT ]}}
 
               Options:
-                {{command:-i, --themeid=THEMEID}}     Theme ID. Must be an existing theme on your store.
-                {{command:-t, --themename=THEMENAME}} Theme name. Must be an existing theme on your store.
-                {{command:-l, --live}}                Push to your remote live theme, and update your live store.
-                {{command:-d, --development}}         Push to your remote development theme, and create it if needed.
-                {{command:-u, --unpublished}}         Create a new unpublished theme and push to it.
-                {{command:-n, --nodelete}}            Runs the push command without deleting remote files from Shopify.
-                {{command:-j, --json}}                Output JSON instead of a UI.
-                {{command:-a, --allow-live}}          Allow push to a live theme.
-                {{command:-p, --publish}}             Publish as the live theme after uploading.
+                {{command:-t, --theme=THEME}}     Theme ID or name of the remote theme.
+                {{command:-i, --themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
+                {{command:-l, --live}}            Push to your remote live theme, and update your live store.
+                {{command:-d, --development}}     Push to your remote development theme, and create it if needed.
+                {{command:-u, --unpublished}}     Create a new unpublished theme and push to it.
+                {{command:-n, --nodelete}}        Runs the push command without deleting remote files from Shopify.
+                {{command:-j, --json}}            Output JSON instead of a UI.
+                {{command:-a, --allow-live}}      Allow push to a live theme.
+                {{command:-p, --publish}}         Publish as the live theme after uploading.
 
               Run without options to select theme from a list.
           HELP
@@ -190,11 +190,11 @@ module Theme
             Usage: {{command:%s theme pull [ ROOT ]}}
 
             Options:
-              {{command:-i, --themeid=THEMEID}}     The Theme ID. Must be an existing theme on your store.
-              {{command:-t, --themename=THEMENAME}} The Theme name. Must be an existing theme on your store.
-              {{command:-d, --development}}         Pull theme files from your remote development theme.
-              {{command:-l, --live}}                Pull theme files from your remote live theme.
-              {{command:-n, --nodelete}}            Runs the pull command without deleting local files.
+              {{command:-t, --theme=THEME}}     Theme ID or name of the remote theme.
+              {{command:-i, --themeid=THEMEID}} The Theme ID. Must be an existing theme on your store.
+              {{command:-l, --live}}            Pull theme files from your remote live theme.
+              {{command:-d, --development}}     Pull theme files from your remote development theme.
+              {{command:-n, --nodelete}}        Runs the pull command without deleting local files.
 
             Run without options to select theme from a list.
           HELP

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -57,15 +57,14 @@ module Theme
               Usage: {{command:%s theme push [ ROOT ]}}
 
               Options:
-                {{command:-t, --theme=THEME}}     Theme ID or name of the remote theme.
-                {{command:-i, --themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
-                {{command:-l, --live}}            Push to your remote live theme, and update your live store.
-                {{command:-d, --development}}     Push to your remote development theme, and create it if needed.
-                {{command:-u, --unpublished}}     Create a new unpublished theme and push to it.
-                {{command:-n, --nodelete}}        Runs the push command without deleting remote files from Shopify.
-                {{command:-j, --json}}            Output JSON instead of a UI.
-                {{command:-a, --allow-live}}      Allow push to a live theme.
-                {{command:-p, --publish}}         Publish as the live theme after uploading.
+                {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of the remote theme.
+                {{command:-l, --live}}             Push to your remote live theme, and update your live store.
+                {{command:-d, --development}}      Push to your remote development theme, and create it if needed.
+                {{command:-u, --unpublished}}      Create a new unpublished theme and push to it.
+                {{command:-n, --nodelete}}         Runs the push command without deleting remote files from Shopify.
+                {{command:-j, --json}}             Output JSON instead of a UI.
+                {{command:-a, --allow-live}}       Allow push to a live theme.
+                {{command:-p, --publish}}          Publish as the live theme after uploading.
 
               Run without options to select theme from a list.
           HELP
@@ -76,6 +75,9 @@ module Theme
           select: "Select theme to push to",
           live: "Are you sure you want to push to your live theme?",
           theme: "\n  Theme: {{blue:%s #%s}} {{green:[live]}}",
+          deprecated_themeid: <<~WARN,
+            {{warning:The {{command:-i, --themeid}} flag is deprecated. Use {{command:-t, --theme}} instead.}}
+          WARN
           theme_not_found: "Theme \"%s\" doesn't exist",
           done: <<~DONE,
             {{green:Your theme was pushed successfully}}
@@ -190,17 +192,19 @@ module Theme
             Usage: {{command:%s theme pull [ ROOT ]}}
 
             Options:
-              {{command:-t, --theme=THEME}}     Theme ID or name of the remote theme.
-              {{command:-i, --themeid=THEMEID}} The Theme ID. Must be an existing theme on your store.
-              {{command:-l, --live}}            Pull theme files from your remote live theme.
-              {{command:-d, --development}}     Pull theme files from your remote development theme.
-              {{command:-n, --nodelete}}        Runs the pull command without deleting local files.
+              {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of the remote theme.
+              {{command:-l, --live}}             Pull theme files from your remote live theme.
+              {{command:-d, --development}}      Pull theme files from your remote development theme.
+              {{command:-n, --nodelete}}         Runs the pull command without deleting local files.
 
             Run without options to select theme from a list.
           HELP
           select: "Select a theme to pull from",
           pulling: "Pulling theme files from %s (#%s) on %s",
           done: "Theme pulled successfully",
+          deprecated_themeid: <<~WARN,
+            {{warning:The {{command:-i, --themeid}} flag is deprecated. Use {{command:-t, --theme}} instead.}}
+          WARN
           theme_not_found: "Theme \"%s\" doesn't exist",
         },
       },

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -57,14 +57,15 @@ module Theme
               Usage: {{command:%s theme push [ ROOT ]}}
 
               Options:
-                {{command:-i, --themeid=THEMEID}} Theme ID. Must be an existing theme on your store.
-                {{command:-l, --live}}            Push to your remote live theme, and update your live store.
-                {{command:-d, --development}}     Push to your remote development theme, and create it if needed.
-                {{command:-u, --unpublished}}     Create a new unpublished theme and push to it.
-                {{command:-n, --nodelete}}        Runs the push command without deleting remote files from Shopify.
-                {{command:-j, --json}}            Output JSON instead of a UI.
-                {{command:-a, --allow-live}}      Allow push to a live theme.
-                {{command:-p, --publish}}         Publish as the live theme after uploading.
+                {{command:-i, --themeid=THEMEID}}     Theme ID. Must be an existing theme on your store.
+                {{command:-t, --themename=THEMENAME}} Theme name. Must be an existing theme on your store.
+                {{command:-l, --live}}                Push to your remote live theme, and update your live store.
+                {{command:-d, --development}}         Push to your remote development theme, and create it if needed.
+                {{command:-u, --unpublished}}         Create a new unpublished theme and push to it.
+                {{command:-n, --nodelete}}            Runs the push command without deleting remote files from Shopify.
+                {{command:-j, --json}}                Output JSON instead of a UI.
+                {{command:-a, --allow-live}}          Allow push to a live theme.
+                {{command:-p, --publish}}             Publish as the live theme after uploading.
 
               Run without options to select theme from a list.
           HELP
@@ -75,7 +76,7 @@ module Theme
           select: "Select theme to push to",
           live: "Are you sure you want to push to your live theme?",
           theme: "\n  Theme: {{blue:%s #%s}} {{green:[live]}}",
-          theme_not_found: "Theme #%s doesn't exist",
+          theme_not_found: "Theme \"%s\" doesn't exist",
           done: <<~DONE,
             {{green:Your theme was pushed successfully}}
 
@@ -189,17 +190,18 @@ module Theme
             Usage: {{command:%s theme pull [ ROOT ]}}
 
             Options:
-              {{command:-i, --themeid=THEMEID}} The Theme ID. Must be an existing theme on your store.
-              {{command:-l, --live}}            Pull theme files from your remote live theme.
-              {{command:-d, --development}}     Pull theme files from your remote development theme.
-              {{command:-n, --nodelete}}        Runs the pull command without deleting local files.
+              {{command:-i, --themeid=THEMEID}}     The Theme ID. Must be an existing theme on your store.
+              {{command:-t, --themename=THEMENAME}} The Theme name. Must be an existing theme on your store.
+              {{command:-d, --development}}         Pull theme files from your remote development theme.
+              {{command:-l, --live}}                Pull theme files from your remote live theme.
+              {{command:-n, --nodelete}}            Runs the pull command without deleting local files.
 
             Run without options to select theme from a list.
           HELP
           select: "Select a theme to pull from",
           pulling: "Pulling theme files from %s (#%s) on %s",
           done: "Theme pulled successfully",
-          not_found: "{{x}} Theme #%s doesn't exist",
+          theme_not_found: "Theme \"%s\" doesn't exist",
         },
       },
     }.freeze

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -173,22 +173,36 @@ module ShopifyCLI
         end
 
         def live(ctx, root: nil)
-          _status, body = fetch_themes(ctx)
-
-          body["themes"]
-            .find { |theme_attrs| theme_attrs["role"] == "main" }
-            .tap { |theme_attrs| break new(ctx, root: root, **allowed_attrs(theme_attrs)) }
+          find(ctx, root) { |attrs| attrs["role"] == "main" }
         end
 
         def development(ctx, root: nil)
-          _status, body = fetch_themes(ctx)
+          find(ctx, root) { |attrs| attrs["role"] == "development" }
+        end
 
-          body["themes"]
-            .find { |theme_attrs| theme_attrs["role"] == "development" }
-            .tap { |theme_attrs| break new(ctx, root: root, **allowed_attrs(theme_attrs)) }
+        # Finds a Theme by its identifier
+        #
+        # #### Parameters
+        # * `ctx` - current running context of your command
+        # * `root` - theme root
+        # * `identifier` - theme ID or theme name
+        def find_by_identifier(ctx, root: nil, identifier:)
+          find(ctx, root) do |attrs|
+            attrs.slice("name", "id").values.map(&:to_s).include?(identifier)
+          end
         end
 
         private
+
+        def find(ctx, root, &block)
+          _status, body = fetch_themes(ctx)
+
+          body["themes"]
+            .find(&block)
+            .tap do |attrs|
+              break new(ctx, root: root, **allowed_attrs(attrs)) if attrs
+            end
+        end
 
         def allowed_attrs(attrs)
           attrs.slice("id", "name", "role").transform_keys(&:to_sym)

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -43,6 +43,27 @@ module Theme
         @command.call([], "pull")
       end
 
+      def test_pull_theme_with_name
+        ShopifyCLI::Theme::Theme.expects(:find_by)
+          .with(@ctx, name: "Test theme", root: ".")
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme_name] = "Test theme"
+        @command.call([], "pull")
+      end
+
       def test_pull_live_theme
         ShopifyCLI::Theme::Theme.expects(:live)
           .with(@ctx, root: ".")
@@ -61,6 +82,27 @@ module Theme
         @ctx.expects(:done)
 
         @command.options.flags[:live] = true
+        @command.call([], "pull")
+      end
+
+      def test_pull_development_theme
+        ShopifyCLI::Theme::Theme.expects(:development)
+          .with(@ctx, root: ".")
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:development] = true
         @command.call([], "pull")
       end
 

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -44,8 +44,8 @@ module Theme
       end
 
       def test_pull_theme_with_name
-        ShopifyCLI::Theme::Theme.expects(:find_by)
-          .with(@ctx, name: "Test theme", root: ".")
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -60,7 +60,7 @@ module Theme
         @syncer.expects(:download_theme!).with(delete: true)
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_name] = "Test theme"
+        @command.options.flags[:theme] = "Test theme"
         @command.call([], "pull")
       end
 

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -22,7 +22,7 @@ module Theme
         @ignore_filter = mock("IgnoreFilter")
       end
 
-      def test_pull_theme
+      def test_pull_with_deprecated_theme_id
         ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
@@ -37,13 +37,35 @@ module Theme
         @syncer.expects(:shutdown)
 
         @syncer.expects(:download_theme!).with(delete: true)
+        @ctx.expects(:warn)
         @ctx.expects(:done)
 
         @command.options.flags[:theme_id] = 1234
         @command.call([], "pull")
       end
 
-      def test_pull_theme_with_name
+      def test_pull_with_id
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme] = 1234
+        @command.call([], "pull")
+      end
+
+      def test_pull_with_name
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
@@ -107,8 +129,8 @@ module Theme
       end
 
       def test_pull_pass_nodelete_to_syncer
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -124,14 +146,14 @@ module Theme
 
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:nodelete] = true
         @command.call([], "pull")
       end
 
       def test_pull_with_ignores
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -148,7 +170,7 @@ module Theme
 
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:ignores] = ["config/*"]
         @command.call([], "pull")
       end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -25,7 +25,7 @@ module Theme
         @ignore_filter = mock("IgnoreFilter")
       end
 
-      def test_push_to_theme_id
+      def test_push_with_deprecated_theme_id
         ShopifyCLI::Theme::Theme.expects(:new)
           .with(@ctx, root: ".", id: 1234)
           .returns(@theme)
@@ -40,13 +40,35 @@ module Theme
         @syncer.expects(:shutdown)
 
         @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:warn)
         @ctx.expects(:done)
 
         @command.options.flags[:theme_id] = 1234
         @command.call([], "push")
       end
 
-      def test_push_to_theme
+      def test_push_with_theme_id
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme] = 1234
+        @command.call([], "push")
+      end
+
+      def test_push_with_theme_name
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
@@ -96,8 +118,8 @@ module Theme
       end
 
       def test_push_to_live_theme
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
@@ -119,13 +141,13 @@ module Theme
         @syncer.expects(:upload_theme!).with(delete: true)
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.call([], "push")
       end
 
       def test_allow_live
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         @theme.expects(:live?).returns(true)
@@ -144,14 +166,14 @@ module Theme
         @syncer.expects(:upload_theme!).with(delete: true)
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:allow_live] = true
         @command.call([], "push")
       end
 
       def test_push_json
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         @theme.expects(:to_h).returns({})
@@ -170,7 +192,7 @@ module Theme
 
         @ctx.expects(:puts).never
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:json] = 1234
         @command.call([], "push")
       end
@@ -178,8 +200,8 @@ module Theme
       def test_push_when_syncer_has_an_error
         syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true)
 
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         @theme.expects(:to_h).returns({})
@@ -198,7 +220,7 @@ module Theme
 
         @ctx.expects(:puts).never
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:json] = 1234
 
         assert_raises(ShopifyCLI::AbortSilent) do
@@ -207,8 +229,8 @@ module Theme
       end
 
       def test_push_and_publish
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -224,14 +246,14 @@ module Theme
         @ctx.expects(:done)
         @theme.expects(:publish)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:publish] = true
         @command.call([], "push")
       end
 
       def test_push_with_ignores
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -247,7 +269,7 @@ module Theme
         @syncer.expects(:upload_theme!).with(delete: true)
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:ignores] = ["config/*"]
         @command.call([], "push")
       end
@@ -330,8 +352,8 @@ module Theme
       end
 
       def test_push_pass_nodelete_to_syncer
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", id: 1234)
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -347,7 +369,7 @@ module Theme
 
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_id] = 1234
+        @command.options.flags[:theme] = 1234
         @command.options.flags[:nodelete] = true
         @command.call([], "push")
       end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -46,9 +46,9 @@ module Theme
         @command.call([], "push")
       end
 
-      def test_push_to_theme_name
-        ShopifyCLI::Theme::Theme.expects(:find_by)
-          .with(@ctx, name: "Test theme", root: ".")
+      def test_push_to_theme
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
@@ -63,7 +63,7 @@ module Theme
         @syncer.expects(:upload_theme!).with(delete: true)
         @ctx.expects(:done)
 
-        @command.options.flags[:theme_name] = "Test theme"
+        @command.options.flags[:theme] = "Test theme"
         @command.call([], "push")
       end
 
@@ -325,7 +325,7 @@ module Theme
         @ctx.expects(:done)
 
         @command.options.flags[:unpublished] = true
-        @command.options.flags[:theme_name] = "NAME"
+        @command.options.flags[:theme] = "NAME"
         @command.call([], "push")
       end
 

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -145,6 +145,21 @@ module ShopifyCLI
         assert theme.development?
       end
 
+      def test_find_by
+        mock_themes_json
+
+        theme = Theme.find_by(@ctx, name: "Venture", root: @root)
+
+        assert_equal 5, theme.id
+        assert_equal "Venture", theme.name
+        assert_equal "unpublished", theme.role
+      end
+
+      def test_find_by_when_theme_is_not_found
+        mock_themes_json
+        assert_nil Theme.find_by(@ctx, name: "Other", root: @root)
+      end
+
       private
 
       def mock_themes_json

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -145,19 +145,29 @@ module ShopifyCLI
         assert theme.development?
       end
 
-      def test_find_by
+      def test_find_by_identifier_with_id
         mock_themes_json
 
-        theme = Theme.find_by(@ctx, name: "Venture", root: @root)
+        theme = Theme.find_by_identifier(@ctx, root: @root, identifier: "5")
 
         assert_equal 5, theme.id
         assert_equal "Venture", theme.name
         assert_equal "unpublished", theme.role
       end
 
-      def test_find_by_when_theme_is_not_found
+      def test_find_by_identifier_with_name
         mock_themes_json
-        assert_nil Theme.find_by(@ctx, name: "Other", root: @root)
+
+        theme = Theme.find_by_identifier(@ctx, root: @root, identifier: "Venture")
+
+        assert_equal 5, theme.id
+        assert_equal "Venture", theme.name
+        assert_equal "unpublished", theme.role
+      end
+
+      def test_find_by_identifier_when_theme_is_not_found
+        mock_themes_json
+        assert_nil Theme.find_by_identifier(@ctx, root: @root, identifier: "Other")
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?

Users can't set the theme name when running commands like `shopify theme push -u` (https://github.com/Shopify/shopify-cli/issues/1431).

### WHAT is this pull request doing?

This PR introduces a new parameter representing the theme name `-t`/`--theme=NAME_OR_ID`. So, now users can perform operations `shopify theme push -u -t my_theme`.

For consistency, this PR also:
- Adds the `-t`/`--theme=NAME_OR_ID` to `theme pull`
- Adds the `-t`/`--theme=NAME_OR_ID` to `theme push` (globally, even without the`--unpublished` parameter)

Thus, now users may rely on the `-t <NAME_OR_ID>` to `push`/`pull` a theme, instead of only relying on `-i <ID>`.

### How to test your changes?

Run the following commands for checking the impact of the new parameter on `theme push`:

```bash
shopify theme push --live
shopify-dev theme push --theme abc
shopify-dev theme push -t abc
shopify-dev theme push -u -t abc
```

Run the following commands for checking the impact of the new parameter on `theme pull`:
```bash
shopify-dev theme pull --theme abc
shopify-dev theme pull -t abc
```

<img width="50%" src="https://user-images.githubusercontent.com/1079279/147081662-5200d07b-eb4c-4c27-b6e1-be602587a4e7.gif">

<img width="50%" src="https://user-images.githubusercontent.com/1079279/147081701-5662d718-e8d3-4fc1-a5af-2578e3822e1b.gif">

<img width="50%" src="https://user-images.githubusercontent.com/1079279/147081713-1d65841f-e931-4e3e-ab48-5de357bb6484.gif">

### Post-release steps
Update documentation with the new `-t`/`--theme=THEME` parameter: https://shopify.dev/themes/tools/cli/theme-commands#push, https://shopify.dev/themes/tools/cli/theme-commands#pull.


### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.