### PR TITLE
[scripts] add language flag to the create command's help

### DIFF
--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -33,8 +33,14 @@ module Script
       end
 
       def self.help
-        allowed_values = Script::Layers::Application::ExtensionPoints.available_types.map { |type| "{{cyan:#{type}}}" }
-        ShopifyCLI::Context.message("script.create.help", ShopifyCLI::TOOL_NAME, allowed_values.join(", "))
+        allowed_apis = Layers::Application::ExtensionPoints.available_types.map { |type| "{{cyan:#{type}}}" }
+        allowed_languages = Layers::Application::ExtensionPoints.all_languages.map { |lang| "{{cyan:#{lang}}}" }
+        ShopifyCLI::Context.message(
+          "script.create.help",
+          ShopifyCLI::TOOL_NAME,
+          allowed_apis.join(", "),
+          allowed_languages.join(", ")
+        )
       end
     end
   end

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -6,33 +6,55 @@ module Script
       class ExtensionPoints
         class << self
           def get(type:)
-            Infrastructure::ExtensionPointRepository.new.get_extension_point(type)
+            extension_point_repository.get_extension_point(type)
           end
 
           def types
-            Infrastructure::ExtensionPointRepository.new.extension_point_types
+            extension_point_repository.extension_point_types
           end
 
           def available_types
-            Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
+            extension_point_repository.extension_points.select do |ep|
               next false if ep.deprecated?
-              !ep.beta? || ShopifyCLI::Feature.enabled?(:scripts_beta_extension_points)
+              !ep.beta? || include_beta_extension_points?
             end.map(&:type)
           end
 
           def deprecated_types
-            Infrastructure::ExtensionPointRepository.new
+            extension_point_repository
               .extension_points
               .select(&:deprecated?)
               .map(&:type)
           end
 
+          def all_languages
+            extension_point_repository
+              .extension_points
+              .map { |ep| ep.library_languages(include_betas: include_beta_languages?) }
+              .flatten
+              .uniq
+          end
+
           def languages(type:)
-            get(type: type).library_languages(include_betas: ShopifyCLI::Feature.enabled?(:scripts_beta_languages))
+            get(type: type).library_languages(include_betas: include_beta_languages?)
           end
 
           def supported_language?(type:, language:)
             languages(type: type).include?(language.downcase)
+          end
+
+          private
+
+          def extension_point_repository
+            Infrastructure::ExtensionPointRepository.new
+          end
+
+          def include_beta_languages?
+            ShopifyCLI::Feature.enabled?(:scripts_beta_languages)
+          end
+
+          def include_beta_extension_points?
+            ShopifyCLI::Feature.enabled?(:scripts_beta_extension_points)
           end
         end
       end

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -14,10 +14,7 @@ module Script
           end
 
           def available_types
-            extension_point_repository.extension_points.select do |ep|
-              next false if ep.deprecated?
-              !ep.beta? || include_beta_extension_points?
-            end.map(&:type)
+            available_extension_points.map(&:type)
           end
 
           def deprecated_types
@@ -28,8 +25,7 @@ module Script
           end
 
           def all_languages
-            extension_point_repository
-              .extension_points
+            available_extension_points
               .map { |ep| ep.library_languages(include_betas: include_beta_languages?) }
               .flatten
               .uniq
@@ -44,6 +40,13 @@ module Script
           end
 
           private
+
+          def available_extension_points
+            extension_point_repository.extension_points.select do |ep|
+              next false if ep.deprecated?
+              !ep.beta? || include_beta_extension_points?
+            end
+          end
 
           def extension_point_repository
             Infrastructure::ExtensionPointRepository.new

--- a/lib/project_types/script/layers/application/extension_points.rb
+++ b/lib/project_types/script/layers/application/extension_points.rb
@@ -4,37 +4,36 @@ module Script
   module Layers
     module Application
       class ExtensionPoints
-        def self.get(type:)
-          Infrastructure::ExtensionPointRepository.new.get_extension_point(type)
-        end
+        class << self
+          def get(type:)
+            Infrastructure::ExtensionPointRepository.new.get_extension_point(type)
+          end
 
-        def self.types
-          Infrastructure::ExtensionPointRepository.new.extension_point_types
-        end
+          def types
+            Infrastructure::ExtensionPointRepository.new.extension_point_types
+          end
 
-        def self.available_types
-          Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
-            next false if ep.deprecated?
-            !ep.beta? || ShopifyCLI::Feature.enabled?(:scripts_beta_extension_points)
-          end.map(&:type)
-        end
+          def available_types
+            Infrastructure::ExtensionPointRepository.new.extension_points.select do |ep|
+              next false if ep.deprecated?
+              !ep.beta? || ShopifyCLI::Feature.enabled?(:scripts_beta_extension_points)
+            end.map(&:type)
+          end
 
-        def self.deprecated_types
-          Infrastructure::ExtensionPointRepository.new
-            .extension_points
-            .select(&:deprecated?)
-            .map(&:type)
-        end
+          def deprecated_types
+            Infrastructure::ExtensionPointRepository.new
+              .extension_points
+              .select(&:deprecated?)
+              .map(&:type)
+          end
 
