### PR TITLE
[scripts] Remove strict option in ConnectApp

### DIFF
--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -6,7 +6,7 @@ module Script
       prerequisite_task ensure_project_type: :script
 
       def call(_args, _)
-        Layers::Application::ConnectApp.call(ctx: @ctx, force: true, strict: true)
+        Layers::Application::ConnectApp.call(ctx: @ctx, force: true)
       rescue StandardError => e
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.connect.error.operation_failed"))
       end

--- a/lib/project_types/script/layers/application/connect_app.rb
+++ b/lib/project_types/script/layers/application/connect_app.rb
@@ -7,7 +7,7 @@ module Script
     module Application
       class ConnectApp
         class << self
-          def call(ctx:, force: false, strict: false)
+          def call(ctx:, force: false)
             script_project_repo = Layers::Infrastructure::ScriptProjectRepository.new(ctx: ctx)
             script_project = script_project_repo.get
 
@@ -39,10 +39,6 @@ module Script
             scripts = script_service.get_app_scripts(extension_point_type: extension_point_type)
 
             uuid = Forms::AskScriptUuid.ask(ctx, scripts, nil)&.uuid
-
-            if strict && uuid.nil?
-              ctx.abort(ctx.message("script.connect.missing_script"))
-            end
 
             script_project_repo.create_env(
               api_key: app["apiKey"],

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -194,7 +194,6 @@ module Script
         },
         connect: {
           connected: "Connected! Your project is now connected to {{green:%s}}",
-          missing_script: "No script has been selected.",
           help: <<~HELP,
             {{command:%s script connect}}: Connects an existing script to an app.
               Usage: {{command:%s script connect}}

--- a/test/project_types/script/commands/connect_test.rb
+++ b/test/project_types/script/commands/connect_test.rb
@@ -18,7 +18,7 @@ module Script
       end
 
       def test_calls_connect_app
-        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, force: true, strict: true)
+        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, force: true)
         perform_command
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

When running `script connect`, an error is raised if the user answers 'no' to the ` Do you want to replace any of the existing scripts on the app with this script?` prompt. We can't have that right now, because that is the only way we can create scripts at the moment. The user should be able to answer `no` and create a new script.

### WHAT is this pull request doing?

Removes the strict option that requires that a script is selected during connect.

### How to test your changes?

- create a script
- run `shopify script connect`
- run `shopify script push` and verify it works
- check the .env file to ensure a new UUID was created and saved

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).