### PR TITLE
Add `-d/--development` flag to Shopify theme pull command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+### Added
+* [#1900](https://github.com/Shopify/shopify-cli/pull/1900): Add `-d'/`--development` flag to Shopify theme pull command
 * [#1896](https://github.com/Shopify/shopify-cli/pull/1896): Release Typescript options for payment_methods and shipping_methods scripts.
 
 ## Version 2.8.0

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -10,6 +10,7 @@ module Theme
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }
         parser.on("-l", "--live") { flags[:live] = true }
+        parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-x", "--ignore=PATTERN") do |pattern|
           flags[:ignores] ||= []
           flags[:ignores] << pattern
@@ -24,6 +25,8 @@ module Theme
           ShopifyCLI::Theme::Theme.new(@ctx, root: root, id: theme_id)
         elsif options.flags[:live]
           ShopifyCLI::Theme::Theme.live(@ctx, root: root)
+        elsif options.flags[:development]
+          ShopifyCLI::Theme::Theme.development(@ctx, root: root)
         else
           form = Forms::Select.ask(
             @ctx,

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -191,6 +191,7 @@ module Theme
             Options:
               {{command:-i, --themeid=THEMEID}} The Theme ID. Must be an existing theme on your store.
               {{command:-l, --live}}            Pull theme files from your remote live theme.
+              {{command:-d, --development}}     Pull theme files from your remote development theme.
               {{command:-n, --nodelete}}        Runs the pull command without deleting local files.
 
             Run without options to select theme from a list.

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -180,6 +180,14 @@ module ShopifyCLI
             .tap { |theme_attrs| break new(ctx, root: root, **allowed_attrs(theme_attrs)) }
         end
 
+        def development(ctx, root: nil)
+          _status, body = fetch_themes(ctx)
+
+          body["themes"]
+            .find { |theme_attrs| theme_attrs["role"] == "development" }
+            .tap { |theme_attrs| break new(ctx, root: root, **allowed_attrs(theme_attrs)) }
+        end
+
         private
 
         def allowed_attrs(attrs)

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -134,6 +134,17 @@ module ShopifyCLI
         assert theme.live?
       end
 
+      def test_development
+        mock_themes_json
+
+        theme = Theme.development(@ctx, root: @root)
+
+        assert_equal 3, theme.id
+        assert_equal "Development", theme.name
+        assert_equal "development", theme.role
+        assert theme.development?
+      end
+
       private
 
       def mock_themes_json


### PR DESCRIPTION
### [Feature]  Add `-d/--development` flag to `shopify theme pull` command. 

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This fixes #1878: Users can't pull the changes from the current development theme to save them after making modification on the local theme customiser.

This saves so much time, and might prevent pulling a different theme especially in stores with 100 themes. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR introduces a new flag representing the development theme `-d/--development`. So, now users can perform operations like `shopify theme pull --development` to retrieve the settings made in local theme customiser without being prompt to select/choose the development theme (works just like the `--live` flag)

### How to test your changes?

To test the changes run the following commands after lunching the development server

```shell
shopify theme pull --development
or 
shopify theme pull -d
```
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

Update documentation with the new -d/--development flag at https://shopify.dev/themes/tools/cli/theme-commands#pull

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.