### PR TITLE
Mark extension debug messages as such

### DIFF
--- a/lib/project_types/extension/models/development_server.rb
+++ b/lib/project_types/extension/models/development_server.rb
@@ -40,7 +40,7 @@ module Extension
 
       def serve(context, server_config)
         CLI::Kit::System.popen3(executable, "serve", "-") do |input, out, err, status|
-          context.puts("Sending configuration data …")
+          context.debug("Sending configuration data to extension development server …")
           input << server_config.to_yaml
           input.close
 
@@ -57,17 +57,15 @@ module Extension
       private
 
       def forward_output_to_user(out, err, ctx)
-        ctx.puts("Starting monitoring threads …")
+        ctx.debug("Starting message processing threads to relay output produced by the extension development server …")
 
         Thread.new do
-          ctx.puts("Ready to process standard output")
           while (line = out.gets)
             ctx.puts(line)
           end
         end
 
         Thread.new do
-          ctx.puts("Ready to process standard error")
           while (error = err.gets)
             ctx.puts(error)
           end


### PR DESCRIPTION
### WHY are these changes introduced?

To avoid printing superflous debug messages when running extension serve


### WHAT is this pull request doing?

Use `context.debug` instead of `context.puts` for debug messages and remove some unnecessary messages.

### How to test your changes?

1. Make sure you have the extension server beta unabled by running `shopify-local config feature extension_server_beta --enable`
2. Create an extension with `shopify extension create`
3. Run `DEBUG shopify extension serve` and verify that the output includes
    ```
    DEBUG Sending configuration data to extension development server …
    DEBUG Starting message relaying threads to capture output produced by the extension development server …
    ```
    Secondly, run `shopify extension serve` and verify that above output is omitted.

### Post-release steps

No further action is required. This can simply be included in the next release. The code path is currently guarded by a feature flag anyway.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.
