### PR TITLE
[scripts] move javy binary location to cli cache directory

### DIFF
--- a/ext/javy/javy.rb
+++ b/ext/javy/javy.rb
@@ -5,7 +5,7 @@ require "digest/sha2"
 
 module Javy
   ROOT = __dir__
-  BIN_FOLDER = File.join(ROOT, "bin")
+  BIN_FOLDER = File.join(ShopifyCLI.cache_dir, "javy", "bin")
   HASH_FOLDER = File.join(ROOT, "hashes")
   VERSION = File.read(File.join(ROOT, "version")).strip
   TARGET = File.join(BIN_FOLDER, "javy-#{VERSION}")


### PR DESCRIPTION
Closes https://github.com/Shopify/script-service/issues/4157

### WHY are these changes introduced?

The previous location javy was stored was in the `shopify-cli/ext/javy/bin` directory. This created a problem when using the gem installed version of the CLI as the executable is within a directory that a default user does not have write permissions for.

### WHAT is this pull request doing?

Change the javy installation directory to the CLI's cache directory (`~/.cache/shopify/` by default on unix), so the new binary is located at `~/.cache/shopify/javy/bin/javy-v0.1.0`. I chose to use the cache directory as it is already used to store binaries like ngrok used for `shopify app serve` or heroku CLI. 

### How to test your changes?

- Check that Javy is installed by default
    - Run `shopify script javy --in build/index.js --out build/index.wasm` inside your script project. The command should succeed and a new javy executable should exist in `~/.cache/shopify/javy/bin/javy-v0.1.0`
- Check that new versions of Javy are installed when the version changes
    - Rename your javy executable at `~/.cache/shopify/javy/bin/javy-v0.1.0` to `~/.cache/shopify/javy/bin/javy-v0.0.0`, to simulate that an older version is installed.
    - Run `shopify script javy --in build/index.js --out build/index.wasm`. The command should succeed.
Ensure that `~/.cache/shopify/javy/bin/javy-v0.1.0` exists and javy-v0.0.0 was deleted.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above.