### PR TITLE
Support wasm push packages

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -57,6 +57,7 @@ module Script
       autoload :CommandRunner, Project.project_filepath("layers/infrastructure/command_runner")
       autoload :PushPackageRepository, Project.project_filepath("layers/infrastructure/push_package_repository")
       autoload :ExtensionPointRepository, Project.project_filepath("layers/infrastructure/extension_point_repository")
+      autoload :MetadataRepository, Project.project_filepath("layers/infrastructure/metadata_repository")
       autoload :ScriptProjectRepository, Project.project_filepath("layers/infrastructure/script_project_repository")
       autoload :ScriptService, Project.project_filepath("layers/infrastructure/script_service")
       autoload :ScriptUploader, Project.project_filepath("layers/infrastructure/script_uploader")

--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -32,6 +32,9 @@ merchandise_discount_types:
       beta: true
       package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
+    wasm:
+      beta: true
+      repo: "https://github.com/Shopify/scripts-apis-examples"
 delivery_discount_types:
   beta: true
   domain: 'discounts'
@@ -39,4 +42,7 @@ delivery_discount_types:
     typescript:
       beta: true
       package: "@shopify/scripts-discounts-apis"
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+    wasm:
+      beta: true
       repo: "https://github.com/Shopify/scripts-apis-examples"

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -9,12 +9,13 @@ module Script
             CLI::UI::Frame.open(ctx.message("script.application.building")) do
               begin
                 UI::StrictSpinner.spin(ctx.message("script.application.building_script")) do |spinner|
+                  script_content = task_runner.build
                   metadata_file_location = task_runner.metadata_file_location
                   metadata = Infrastructure::MetadataRepository.new(ctx: ctx).get_metadata(metadata_file_location)
 
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
                     script_project: script_project,
-                    script_content: task_runner.build,
+                    script_content: script_content,
                     metadata: metadata,
                     library: library,
                   )

--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -9,10 +9,13 @@ module Script
             CLI::UI::Frame.open(ctx.message("script.application.building")) do
               begin
                 UI::StrictSpinner.spin(ctx.message("script.application.building_script")) do |spinner|
+                  metadata_file_location = task_runner.metadata_file_location
+                  metadata = Infrastructure::MetadataRepository.new(ctx: ctx).get_metadata(metadata_file_location)
+
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
                     script_project: script_project,
                     script_content: task_runner.build,
-                    metadata: task_runner.metadata,
+                    metadata: metadata,
                     library: library,
                   )
                   spinner.update_title(ctx.message("script.application.built"))

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -30,7 +30,6 @@ module Script
             ProjectDependencies.install(ctx: ctx, task_runner: task_runner)
             BuildScript.call(ctx: ctx, task_runner: task_runner, script_project: script_project, library: library_data)
 
-            compiled_type = task_runner.compiled_type
             metadata_file_location = task_runner.metadata_file_location
             metadata = Infrastructure::MetadataRepository.new(ctx: ctx).get_metadata(metadata_file_location)
 

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -33,31 +33,33 @@ module Script
             metadata_file_location = task_runner.metadata_file_location
             metadata = Infrastructure::MetadataRepository.new(ctx: ctx).get_metadata(metadata_file_location)
 
