### PR TITLE
Disambiguate -s as store option

### DIFF
--- a/lib/shopify_cli/commands/login.rb
+++ b/lib/shopify_cli/commands/login.rb
@@ -7,7 +7,7 @@ module ShopifyCLI
       PERMANENT_DOMAIN_SUFFIX = /\.myshopify\.(com|io)$/
 
       options do |parser, flags|
-        parser.on("--store=STORE") { |url| flags[:shop] = url }
+        parser.on("-s", "--store=STORE") { |url| flags[:shop] = url }
         # backwards compatibility allow 'shop' for now
         parser.on("--shop=SHOP") { |url| flags[:shop] = url }
         parser.on("--password=PASSWORD") { |password| flags[:password] = password }

--- a/lib/shopify_cli/commands/switch.rb
+++ b/lib/shopify_cli/commands/switch.rb
@@ -4,7 +4,7 @@ module ShopifyCLI
   module Commands
     class Switch < ShopifyCLI::Command
       options do |parser, flags|
-        parser.on("--store=STORE") { |url| flags[:shop] = url }
+        parser.on("-s", "--store=STORE") { |url| flags[:shop] = url }
         # backwards compatibility allow 'shop' for now
         parser.on("--shop=SHOP") { |url| flags[:shop] = url }
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Better error experience when the user mistypes `--store` as `-store`. This happens at least 100 times a month to our error-reporting users.

This actually restores the UX from before we accepted both `--shop` and `--store`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Before and after:

```
in shopify-cli/ on resolve-s-to-store 
[°‿°]> shopify login -store=ariel-caplan-test.myshopify.com                         

Traceback (most recent call last):
	25: from /Users/amcaplan/.gem/ruby/2.7.5/bin/shopify:23:in `<main>'
	24: from /Users/amcaplan/.gem/ruby/2.7.5/bin/shopify:23:in `load'
	23: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:47:in `<top (required)>'
	22: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:36:in `block in <top (required)>'
	21: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:21:in `call'
	20: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:75:in `handle_abort'
	19: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:37:in `block (2 levels) in <top (required)>'
	18: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/entry_point.rb:23:in `call'
	17: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/monorail.rb:30:in `log'
	16: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/entry_point.rb:24:in `block in call'
	15: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:15:in `call'
	14: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:43:in `with_traps'
	13: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:55:in `twrap'
	12: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:44:in `block in with_traps'
	11: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:55:in `twrap'
	10: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:45:in `block (2 levels) in with_traps'
	 9: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:16:in `block in call'
	 8: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:35:in `with_logging'
	 7: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-ui/lib/cli/ui.rb:176:in `log_output_to'
	 6: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:36:in `block in with_logging'
	 5: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:169:in `with_id'
	 4: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:37:in `block (2 levels) in with_logging'
	 3: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:17:in `block (2 levels) in call'
	 2: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/command.rb:27:in `call'
	 1: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/options.rb:19:in `parse'
/Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/options.rb:28:in `parse_flags': invalid option: s (OptionParser::InvalidOption)
	25: from /Users/amcaplan/.gem/ruby/2.7.5/bin/shopify:23:in `<main>'
	24: from /Users/amcaplan/.gem/ruby/2.7.5/bin/shopify:23:in `load'
	23: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:47:in `<top (required)>'
	22: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:36:in `block in <top (required)>'
	21: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:21:in `call'
	20: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:75:in `handle_abort'
	19: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/bin/shopify:37:in `block (2 levels) in <top (required)>'
	18: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/entry_point.rb:23:in `call'
	17: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/monorail.rb:30:in `log'
	16: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/entry_point.rb:24:in `block in call'
	15: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:15:in `call'
	14: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:43:in `with_traps'
	13: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:55:in `twrap'
	12: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:44:in `block in with_traps'
	11: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:55:in `twrap'
	10: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:45:in `block (2 levels) in with_traps'
	 9: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:16:in `block in call'
	 8: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:35:in `with_logging'
	 7: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-ui/lib/cli/ui.rb:176:in `log_output_to'
	 6: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:36:in `block in with_logging'
	 5: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:169:in `with_id'
	 4: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/vendor/deps/cli-kit/lib/cli/kit/executor.rb:37:in `block (2 levels) in with_logging'
	 3: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/core/executor.rb:17:in `block (2 levels) in call'
	 2: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/command.rb:27:in `call'
	 1: from /Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/options.rb:19:in `parse'
/Users/amcaplan/.gem/ruby/2.7.5/gems/shopify-cli-2.7.4/lib/shopify_cli/options.rb:28:in `parse_flags': ambiguous option: -store=ariel-caplan-test.myshopify.com (OptionParser::AmbiguousOption)

in shopify-cli/ on resolve-s-to-store 
[°‿°]> bin/shopify login -store=ariel-caplan-test.myshopify.com
⭑ You are running a development version of the CLI at:
  /Users/amcaplan/src/github.com/Shopify/shopify-cli/bin/shopify

┏━━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ✗ Invalid store provided (tore=ariel-caplan-test.myshopify.com). Please provide the store in the following format: my-store.myshopify.com
┃ 
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

```

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
See before/after above

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.