### PR TITLE
Recognize attempts to pass a store name and suggest correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#1934](https://github.com/Shopify/shopify-cli/pull/1934): Block directories in theme assets
+* [#1880](https://github.com/Shopify/shopify-cli/pull/1880): Recognize attempts to pass a store name and suggest correction
 
 ### Fixed
 * [#1874](https://github.com/Shopify/shopify-cli/pull/1874): Make ngrok errors more robust and helpful

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -36,6 +36,12 @@ module ShopifyCLI
         end
       rescue OptionParser::InvalidOption => error
         arg = error.args.first
+        store_name = arg.match(/\A--(?<store_name>.*\.myshopify\.com)\z/)&.[](:store_name)
+        if store_name
+          # Sometimes it may look like --invalidoption=https://storename.myshopify.com
+          store_name = store_name.sub(%r{\A(.*=)?(https?://)?}, "")
+          raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option_store_equals", arg, store_name)
+        end
         raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option", arg)
       rescue OptionParser::MissingArgument => error
         arg = error.args.first

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -37,7 +37,7 @@ module ShopifyCLI
       rescue OptionParser::InvalidOption => error
         arg = error.args.first
         store_name = arg.match(/\A--(?<store_name>.*\.myshopify\.com)\z/)&.[](:store_name)
-        if store_name
+        if store_name && !arg.match?(/\A--(store|shop)=/)
           # Sometimes it may look like --invalidoption=https://storename.myshopify.com
           store_name = store_name.sub(%r{\A(.*=)?(https?://)?}, "")
           raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option_store_equals", arg, store_name)

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -40,7 +40,8 @@ module ShopifyCLI
         if store_name && !arg.match?(/\A--(store|shop)=/)
           # Sometimes it may look like --invalidoption=https://storename.myshopify.com
           store_name = store_name.sub(%r{\A(.*=)?(https?://)?}, "")
-          raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option_store_equals", arg, store_name)
+          raise ShopifyCLI::Abort,
+            @ctx.message("core.errors.option_parser.invalid_option_store_equals", arg, store_name)
         end
         raise ShopifyCLI::Abort, @ctx.message("core.errors.option_parser.invalid_option", arg)
       rescue OptionParser::MissingArgument => error

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -20,6 +20,7 @@ module ShopifyCLI
           missing_ruby: "Ruby is required to continue. Install Ruby here: https://www.ruby-lang.org/en/downloads.",
           option_parser: {
             invalid_option: "The option {{command:%s}} is not supported.",
+            invalid_option_store_equals: "The option {{command:%s}} is not supported, did you mean: {{command:--store=%s}}.",
             missing_argument: "The required argument {{command:%s}} is missing.",
           },
         },

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -20,7 +20,12 @@ module ShopifyCLI
           missing_ruby: "Ruby is required to continue. Install Ruby here: https://www.ruby-lang.org/en/downloads.",
           option_parser: {
             invalid_option: "The option {{command:%s}} is not supported.",
-            invalid_option_store_equals: "The option {{command:%s}} is not supported, did you mean: {{command:--store=%s}}.",
+            invalid_option_store_equals: <<~MESSAGE,
+            The option {{command:%s}} isn't recognized.
+
+            Try this:
+            {{command:--store=%s}}.
+            MESSAGE
             missing_argument: "The required argument {{command:%s}} is missing.",
           },
         },

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -38,7 +38,7 @@ module ShopifyCLI
         ["store=", false],
         ["shop=", false],
         ["s=", false, "-s="],
-      ].each do |prefix, correction_expected = true, full_prefix="--#{prefix}"|
+      ].each do |prefix, correction_expected = true, full_prefix = "--#{prefix}"|
         store_name = "mystore.myshopify.com"
         store_name_with_prefix = "#{full_prefix}#{store_name}"
 
@@ -49,7 +49,10 @@ module ShopifyCLI
 
           if correction_expected
             assert_message_output(io: io, expected_content: [
-              @context.message("core.errors.option_parser.invalid_option_store_equals", store_name_with_prefix, store_name),
+              @context.message(
+                "core.errors.option_parser.invalid_option_store_equals",
+                store_name_with_prefix, store_name
+              ),
             ])
           else
             assert_message_output(io: io, expected_content: [

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -29,18 +29,32 @@ module ShopifyCLI
         assert_match(CLI::UI.fmt(ShopifyCLI::Commands::Populate::Customer.help), io.join)
       end
 
-      ["", "http://", "https://", "invalidoption=", "invalidoption=https://"].each do |prefix|
+      [
+        "",
+        "http://",
+        "https://",
+        "invalidoption=",
+        "invalidoption=https://",
+        ["store=", false],
+        ["shop=", false],
+      ].each do |prefix, correction_expected = true|
         store_name = "mystore.myshopify.com"
         store_name_with_prefix = "--#{prefix}#{store_name}"
 
         define_method("test_calls_with#{"_prefix_#{prefix}" unless prefix.empty?}_store_as_raw_param") do
           io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
-            run_cmd("login #{store_name_with_prefix}")
+            run_cmd("help login #{store_name_with_prefix}")
           end
 
-          assert_message_output(io: io, expected_content: [
-            @context.message("core.errors.option_parser.invalid_option_store_equals", store_name_with_prefix, store_name),
-          ])
+          if correction_expected
+            assert_message_output(io: io, expected_content: [
+              @context.message("core.errors.option_parser.invalid_option_store_equals", store_name_with_prefix, store_name),
+            ])
+          else
+            assert_message_output(io: io, expected_content: [
+              @context.message("core.errors.option_parser.invalid_option", store_name_with_prefix),
+            ])
+          end
         end
       end
     end

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -28,6 +28,21 @@ module ShopifyCLI
 
         assert_match(CLI::UI.fmt(ShopifyCLI::Commands::Populate::Customer.help), io.join)
       end
+
+      ["", "http://", "https://", "invalidoption=", "invalidoption=https://"].each do |prefix|
+        store_name = "mystore.myshopify.com"
+        store_name_with_prefix = "--#{prefix}#{store_name}"
+
+        define_method("test_calls_with#{"_prefix_#{prefix}" unless prefix.empty?}_store_as_raw_param") do
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+            run_cmd("login #{store_name_with_prefix}")
+          end
+
+          assert_message_output(io: io, expected_content: [
+            @context.message("core.errors.option_parser.invalid_option_store_equals", store_name_with_prefix, store_name),
+          ])
+        end
+      end
     end
   end
 end

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -37,9 +37,10 @@ module ShopifyCLI
         "invalidoption=https://",
         ["store=", false],
         ["shop=", false],
-      ].each do |prefix, correction_expected = true|
+        ["s=", false, "-s="],
+      ].each do |prefix, correction_expected = true, full_prefix="--#{prefix}"|
         store_name = "mystore.myshopify.com"
-        store_name_with_prefix = "--#{prefix}#{store_name}"
+        store_name_with_prefix = "#{full_prefix}#{store_name}"
 
         define_method("test_calls_with#{"_prefix_#{prefix}" unless prefix.empty?}_store_as_raw_param") do
           io = capture_io_and_assert_raises(ShopifyCLI::Abort) do


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

We often see failed attempts to pass a store name. Sometimes they [mess up](https://app.bugsnag.com/shopify/shopify-cli/errors/615c602b14a5fc000787762e?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in][type]=gt&filters[release.seen_in][value]=2.7.3&event_id=61bf79e5008a8c9cb5d00000) [the name](https://app.bugsnag.com/shopify/shopify-cli/errors/615c602b14a5fc000787762e?filters[event.since]=30d&filters[error.status]=open&filters[release.seen_in][type]=gt&filters[release.seen_in][value]=2.7.3&event_id=61bf33b6008a9606f27c0000) of the param, other times they try to [pass it as a raw param](https://app.bugsnag.com/shopify/shopify-cli/errors/615c602b14a5fc000787762e?filters[event.since]=30d&filters[error.status]=open&event_id=61c20ac6008a8b0460f20000).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This attempts to guide them to solve the problem more precisely by indicating what we expect from them. Before/after:

<img width="1275" alt="Screen Shot 2021-12-23 at 12 38 47" src="https://user-images.githubusercontent.com/6288426/147229578-a6ce9207-da77-4962-9397-d9eee931c1a8.png">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

```
$ shopify app create rails --name=FOOBAR --invalidoption=https://storename.myshopify.com
```

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.