-            UI::PrintingSpinner.spin(ctx, ctx.message("script.application.pushing")) do |p_ctx, spinner|
-              package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
-                script_project: script_project,
-                metadata: metadata,
-                library: library_data,
-              )
-              script_service = Infrastructure::ServiceLocator.script_service(
-                ctx: p_ctx,
-                api_key: script_project.api_key
-              )
-              module_upload_url = Infrastructure::ScriptUploader.new(script_service).upload(package.script_content)
-              uuid = script_service.set_app_script(
-                uuid: package.uuid,
-                extension_point_type: package.extension_point_type,
-                force: force,
-                metadata: package.metadata,
-                script_config: package.script_config,
-                module_upload_url: module_upload_url,
-                library: package.library,
-                input_query: script_project.input_query,
-              )
-              if ShopifyCLI::Environment.interactive?
-                script_project_repo.update_env(uuid: uuid)
+            CLI::UI::Frame.open(ctx.message("script.application.pushing")) do
+              UI::PrintingSpinner.spin(ctx, ctx.message("script.application.pushing_script")) do |p_ctx, spinner|
+                package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
+                  script_project: script_project,
+                  metadata: metadata,
+                  library: library_data,
+                )
+                script_service = Infrastructure::ServiceLocator.script_service(
+                  ctx: p_ctx,
+                  api_key: script_project.api_key
+                )
+                module_upload_url = Infrastructure::ScriptUploader.new(script_service).upload(package.script_content)
+                uuid = script_service.set_app_script(
+                  uuid: package.uuid,
+                  extension_point_type: package.extension_point_type,
+                  force: force,
+                  metadata: package.metadata,
+                  script_config: package.script_config,
+                  module_upload_url: module_upload_url,
+                  library: package.library,
+                  input_query: script_project.input_query,
+                )
+                if ShopifyCLI::Environment.interactive?
+                  script_project_repo.update_env(uuid: uuid)
+                end
+                spinner.update_title(p_ctx.message("script.application.pushed"))
               end