-        def self.languages(type:)
-          get(type: type).libraries.all.map do |library|
-            next nil if library.beta? && !ShopifyCLI::Feature.enabled?(:scripts_beta_languages)
-            library.language
-          end.compact
-        end
+          def languages(type:)
+            get(type: type).library_languages(include_betas: ShopifyCLI::Feature.enabled?(:scripts_beta_languages))
+          end
 
-        def self.supported_language?(type:, language:)
-          languages(type: type).include?(language.downcase)
+          def supported_language?(type:, language:)
+            languages(type: type).include?(language.downcase)
+          end
         end
       end
     end

--- a/lib/project_types/script/layers/domain/extension_point.rb
+++ b/lib/project_types/script/layers/domain/extension_point.rb
@@ -26,6 +26,12 @@ module Script
           @type.gsub("_", "-")
         end
 
+        def library_languages(include_betas: false)
+          @libraries.all.map do |library|
+            include_betas || !library.beta? ? library.language : nil
+          end.compact
+        end
+
         class ExtensionPointLibraries
           def initialize(config)
             @config = config

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -162,6 +162,7 @@ module Script
               Options:
                 {{command:--name=NAME}} Script project name. Use any string.
                 {{command:--api=TYPE}} Script API name. Allowed values: %2$s.
+                {{command:--language=LANGUAGE}} Programming language. Allowed values: %3$s.
           HELP
 
           error: {

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -51,9 +51,13 @@ module Script
 
       def test_help
         Script::Layers::Application::ExtensionPoints.expects(:available_types).returns(%w(ep1 ep2))
-        ShopifyCLI::Context
-          .expects(:message)
-          .with("script.create.help", ShopifyCLI::TOOL_NAME, "{{cyan:ep1}}, {{cyan:ep2}}")
+        Script::Layers::Application::ExtensionPoints.expects(:all_languages).returns(%w(lang1 lang2))
+        ShopifyCLI::Context.expects(:message).with(
+          "script.create.help",
+          ShopifyCLI::TOOL_NAME,
+          "{{cyan:ep1}}, {{cyan:ep2}}",
+          "{{cyan:lang1}}, {{cyan:lang2}}"
+        )
         Script::Command::Create.help
       end
 

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -68,6 +68,29 @@ describe Script::Layers::Application::ExtensionPoints do
     end
   end
 
+  describe ".all_languages" do
+    subject { Script::Layers::Application::ExtensionPoints.all_languages }
+
+    describe "when beta language flag is enabled" do
+      before { ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once }
+
+      it "returns a list of all languages implemented by all extension points" do
+        assert_equal 2, subject.count
+        assert_equal "assemblyscript", subject[0]
+        assert_equal "rust", subject[1]
+      end
+    end
+
+    describe "when beta language flag is disabled" do
+      before { ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once }
+
+      it "returns a list of non-beta languages implemented by all extension points" do
+        assert_equal 1, subject.count
+        assert_equal "assemblyscript", subject[0]
+      end
+    end
+  end
+
   describe ".languages" do
     let(:type) { extension_point_type }
     subject { Script::Layers::Application::ExtensionPoints.languages(type: type) }

--- a/test/project_types/script/layers/application/extension_points_test.rb
+++ b/test/project_types/script/layers/application/extension_points_test.rb
@@ -71,20 +71,59 @@ describe Script::Layers::Application::ExtensionPoints do
   describe ".all_languages" do
     subject { Script::Layers::Application::ExtensionPoints.all_languages }
 
-    describe "when beta language flag is enabled" do
-      before { ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(true).at_least_once }
+    let(:scripts_beta_extension_points) { false }
+    let(:scripts_beta_languages) { false }
 
-      it "returns a list of all languages implemented by all extension points" do
+    before do
+      ShopifyCLI::Feature
+        .expects(:enabled?)
+        .with(:scripts_beta_languages)
+        .returns(scripts_beta_languages)
+        .at_least_once
+      ShopifyCLI::Feature
+        .expects(:enabled?)
+        .with(:scripts_beta_extension_points)
+        .returns(scripts_beta_extension_points)
+        .at_least_once
+    end
+
+    describe "when beta language flag is enabled" do
+      let(:scripts_beta_languages) { true }
+
+      it "returns a list of all languages implemented by non beta extension points" do
         assert_equal 2, subject.count
         assert_equal "assemblyscript", subject[0]
         assert_equal "rust", subject[1]
       end
     end
 
-    describe "when beta language flag is disabled" do
-      before { ShopifyCLI::Feature.expects(:enabled?).with(:scripts_beta_languages).returns(false).at_least_once }
+    describe "when beta extension_points is enabled" do
+      let(:scripts_beta_extension_points) { true }
 
       it "returns a list of non-beta languages implemented by all extension points" do
+        assert_equal 2, subject.count
+        assert_equal "assemblyscript", subject[0]
+        assert_equal "tinygo", subject[1]
+      end
+    end
+
+    describe "when beta language and extension points flags are enabled" do
+      let(:scripts_beta_languages) { true }
+      let(:scripts_beta_extension_points) { true }
+
+      it "returns a list of all languages implemented by all extension points" do
+        assert_equal 3, subject.count
+        assert_equal "assemblyscript", subject[0]
+        assert_equal "rust", subject[1]
+        assert_equal "tinygo", subject[2]
+      end
+    end
+
+    describe "when beta language and extension points flags are disabled" do
+      let(:scripts_beta_languages) { false }
+      let(:scripts_beta_extension_points) { false }
+
+      it "returns a list of non-beta languages implemented by non beta extension points" do
         assert_equal 1, subject.count
         assert_equal "assemblyscript", subject[0]
       end

--- a/test/project_types/script/layers/domain/extension_point_test.rb
+++ b/test/project_types/script/layers/domain/extension_point_test.rb
@@ -10,6 +10,9 @@ describe Script::Layers::Domain::ExtensionPoint do
         "assemblyscript" => {
           "package" => "@shopify/extension-point-as-fake",
         },
+        "typescript" => {
+          "package" => "@shopify/extension-point-ts-fake",
+        },
       },
     }
   end
