### PR TITLE
Remove beta flag from payment and shipping APIs

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -5,7 +5,6 @@ payment_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
       package: "@shopify/scripts-checkout-apis"
     typescript:
-      beta: true
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_methods:
@@ -15,7 +14,6 @@ shipping_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
       package: "@shopify/scripts-checkout-apis"
     typescript:
-      beta: true
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
 merchandise_discount_types:


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/script-service/issues/3780

We're ready to release the Typescript APIs for payment and shipping methods to beta partners.

### WHAT is this pull request doing?

By removing these flags, `Typescript` will appear as a language option when creating a payment or shipping script. Partners will no longer need a beta flag to gain access to the Typescript template.

### How to test your changes?

`shopify script create`

### Post-release steps

This will require a release so that Partners can access it.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.