### PR TITLE
Replicate verify none workaround used in http_request

### DIFF
--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -229,6 +229,7 @@ module ShopifyCLI
       uri = URI.parse("#{auth_url}#{endpoint}")
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
+      https.verify_mode = OpenSSL::SSL::VERIFY_NONE if ENV["SSL_VERIFY_NONE"]
       request = Net::HTTP::Post.new(uri.path)
       request["User-Agent"] = "Shopify CLI #{::ShopifyCLI::VERSION}"
       request.body = URI.encode_www_form(params)


### PR DESCRIPTION
### WHY are these changes introduced?

An unknown SSL bug causes Shopify developers to be unable to connect to instances of identity hosted in the spin environment.

It's a bug that appears to be environment specific, and we don't have a reliable reproduction at the moment.

### WHAT is this pull request doing?

When we first encountered we wrote a workaround into https://github.com/Shopify/shopify-cli/blob/10d7ebd75fc8c83bcb3c0d9a9b79165bdc3d04d5/lib/shopify-cli/http_request.rb

It seems that this file bypasses that underlying http library. I've replicated the workaround into this file, which is to skip the ssl verification step.

Ideally this would be refactored to use the shared http library, but this change will help devs get unblocked in the short term without having to inject code into their dev copy of the CLI.

### How to test your changes?

Try to login on a spin instance

### Post-release steps

This is a dev only change. It isn't relevant for a release.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.