### PR TITLE
Consolidate spin vars and allow inference

### DIFF
--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -36,7 +36,7 @@ module ShopifyCLI
       # the partners dashboard and identity.
       LOCAL_PARTNERS = "SHOPIFY_APP_CLI_LOCAL_PARTNERS"
 
-      # When true the CLI points to spin instances of services 
+      # When true the CLI points to spin instances of services
       SPIN = "SPIN"
       INFER_SPIN = "INFER_SPIN"
       SPIN_WORKSPACE = "SPIN_WORKSPACE"

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -36,8 +36,8 @@ module ShopifyCLI
       # the partners dashboard and identity.
       LOCAL_PARTNERS = "SHOPIFY_APP_CLI_LOCAL_PARTNERS"
 
-      # When true the CLI points to a spin instance of spin
-      SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"
+      # When true the CLI points to spin instances of services 
+      SPIN = "SPIN"
       SPIN_WORKSPACE = "SPIN_WORKSPACE"
       SPIN_NAMESPACE = "SPIN_NAMESPACE"
       SPIN_HOST = "SPIN_HOST"

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -38,9 +38,13 @@ module ShopifyCLI
 
       # When true the CLI points to spin instances of services 
       SPIN = "SPIN"
+      INFER_SPIN = "INFER_SPIN"
       SPIN_WORKSPACE = "SPIN_WORKSPACE"
       SPIN_NAMESPACE = "SPIN_NAMESPACE"
       SPIN_HOST = "SPIN_HOST"
+
+      # Deprecated, equivalent to using SPIN=1
+      SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"
 
       # Environments
       TEST = "SHOPIFY_CLI_TEST"

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -89,10 +89,14 @@ module ShopifyCLI
     end
 
     def self.spin_url(env_variables: ENV)
-      spin_workspace = spin_workspace(env_variables: env_variables)
-      spin_namespace = spin_namespace(env_variables: env_variables)
-      spin_host = spin_host(env_variables: env_variables)
-      "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
+      if infer_spin?(env_variables: env_variables)
+        %x(spin info fqdn 2> /dev/null).strip
+      else
+        spin_workspace = spin_workspace(env_variables: env_variables)
+        spin_namespace = spin_namespace(env_variables: env_variables)
+        spin_host = spin_host(env_variables: env_variables)
+        "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
+      end
     end
 
     def self.send_monorail_events?(env_variables: ENV)
@@ -113,31 +117,11 @@ module ShopifyCLI
     def self.spin_workspace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
       return env_value unless env_value.nil?
-
-      if infer_spin?(env_variables: env_variables)
-        infer_spin_workspace
-      else
-        raise "No value set for #{Constants::EnvironmentVariables::SPIN_WORKSPACE}"
-      end
-    end
-
-    def self.infer_spin_workspace
-      %x(cut -d \".\" -f2 <<< \$(spin info fqdn 2> /dev/null)).strip
     end
 
     def self.spin_namespace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
       return env_value unless env_value.nil?
-
-      if infer_spin?(env_variables: env_variables)
-        infer_spin_namespace
-      else
-        raise "No value set for #{Constants::EnvironmentVariables::SPIN_NAMESPACE}"
-      end
-    end
-
-    def self.infer_spin_namespace
-      %x(cut -d \".\" -f3 <<< \$(spin info fqdn 2> /dev/null)).strip
     end
 
     def self.spin_host(env_variables: ENV)

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -61,17 +61,10 @@ module ShopifyCLI
       )
     end
 
-    def self.use_spin_partners_instance?(env_variables: ENV)
-      env_variable_truthy?(
-        Constants::EnvironmentVariables::SPIN_PARTNERS,
-        env_variables: env_variables
-      )
-    end
-
     def self.partners_domain(env_variables: ENV)
       if use_local_partners_instance?(env_variables: env_variables)
         "partners.myshopify.io"
-      elsif use_spin_partners_instance?(env_variables: env_variables)
+      elsif use_spin?(env_variables: env_variables)
         "partners.#{spin_url(env_variables: env_variables)}"
       else
         "partners.shopify.com"
@@ -79,8 +72,10 @@ module ShopifyCLI
     end
 
     def self.use_spin?(env_variables: ENV)
-      !env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE].nil? &&
-        !env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE].nil?
+      env_variable_truthy?(
+        Constants::EnvironmentVariables::SPIN,
+        env_variables: env_variables
+      )
     end
 
     def self.spin_url(env_variables: ENV)
@@ -89,6 +84,7 @@ module ShopifyCLI
       spin_host = spin_host(env_variables: env_variables)
       "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
     end
+
 
     def self.send_monorail_events?(env_variables: ENV)
       env_variable_truthy?(
@@ -106,11 +102,19 @@ module ShopifyCLI
     end
 
     def self.spin_workspace(env_variables: ENV)
-      env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
+      env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE] || infer_spin_workspace
+    end
+
+    def self.infer_spin_workspace
+      `cut -d \".\" -f2 <<< \$(spin info fqdn 2> /dev/null)`.strip
     end
 
     def self.spin_namespace(env_variables: ENV)
-      env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
+      env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE] || infer_spin_namespace
+    end
+
+    def self.infer_spin_namespace
+      `cut -d \".\" -f3 <<< \$(spin info fqdn 2> /dev/null)`.strip
     end
 
     def self.spin_host(env_variables: ENV)

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -75,6 +75,16 @@ module ShopifyCLI
       env_variable_truthy?(
         Constants::EnvironmentVariables::SPIN,
         env_variables: env_variables
+      ) || env_variable_truthy?(
+        Constants::EnvironmentVariables::SPIN_PARTNERS,
+        env_variables: env_variables
+      )
+    end
+
+    def self.infer_spin?(env_variables: ENV)
+      env_variable_truthy?(
+        Constants::EnvironmentVariables::INFER_SPIN,
+        env_variables: env_variables
       )
     end
 