-              spinner.update_title(p_ctx.message("script.application.pushed"))
             end
           end
         end

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -19,7 +19,7 @@ module Script
             raise Infrastructure::Errors::LanguageLibraryForAPINotFoundError.new(
               language: script_project.language,
               api: script_project.extension_point_type
-            ) unless library || (script_project.language == "wasm")
+            ) if library.nil? && (script_project.language != "wasm")
 
             library_name = library&.package
             library_data = {

--- a/lib/project_types/script/layers/domain/errors.rb
+++ b/lib/project_types/script/layers/domain/errors.rb
@@ -32,7 +32,13 @@ module Script
           end
         end
 
-        class MetadataNotFoundError < ScriptProjectError; end
+        class MetadataNotFoundError < ScriptProjectError
+          attr_reader :filename
+          def initialize(filename)
+            super()
+            @filename = filename
+          end
+        end
 
         class MetadataValidationError < ScriptProjectError; end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -33,14 +33,8 @@ module Script
             ctx.dir_exist?("node_modules")
           end
 
-          def metadata
-            unless @ctx.file_exist?(METADATA_FILE)
-              msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)
-              raise Domain::Errors::MetadataNotFoundError, msg
-            end
-
-            raw_contents = File.read(METADATA_FILE)
-            Domain::Metadata.create_from_json(@ctx, raw_contents)
+          def metadata_file_location
+            METADATA_FILE
           end
 
           def library_version(library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -34,14 +34,8 @@ module Script
             ctx.dir_exist?("node_modules")
           end
 
-          def metadata
-            unless @ctx.file_exist?(METADATA_FILE)
-              msg = @ctx.message("script.error.metadata_not_found_cause", METADATA_FILE)
-              raise Domain::Errors::MetadataNotFoundError, msg
-            end
-
-            raw_contents = File.read(METADATA_FILE)
-            Domain::Metadata.create_from_json(@ctx, raw_contents)
+          def metadata_file_location
+            METADATA_FILE
           end
 
           def library_version(library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
@@ -21,10 +21,6 @@ module Script
             nil
           end
 
-          def compiled_type
-            "wasm"
-          end
-
           def metadata_file_location
             "metadata.json"
           end

--- a/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
@@ -5,6 +5,7 @@ module Script
     module Infrastructure
       module Languages
         class WasmTaskRunner
+          BYTECODE_FILE = "script.wasm"
           attr_reader :ctx, :script_name
 
           def initialize(ctx, script_name)
@@ -18,6 +19,19 @@ module Script
 
           def library_version(_library_name)
             nil
+          end
+
+          def compiled_type
+            "wasm"
+          end
+
+          def metadata_file_location
+            "metadata.json"
+          end
+
+          def build
+            raise Errors::WebAssemblyBinaryNotFoundError unless ctx.file_exist?(BYTECODE_FILE)
+            ctx.binread(BYTECODE_FILE)
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/metadata_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/metadata_repository.rb
@@ -1,0 +1,18 @@
+
+module Script
+  module Layers
+    module Infrastructure
+      class MetadataRepository
+        include SmartProperties
+        property! :ctx, accepts: ShopifyCLI::Context
+
+        def get_metadata(file_location)
+          raise Domain::Errors::MetadataNotFoundError, file_location unless ctx.file_exist?(file_location)
+
+          raw_contents = File.read(file_location)
+          Domain::Metadata.create_from_json(ctx, raw_contents)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -24,7 +24,7 @@ module Script
 
         def get_push_package(script_project:, metadata:, library:)
           build_file_path = file_path(script_project.id)
-          raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
+          raise Domain::Errors::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = ctx.binread(build_file_path)
           Domain::PushPackage.new(

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -35,12 +35,14 @@ module Script
             configurationUi: script_config.configuration_ui,
             configurationDefinition: script_config.configuration&.to_json,
             moduleUploadUrl: module_upload_url,
-            library: {
-              language: library[:language],
-              version: library[:version],
-            },
             inputQuery: input_query,
           }
+
+          variables[:library] = {
+            language: library[:language],
+            version: library[:version],
+          }  if library
+
           resp_hash = make_request(query_name: query_name, variables: variables)
           user_errors = resp_hash["data"]["appScriptSet"]["userErrors"]
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -129,8 +129,8 @@ module Script
             "\nbuild: npx shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
 
           web_assembly_binary_not_found: "WebAssembly binary not found.",
-          web_assembly_binary_not_found_suggestion: "No WebAssembly binary found." \
-            "Check that your build npm script outputs the generated binary to the root of the directory." \
+          web_assembly_binary_not_found_suggestion: "No WebAssembly binary found. " \
+            "Check that your build script outputs the generated binary to the root of the directory. " \
             "Generated binary should match the script name: <script_name>.wasm",
 
           project_config_not_found: "Internal error - Script can't be created because the project's config file is missing from the repository.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -239,6 +239,7 @@ module Script
           building_script: "Building script",
           built: "Built",
           pushing: "Pushing",
+          pushing_script: "Pushing script",
           pushed: "Pushed",
           ensure_env: {
             organization: "Partner organization {{green:%s (%s)}}.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -100,7 +100,7 @@ module Script
           }
         when Layers::Domain::Errors::MetadataNotFoundError
           {
-            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause", e.filename),
             help_suggestion: ShopifyCLI::Context.message("script.error.metadata_not_found_help"),
           }
         when Layers::Domain::Errors::MissingScriptConfigFieldError

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -10,8 +10,11 @@ describe Script::Layers::Application::BuildScript do
     let(:script_name) { "name" }
     let(:op_failed_msg) { "msg" }
     let(:content) { "content" }
-    let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", false) }
-    let(:task_runner) { stub(metadata: metadata) }
+    let(:compiled_type) { "wasm" }
+    let(:metadata_file_location) { "metadata.json" }
+    let(:metadata_repository) { TestHelpers::FakeMetadataRepository.new }
+    let(:metadata) { metadata_repository.get_metadata(metadata_file_location) }
+    let(:task_runner) { stub(metadata_file_location: metadata_file_location) }
     let(:script_project) { stub }
 
     let(:library_language) { "assemblyscript" }
@@ -44,6 +47,9 @@ describe Script::Layers::Application::BuildScript do
       script_project
         .stubs(:language)
         .returns(library_language)
+
+      metadata_repository.create_metadata(metadata_file_location)
+      Script::Layers::Infrastructure::MetadataRepository.stubs(:new).returns(metadata_repository)
     end
 
     subject do

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -10,7 +10,6 @@ describe Script::Layers::Application::BuildScript do
     let(:script_name) { "name" }
     let(:op_failed_msg) { "msg" }
     let(:content) { "content" }
-    let(:compiled_type) { "wasm" }
     let(:metadata_file_location) { "metadata.json" }
     let(:metadata_repository) { TestHelpers::FakeMetadataRepository.new }
     let(:metadata) { metadata_repository.get_metadata(metadata_file_location) }

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -231,39 +231,11 @@ out: "some non-json parsable error output", cmd: cmd
     end
   end
 
-  describe ".metadata" do
-    subject { as_task_runner.metadata }
+  describe ".metadata_file_location" do
+    subject { as_task_runner.metadata_file_location }
 
-    describe "when metadata file is present and valid" do
-      let(:metadata_json) do
-        JSON.dump(
-          {
-            schemaVersions: {
-              example: { major: "1", minor: "0" },
-            },
-          },
-        )
-      end
-
-      it "should return a proper metadata object" do
-        File.expects(:read).with("build/metadata.json").once.returns(metadata_json)
-
-        ctx
-          .expects(:file_exist?)
-          .with("build/metadata.json")
-          .once
-          .returns(true)
-
-        assert subject
-      end
-    end
-
-    describe "when metadata file is missing" do
-      it "should raise an exception" do
-        assert_raises(Script::Layers::Domain::Errors::MetadataNotFoundError) do
-          subject
-        end
-      end
+    it "should return the filename" do
+      assert_equal("build/metadata.json", subject)
     end
   end
 end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -143,39 +143,11 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     end
   end
 
-  describe ".metadata" do
-    subject { runner.metadata }
+  describe ".metadata_file_location" do
+    subject { runner.metadata_file_location }
 
-    describe "when metadata file is present and valid" do
-      let(:metadata_json) do
-        JSON.dump(
-          {
-            schemaVersions: {
-              example: { major: "1", minor: "0" },
-            },
-          },
-        )
-      end
-
-      it "should return a proper metadata object" do
-        File.expects(:read).with("build/metadata.json").once.returns(metadata_json)
-
-        ctx
-          .expects(:file_exist?)
-          .with("build/metadata.json")
-          .once
-          .returns(true)
-
-        assert subject
-      end
-    end
-
-    describe "when metadata file is missing" do
-      it "should raise an exception" do
-        assert_raises(Script::Layers::Domain::Errors::MetadataNotFoundError) do
-          subject
-        end
-      end
+    it "should return the filename" do
+      assert_equal("build/metadata.json", subject)
     end
   end
 

--- a/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
@@ -25,14 +25,6 @@ describe Script::Layers::Infrastructure::Languages::WasmTaskRunner do
     end
   end
 
-  describe ".compiled_type" do
-    subject { runner.compiled_type }
-
-    it "should always return wasm" do
-      assert_equal "wasm", subject
-    end
-  end
-
   describe ".metadata_file_location" do
     subject { runner.metadata_file_location }
 

--- a/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
@@ -2,9 +2,11 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::Languages::WasmTaskRunner do
+  include TestHelpers::FakeFS
+
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_name) { "foo" }
-  let(:library_name) { "@shopify/extension-point-as-fake" }
+  let(:library_name) { nil }
   let(:runner) { Script::Layers::Infrastructure::Languages::WasmTaskRunner.new(ctx, script_name) }
 
   describe ".dependencies_installed?" do
@@ -18,9 +20,47 @@ describe Script::Layers::Infrastructure::Languages::WasmTaskRunner do
   describe ".library_version" do
     subject { runner.library_version(library_name) }
 
-    describe "regardless of the library_name" do
-      it "should return nil" do
-        assert_nil subject
+    it "should always return nil" do
+      assert_nil subject
+    end
+  end
+
+  describe ".compiled_type" do
+    subject { runner.compiled_type }
+
+    it "should always return wasm" do
+      assert_equal "wasm", subject
+    end
+  end
+
+  describe ".metadata_file_location" do
+    subject { runner.metadata_file_location }
+
+    it "should return the file location" do
+      assert_equal "metadata.json", subject
+    end
+  end
+
+  describe ".build" do
+    subject { runner.build }
+
+    describe "when there is an existing .wasm file" do
+      let(:wasm) { "some compiled code" }
+      let(:wasmfile) { "script.wasm" }
+
+      before do
+        ctx.write(wasmfile, wasm)
+      end
+      it "should return the contents of the file" do
+        assert_equal wasm, subject
+      end
+    end
+
+    describe "when there is no existing .wasm file" do
+      it "should raise an error" do
+        assert_raises(Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError) do
+          subject
+        end
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/metadata_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/metadata_repository_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Infrastructure::MetadataRepository do
+  include TestHelpers::FakeFS
+  let(:instance) { Script::Layers::Infrastructure::MetadataRepository.new(ctx: ctx) }
+  let(:ctx) { TestHelpers::FakeContext.new }
+
+  describe ".get_metadata" do
+    let(:metadata_file_location) { "metadata.json" }
+    subject { instance.get_metadata(metadata_file_location) }
+
+    describe "when metadata file is present and valid" do
+      let(:major_version) { "1" }
+      let(:minor_version) { "0" }
+      let(:metadata_json) do
+        JSON.dump(
+          {
+            schemaVersions: {
+              example: { major: major_version, minor: minor_version },
+            },
+          },
+        )
+      end
+
+      before do
+        File.write(metadata_file_location, metadata_json)
+      end
+
+      it "should return a proper metadata object" do
+        assert_instance_of Script::Layers::Domain::Metadata, subject
+        assert_equal major_version, subject.schema_major_version
+        assert_equal minor_version, subject.schema_minor_version
+      end
+    end
+
+    describe "when metadata file is missing" do
+      it "should raise an exception" do
+        assert_raises(Script::Layers::Domain::Errors::MetadataNotFoundError) do
+          subject
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/script/test_helpers.rb
+++ b/test/project_types/script/test_helpers.rb
@@ -1,5 +1,6 @@
 module TestHelpers
   autoload :FakeExtensionPointRepository, "project_types/script/test_helpers/fake_extension_point_repository"
+  autoload :FakeMetadataRepository, "project_types/script/test_helpers/fake_metadata_repository"
   autoload :FakePushPackageRepository, "project_types/script/test_helpers/fake_push_package_repository"
   autoload :FakeScriptProjectRepository, "project_types/script/test_helpers/fake_script_project_repository"
 end

--- a/test/project_types/script/test_helpers/fake_metadata_repository.rb
+++ b/test/project_types/script/test_helpers/fake_metadata_repository.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TestHelpers
+  class FakeMetadataRepository
+    def initialize
+      @cache = {}
+    end
+
+    def create_metadata(file_location,
+      schema_major_version = "1",
+      schema_minor_version = "0",
+      use_msgpack = true)
+      @cache[file_location] = Script::Layers::Domain::Metadata.new(
+        schema_major_version,
+        schema_minor_version,
+        use_msgpack
+      )
+    end
+
+    def get_metadata(file_location)
+      if @cache.key?(file_location)
+        @cache[file_location]
+      else
+        raise Domain::Errors::MetadataNotFoundError, file_location
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/4124

This PR depends on https://github.com/Shopify/shopify-cli/pull/1905 being shipped first.

### WHAT is this pull request doing?

Adds the ability for the CLI to push script projects that provide a Wasm module directly.
It does so by:

- Reading the existing Wasm module during the the build step in `PushScript` if the project.language is Wasm
- Refactoring how we read metadata into `MetadataRepository`.
  - Read from the files generated during the create step
- Slight change to how `ScriptService` class was building the variables for the GQL request.

### How to test your changes?

- Copy over any random Wasm to `/script.wasm` in the root directory.
- `shopify script push`.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.