### PR TITLE
[Scripts] Limit module file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+* [#1928](https://github.com/Shopify/shopify-cli/pull/1928): Ensure script Wasm file sizes don't exceed the limit
 
 ### Fixed
 * [#1937](https://github.com/Shopify/shopify-cli/pull/1937): Fix `theme pull` to no longer add empty lines on Windows

--- a/lib/project_types/script/graphql/module_upload_url_generate.graphql
+++ b/lib/project_types/script/graphql/module_upload_url_generate.graphql
@@ -1,7 +1,10 @@
 mutation moduleUploadUrlGenerate {
   moduleUploadUrlGenerate {
-    url
-    headers
+    details {
+      url
+      headers
+      humanizedMaxSize
+    }
     userErrors {
       field
       message

--- a/lib/project_types/script/graphql/module_upload_url_generate.graphql
+++ b/lib/project_types/script/graphql/module_upload_url_generate.graphql
@@ -1,6 +1,7 @@
 mutation moduleUploadUrlGenerate {
   moduleUploadUrlGenerate {
     url
+    headers
     userErrors {
       field
       message

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -159,6 +159,7 @@ module Script
         class ScriptUploadError < ScriptProjectError; end
         class ProjectConfigNotFoundError < ScriptProjectError; end
         class InvalidProjectConfigError < ScriptProjectError; end
+        class ScriptTooLargeError < ScriptProjectError; end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -161,21 +161,11 @@ module Script
         class InvalidProjectConfigError < ScriptProjectError; end
 
         class ScriptTooLargeError < ScriptProjectError
-          attr_reader :file_size_limit
+          attr_reader :max_size
 
-          def initialize(file_size_limit)
+          def initialize(max_size)
             super()
-            @file_size_limit = file_size_limit
-          end
-
-          def humanized_file_size_limit
-            if file_size_limit < 1_000
-              { unit: "B", file_size_limit: file_size_limit }
-            elsif file_size_limit < 1_000_000
-              { unit: "KB", file_size_limit: file_size_limit / 1_000 }
-            else
-              { unit: "MB", file_size_limit: file_size_limit / 1_000_000 }
-            end
+            @max_size = max_size
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -159,7 +159,25 @@ module Script
         class ScriptUploadError < ScriptProjectError; end
         class ProjectConfigNotFoundError < ScriptProjectError; end
         class InvalidProjectConfigError < ScriptProjectError; end
-        class ScriptTooLargeError < ScriptProjectError; end
+
+        class ScriptTooLargeError < ScriptProjectError
+          attr_reader :file_size_limit
+
+          def initialize(file_size_limit)
+            super()
+            @file_size_limit = file_size_limit
+          end
+
+          def humanized_file_size_limit
+            if file_size_limit < 1_000
+              { unit: "B", file_size_limit: file_size_limit }
+            elsif file_size_limit < 1_000_000
+              { unit: "KB", file_size_limit: file_size_limit / 1_000 }
+            else
+              { unit: "MB", file_size_limit: file_size_limit / 1_000_000 }
+            end
+          end
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -98,7 +98,9 @@ module Script
           user_errors = response["data"]["moduleUploadUrlGenerate"]["userErrors"]
 
           raise Errors::GraphqlError, user_errors if user_errors.any?
-          response["data"]["moduleUploadUrlGenerate"]["url"]
+
+          data = response["data"]["moduleUploadUrlGenerate"]
+          { url: data["url"], headers: data["headers"] }
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -99,8 +99,8 @@ module Script
 
           raise Errors::GraphqlError, user_errors if user_errors.any?
 
-          data = response["data"]["moduleUploadUrlGenerate"]
-          { url: data["url"], headers: data["headers"] }
+          data = response["data"]["moduleUploadUrlGenerate"]["details"]
+          { url: data["url"], headers: data["headers"], max_size: data["humanizedMaxSize"] }
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -91,7 +91,7 @@ module Script
           response["data"]["appScripts"]
         end
 
-        def generate_module_upload_url
+        def generate_module_upload_details
           query_name = "module_upload_url_generate"
           variables = {}
           response = make_request(query_name: query_name, variables: variables)

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -2,6 +2,8 @@ module Script
   module Layers
     module Infrastructure
       class ScriptUploader
+        CONTENT_LENGTH_RANGE_HEADER = "x-goog-content-length-range"
+
         def initialize(script_service)
           @script_service = script_service
         end
@@ -16,14 +18,15 @@ module Script
           request = Net::HTTP::Put.new(url)
           request["Content-Type"] = "application/wasm"
 
-          upload_details[:headers].each do |header, value|
+          headers = upload_details[:headers]
+          headers.each do |header, value|
             request[header] = value
           end
 
           request.body = script_content
 
           response = https.request(request)
-          raise Errors::ScriptTooLargeError if script_too_large?(response)
+          raise Errors::ScriptTooLargeError, file_size_limit(headers) if script_too_large?(response)
           raise Errors::ScriptUploadError unless response.code == "200"
 
           upload_details[:url]
@@ -33,6 +36,12 @@ module Script
 
         def script_too_large?(response)
           response.code == "400" && response.body.include?("EntityTooLarge")
+        end
+
+        def file_size_limit(headers)
+          content_length_range_value = headers[CONTENT_LENGTH_RANGE_HEADER]
+          return 0 unless content_length_range_value
+          content_length_range_value.split(",")[1].to_i
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -23,9 +23,16 @@ module Script
           request.body = script_content
 
           response = https.request(request)
+          raise Errors::ScriptTooLargeError if script_too_large?(response)
           raise Errors::ScriptUploadError unless response.code == "200"
 
           upload_details[:url]
+        end
+
+        private
+
+        def script_too_large?(response)
+          response.code == "400" && response.body.include?("EntityTooLarge")
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -7,19 +7,25 @@ module Script
         end
 
         def upload(script_content)
-          @script_service.generate_module_upload_url.tap do |url|
-            url = URI(url)
+          upload_details = @script_service.generate_module_upload_url
+          url = URI(upload_details[:url])
 
-            https = Net::HTTP.new(url.host, url.port)
-            https.use_ssl = true
+          https = Net::HTTP.new(url.host, url.port)
+          https.use_ssl = true
 
-            request = Net::HTTP::Put.new(url)
-            request["Content-Type"] = "application/wasm"
-            request.body = script_content
+          request = Net::HTTP::Put.new(url)
+          request["Content-Type"] = "application/wasm"
 
-            response = https.request(request)
-            raise Errors::ScriptUploadError unless response.code == "200"
+          upload_details[:headers].each do |header, value|
+            request[header] = value
           end
+
+          request.body = script_content
+
+          response = https.request(request)
+          raise Errors::ScriptUploadError unless response.code == "200"
+
+          upload_details[:url]
         end
       end
     end

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -7,7 +7,7 @@ module Script
         end
 
         def upload(script_content)
-          upload_details = @script_service.generate_module_upload_url
+          upload_details = @script_service.generate_module_upload_details
           url = URI(upload_details[:url])
 
           https = Net::HTTP.new(url.host, url.port)

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -140,6 +140,9 @@ module Script
           script_upload_cause: "Fail to upload script.",
           script_upload_help: "Try again.",
 
+          script_too_large_cause: "Script Wasm is too large.",
+          script_too_large_help: "Reduce the size of the Wasm file.",
+
           api_library_not_found_cause: "Script can't be created because API library %{library_name} is missing from the dependencies",
           api_library_not_found_help: "This error can occur because the API library was removed from your system or there is a problem with dependencies in the repository.",
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -141,7 +141,7 @@ module Script
           script_upload_help: "Try again.",
 
           script_too_large_cause: "The size of your Wasm binary file is too large.",
-          script_too_large_help: "Make sure that it is less than %{limit} %{unit}.",
+          script_too_large_help: "Make sure that it is less than %{max_size}.",
 
           api_library_not_found_cause: "Script can't be created because API library %{library_name} is missing from the dependencies",
           api_library_not_found_help: "This error can occur because the API library was removed from your system or there is a problem with dependencies in the repository.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -140,8 +140,8 @@ module Script
           script_upload_cause: "Fail to upload script.",
           script_upload_help: "Try again.",
 
-          script_too_large_cause: "Script Wasm is too large.",
-          script_too_large_help: "Reduce the size of the Wasm file.",
+          script_too_large_cause: "The size of your Wasm binary file is too large.",
+          script_too_large_help: "Make sure that it is less than %{limit} %{unit}.",
 
           api_library_not_found_cause: "Script can't be created because API library %{library_name} is missing from the dependencies",
           api_library_not_found_help: "This error can occur because the API library was removed from your system or there is a problem with dependencies in the repository.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -141,7 +141,7 @@ module Script
           script_upload_help: "Try again.",
 
           script_too_large_cause: "The size of your Wasm binary file is too large.",
-          script_too_large_help: "Make sure that it is less than %{max_size}.",
+          script_too_large_help: "It must be less than %{max_size}.",
 
           api_library_not_found_cause: "Script can't be created because API library %{library_name} is missing from the dependencies",
           api_library_not_found_help: "This error can occur because the API library was removed from your system or there is a problem with dependencies in the repository.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -251,6 +251,11 @@ module Script
             cause_of_error: ShopifyCLI::Context.message("script.error.script_upload_cause"),
             help_suggestion: ShopifyCLI::Context.message("script.error.script_upload_help"),
           }
+        when Layers::Infrastructure::Errors::ScriptTooLargeError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.script_too_large_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.script_too_large_help"),
+          }
         when Layers::Infrastructure::Errors::APILibraryNotFoundError
           {
             cause_of_error: ShopifyCLI::Context

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -252,14 +252,9 @@ module Script
             help_suggestion: ShopifyCLI::Context.message("script.error.script_upload_help"),
           }
         when Layers::Infrastructure::Errors::ScriptTooLargeError
-          humanized_file_size_limit = e.humanized_file_size_limit
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.script_too_large_cause"),
-            help_suggestion: ShopifyCLI::Context.message(
-              "script.error.script_too_large_help",
-              limit: humanized_file_size_limit[:file_size_limit],
-              unit: humanized_file_size_limit[:unit],
-            ),
+            help_suggestion: ShopifyCLI::Context.message("script.error.script_too_large_help", max_size: e.max_size),
           }
         when Layers::Infrastructure::Errors::APILibraryNotFoundError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -252,9 +252,14 @@ module Script
             help_suggestion: ShopifyCLI::Context.message("script.error.script_upload_help"),
           }
         when Layers::Infrastructure::Errors::ScriptTooLargeError
+          humanized_file_size_limit = e.humanized_file_size_limit
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.script_too_large_cause"),
-            help_suggestion: ShopifyCLI::Context.message("script.error.script_too_large_help"),
+            help_suggestion: ShopifyCLI::Context.message(
+              "script.error.script_too_large_help",
+              limit: humanized_file_size_limit[:file_size_limit],
+              unit: humanized_file_size_limit[:unit],
+            ),
           }
         when Layers::Infrastructure::Errors::APILibraryNotFoundError
           {

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -335,10 +335,12 @@ describe Script::Layers::Infrastructure::ScriptService do
   describe ".generate_module_upload_url" do
     let(:user_errors) { [] }
     let(:url) { nil }
+    let(:headers) { {} }
     let(:response) do
       {
         "data" => {
           "moduleUploadUrlGenerate" => {
+            "headers" => headers,
             "url" => url,
             "userErrors" => user_errors,
           },
@@ -354,9 +356,14 @@ describe Script::Layers::Infrastructure::ScriptService do
 
     describe "when a url can be generated" do
       let(:url) { "http://fake.com" }
+      let(:headers) { { "header" => "value" } }
 
       it "returns a url" do
-        assert_equal url, subject
+        assert_equal url, subject[:url]
+      end
+
+      it "returns headers" do
+        assert_equal headers, subject[:headers]
       end
     end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -336,13 +336,17 @@ describe Script::Layers::Infrastructure::ScriptService do
     let(:user_errors) { [] }
     let(:url) { nil }
     let(:headers) { {} }
+    let(:humanized_max_size) { "" }
     let(:response) do
       {
         "data" => {
           "moduleUploadUrlGenerate" => {
-            "headers" => headers,
-            "url" => url,
             "userErrors" => user_errors,
+            "details" => {
+              "headers" => headers,
+              "url" => url,
+              "humanizedMaxSize" => humanized_max_size,
+            },
           },
         },
       }
@@ -357,6 +361,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     describe "when a url can be generated" do
       let(:url) { "http://fake.com" }
       let(:headers) { { "header" => "value" } }
+      let(:humanized_max_size) { "123 Bytes" }
 
       it "returns a url" do
         assert_equal url, subject[:url]
@@ -364,6 +369,10 @@ describe Script::Layers::Infrastructure::ScriptService do
 
       it "returns headers" do
         assert_equal headers, subject[:headers]
+      end
+
+      it "returns max size" do
+        assert_equal humanized_max_size, subject[:max_size]
       end
     end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -332,7 +332,7 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
   end
 
-  describe ".generate_module_upload_url" do
+  describe ".generate_module_upload_details" do
     let(:user_errors) { [] }
     let(:url) { nil }
     let(:headers) { {} }
@@ -352,7 +352,7 @@ describe Script::Layers::Infrastructure::ScriptService do
       api_client.stubs(:query).returns(response)
     end
 
-    subject { script_service.generate_module_upload_url }
+    subject { script_service.generate_module_upload_details }
 
     describe "when a url can be generated" do
       let(:url) { "http://fake.com" }

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -7,11 +7,16 @@ describe Script::Layers::Infrastructure::ScriptUploader do
     let(:script_content) { "(module)" }
     let(:url) { "https://some-bucket" }
     let(:headers) { { "header" => "value" } }
+    let(:max_size) { "1234 Bytes" }
 
     subject { instance.upload(script_content) }
 
     before do
-      script_service.expects(:generate_module_upload_details).returns({ url: url, headers: headers })
+      script_service.expects(:generate_module_upload_details).returns({
+        url: url,
+        headers: headers,
+        max_size: max_size,
+      })
     end
 
     describe "when fail to upload module" do

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -11,7 +11,7 @@ describe Script::Layers::Infrastructure::ScriptUploader do
     subject { instance.upload(script_content) }
 
     before do
-      script_service.expects(:generate_module_upload_url).returns({ url: url, headers: headers })
+      script_service.expects(:generate_module_upload_details).returns({ url: url, headers: headers })
     end
 
     describe "when fail to upload module" do

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -27,6 +27,24 @@ describe Script::Layers::Infrastructure::ScriptUploader do
       end
     end
 
+    describe "when Wasm is too large" do
+      before do
+        stub_request(:put, url).with(
+          headers: { "Content-Type" => "application/wasm" },
+          body: script_content
+        ).to_return(
+          status: 400,
+          body: "<?xml version='1.0' encoding='UTF-8'?><Error><Code>EntityTooLarge</Code><Message>Your proposed " \
+            "upload is larger than the maximum object size specified in your Policy Document.</Message><Details>" \
+            "Content-length exceeds upper bound on range</Details></Error>",
+        )
+      end
+
+      it "should raise an ScriptTooLargeError" do
+        assert_raises(Script::Layers::Infrastructure::Errors::ScriptTooLargeError) { subject }
+      end
+    end
+
     describe "when succeed to upload module" do
       before do
         stub_request(:put, url).with(

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -6,11 +6,12 @@ describe Script::Layers::Infrastructure::ScriptUploader do
     let(:instance) { Script::Layers::Infrastructure::ScriptUploader.new(script_service) }
     let(:script_content) { "(module)" }
     let(:url) { "https://some-bucket" }
+    let(:headers) { { "header" => "value" } }
 
     subject { instance.upload(script_content) }
 
     before do
-      script_service.expects(:generate_module_upload_url).returns(url)
+      script_service.expects(:generate_module_upload_url).returns({ url: url, headers: headers })
     end
 
     describe "when fail to upload module" do


### PR DESCRIPTION
### WHY are these changes introduced?

In order to support a file size limit in GCS, the client must include the `x-goog-content-length-range` header in the upload request. Otherwise, GCS will not allow the file upload.

Related issue: https://github.com/Shopify/script-service/issues/4128
Backend PR: https://github.com/Shopify/script-service/pull/4158

Closes https://github.com/Shopify/script-service/issues/4129

### How to test your changes?

1. Use my backend branch
2. Push a script => it should work
3. Lower the file size limit in the backend (e.g. 100 bytes)
4. Push a script => it should fail

![image](https://user-images.githubusercontent.com/1742857/149592571-9c4b0317-1746-42b2-aa20-5b9dd907dcf5.png)

### Post-release steps

- Notify @andrewhassan so the corresponding backend change can be shipped around the same time.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ x] I've included any post-release steps in the section above.