### PR TITLE
Rename registration-id to extension-id

### DIFF
--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -9,7 +9,7 @@ module Extension
       options do |parser, flags|
         parser.on("--api-key=API_KEY") { |api_key| flags[:api_key] = api_key.gsub('"', "") }
         parser.on("--api-secret=API_SECRET") { |api_secret| flags[:api_secret] = api_secret.gsub('"', "") }
-        parser.on("--registration-id=REGISTRATION_ID") do |registration_id|
+        parser.on("--extension-id=EXTENSION_ID") do |registration_id|
           flags[:registration_id] = registration_id.gsub('"', "")
         end
       end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -91,7 +91,7 @@ module Extension
             Usage: {{command:%s extension push}}
             Options:
               {{command:--api-key=API_KEY}} Connect your extension and app by inserting your app's API key (which you can get from your app setup page on shopify.dev).
-              {{command:--registration-id=REGISTRATION_ID}} The id of the extension's registration.
+              {{command:--extension-id=EXTENSION_ID}} The id of the extension's registration.
         HELP
         frame_title: "Pushing your extension to Shopify",
         waiting_text: "Pushing code to Shopify…",


### PR DESCRIPTION
### WHY are these changes introduced?
While testing the `push` command I realized the `--registration-id` argument that we use to set the ID of the extension is inconsistent and misleading with the name that we use in the `.env` file, `EXTENSION_ID`. In that file we also have `EXTENSION_UUID`.

### WHAT is this pull request doing?
I'm adjusting the command to take `--extension-id` instead of `--registration-id`.

### How to test your changes?
1. Check out the branch
2. Create an extension or use one from shopify-cli-example app and push the extension using CLI arguments.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.