@@ -84,7 +94,6 @@ module ShopifyCLI
       spin_host = spin_host(env_variables: env_variables)
       "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
     end
-
 
     def self.send_monorail_events?(env_variables: ENV)
       env_variable_truthy?(
@@ -102,7 +111,14 @@ module ShopifyCLI
     end
 
     def self.spin_workspace(env_variables: ENV)
-      env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE] || infer_spin_workspace
+      env_value = env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
+      return env_value unless env_value.nil?
+      
+      if infer_spin?(env_variables: env_variables)
+        infer_spin_workspace
+      else
+        raise "No value set for #{Constants::EnvironmentVariables::SPIN_WORKSPACE}"
+      end
     end
 
     def self.infer_spin_workspace
@@ -110,7 +126,14 @@ module ShopifyCLI
     end
 
     def self.spin_namespace(env_variables: ENV)
-      env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE] || infer_spin_namespace
+      env_value = env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
+      return env_value unless env_value.nil?
+      
+      if infer_spin?(env_variables: env_variables)
+        infer_spin_namespace
+      else
+        raise "No value set for #{Constants::EnvironmentVariables::SPIN_NAMESPACE}"
+      end
     end
 
     def self.infer_spin_namespace

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -113,7 +113,7 @@ module ShopifyCLI
     def self.spin_workspace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
       return env_value unless env_value.nil?
-      
+
       if infer_spin?(env_variables: env_variables)
         infer_spin_workspace
       else
@@ -122,13 +122,13 @@ module ShopifyCLI
     end
 
     def self.infer_spin_workspace
-      `cut -d \".\" -f2 <<< \$(spin info fqdn 2> /dev/null)`.strip
+      %x(cut -d \".\" -f2 <<< \$(spin info fqdn 2> /dev/null)).strip
     end
 
     def self.spin_namespace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
       return env_value unless env_value.nil?
-      
+
       if infer_spin?(env_variables: env_variables)
         infer_spin_namespace
       else
@@ -137,7 +137,7 @@ module ShopifyCLI
     end
 
     def self.infer_spin_namespace
-      `cut -d \".\" -f3 <<< \$(spin info fqdn 2> /dev/null)`.strip
+      %x(cut -d \".\" -f3 <<< \$(spin info fqdn 2> /dev/null)).strip
     end
 
     def self.spin_host(env_variables: ENV)

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -117,11 +117,19 @@ module ShopifyCLI
     def self.spin_workspace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
       return env_value unless env_value.nil?
+
+      if env_value.nil?
+        raise "No value set for #{Constants::EnvironmentVariables::SPIN_WORKSPACE}"
+      end
     end
 
     def self.spin_namespace(env_variables: ENV)
       env_value = env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
       return env_value unless env_value.nil?
+
+      if env_value.nil?
+        raise "No value set for #{Constants::EnvironmentVariables::SPIN_NAMESPACE}"
+      end
     end
 
     def self.spin_host(env_variables: ENV)

--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -255,7 +255,7 @@ module ShopifyCLI
     def auth_url
       if Environment.use_local_partners_instance?
         "https://identity.myshopify.io/oauth"
-      elsif Environment.use_spin_partners_instance?
+      elsif Environment.use_spin?
         "https://identity.#{Environment.spin_url}/oauth"
       else
         "https://accounts.shopify.com/oauth"
@@ -263,7 +263,7 @@ module ShopifyCLI
     end
 
     def client_id_for_application(application_name)
-      client_ids = if Environment.use_local_partners_instance? || Environment.use_spin_partners_instance?
+      client_ids = if Environment.use_local_partners_instance? || Environment.use?
         DEV_APPLICATION_CLIENT_IDS
       else
         APPLICATION_CLIENT_IDS
@@ -279,7 +279,7 @@ module ShopifyCLI
     end
 
     def client_id
-      if Environment.use_local_partners_instance? || Environment.use_spin_partners_instance?
+      if Environment.use_local_partners_instance? || Environment.use_spin?
         Constants::Identity::CLIENT_ID_DEV
       else
         # In the future we might want to use Identity's dynamic

--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -263,7 +263,7 @@ module ShopifyCLI
     end
 
     def client_id_for_application(application_name)
-      client_ids = if Environment.use_local_partners_instance? || Environment.use?
+      client_ids = if Environment.use_local_partners_instance? || Environment.use_spin?
         DEV_APPLICATION_CLIENT_IDS
       else
         APPLICATION_CLIENT_IDS

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -209,8 +209,6 @@ module ShopifyCLI
         Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => nil,
       }
 
-      Environment.expects(:infer_spin_namespace)
-
       Environment.spin_url(env_variables: env_variables)
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Setting up the CLI to use spin is currently a manual process in which you need to find and enter in your current spin namespace and workspace. We should be able to point at the active spin workspace with a single flag.

### WHAT is this pull request doing?

- Consolidate the two sets of spin variables into a single `SPIN` variable. If you're using Spin, everything you're calling should be in Spin.
- Add a `INFER_SPIN` env variable which tells the CLI to try pulling the workspace/namespace from spin by parsing the output of the `spin info fqdn` command.

### How to test your changes?

Unset SPIN_WORKSPACE and SPIN_NAMESPACE

Run commands with `SPIN=1 INFER_SPIN=1` and check that it uses your active spin workspace.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.