### PR TITLE
Packaging for release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+
+## Version 2.8.0
 ### Fixed
 * [#1879](https://github.com/Shopify/shopify-cli/pull/1879): Disambiguate -s as store option
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.7.4)
+    shopify-cli (2.8.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.9.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.7.4"
+  VERSION = "2.8.0"
 end


### PR DESCRIPTION
I'm releasing a new version of the Shopify CLI, 2.8.0, with the following changelog:

### Fixed
* [#1879](https://github.com/Shopify/shopify-cli/pull/1879): Disambiguate -s as store option