@@ -18,6 +21,9 @@ describe Script::Layers::Domain::ExtensionPoint do
       "libraries" => {
         "assemblyscript" => {
           "package" => "@shopify/extension-point-as-fake",
+        },
+        "typescript" => {
+          "package" => "@shopify/extension-point-ts-fake",
         },
         "rust" => {
           "beta" => true,
@@ -72,24 +78,52 @@ describe Script::Layers::Domain::ExtensionPoint do
       end
     end
 
-    describe "when multiple libraries are implemented" do
-      subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_rust) }
-      it "should return all the implemented libraries" do
-        extension_point = subject
-        assert_equal 2, extension_point.libraries.all.count
-        refute_nil extension_point.libraries.for("assemblyscript")
-        refute_nil extension_point.libraries.for("rust")
+    describe ".libraries" do
+      describe "when multiple libraries are implemented" do
+        subject { Script::Layers::Domain::ExtensionPoint.new(type, config_with_rust) }
+        it "should return all the implemented libraries" do
+          extension_point = subject
+          assert_equal 3, extension_point.libraries.all.count
+          refute_nil extension_point.libraries.for("assemblyscript")
+          refute_nil extension_point.libraries.for("rust")
+        end
+      end
+
+      describe "when a libary is not implemented" do
+        subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+
+        it "should not return that library" do
+          extension_point = subject
+
+          assert_equal 2, extension_point.libraries.all.count
+          assert_nil extension_point.libraries.for("rust")
+        end
       end
     end
 
-    describe "when a libary is not implemented" do
-      subject { Script::Layers::Domain::ExtensionPoint.new(type, config) }
+    describe ".library_languages" do
+      let(:ep) { Script::Layers::Domain::ExtensionPoint.new(type, config_with_rust) }
+      subject { ep.library_languages(include_betas: include_betas) }
 
-      it "should not return that library" do
-        extension_point = subject
+      describe "include_betas argument is true" do
+        let(:include_betas) { true }
 
-        assert_equal 1, extension_point.libraries.all.count
-        assert_nil extension_point.libraries.for("rust")
+        it "returns all the languages of the libraries" do
+          assert_equal 3, subject.count
+          assert_includes subject, "assemblyscript"
+          assert_includes subject, "typescript"
+          assert_includes subject, "rust"
+        end
+      end
+
+      describe "include_betas argument is false" do
+        let(:include_betas) { false }
+
+        it "returns only non-beta languages of the libraries" do
+          assert_equal 2, subject.count
+          assert_includes subject, "assemblyscript"
+          assert_includes subject, "typescript"
+        end
       end
     end
   end

--- a/test/project_types/script/test_helpers/fake_extension_point_repository.rb
+++ b/test/project_types/script/test_helpers/fake_extension_point_repository.rb
@@ -37,7 +37,17 @@ module TestHelpers
     end
 
     def beta_config(type)
-      example_config(type).merge({ "beta" => true })
+      {
+        "domain" => "fake-domain",
+        "libraries" => {
+          "tinygo" => {
+            "repo" => "fake-repo",
+            "package" => type,
+            "version" => "1",
+          },
+        },
+        "beta" => true,
+      }
     end
 
     def deprecated_config(type)


### PR DESCRIPTION
### WHY are these changes introduced?

The `script create` command does not document the `--language` flag. We want to display the available options in the help text.

### WHAT is this pull request doing?

- creates a method in the ExtensionPoints application service that determines all valid library languages
- adds text to the create script help message to display the available languages. Text taken from @kwringe:
![image](https://user-images.githubusercontent.com/28009669/149041565-1a58b482-7def-4642-869d-708dda67c1ad.png)


### How to test your changes?

- Run `shopify help script create` and see the help text!
- The languages displayed will change based on if you have the beta languages and beta extension points feature flags enabled. You can enable and disable these flags, add `beta: true` fields to the `project_types/script/config/extension_points.yml file`, and verify that beta objects are not included. 

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above.