### PR TITLE
revert "Remove beta flag from payment and shipping APIs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#1900](https://github.com/Shopify/shopify-cli/pull/1900): Add `-d'/`--development` flag to Shopify theme pull command
-* [#1896](https://github.com/Shopify/shopify-cli/pull/1896): Release Typescript options for payment_methods and shipping_methods scripts
 
 ### Fixed
 * [#1909](https://github.com/Shopify/shopify-cli/pull/1909): Fix `theme serve` on Safari

--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -5,6 +5,7 @@ payment_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
       package: "@shopify/scripts-checkout-apis"
     typescript:
+      beta: true
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_methods:
@@ -14,6 +15,7 @@ shipping_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
       package: "@shopify/scripts-checkout-apis"
     typescript:
+      beta: true
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
 merchandise_discount_types:


### PR DESCRIPTION
### WHY are these changes introduced?

Reverts https://github.com/Shopify/shopify-cli/pull/1896

As per Mitch's update, we will not be releasing TS support for payment/shipping APIs yet so I am adding the beta flag back in. A new release hasn't been made yet, so we can just remove it from the unreleased changelog. 

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above.