### PR TITLE
Fix `theme pull` to no longer add empty lines on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#1937](https://github.com/Shopify/shopify-cli/pull/1937): Fix `theme pull` to no longer add empty lines on Windows
+
 ## 2.9.0
 
 ### Fixed

--- a/lib/shopify_cli/theme/file.rb
+++ b/lib/shopify_cli/theme/file.rb
@@ -18,7 +18,7 @@ module ShopifyCLI
 
       def read
         if text?
-          path.read
+          path.read(universal_newline: true)
         else
           path.read(mode: "rb")
         end
@@ -27,7 +27,7 @@ module ShopifyCLI
       def write(content)
         path.parent.mkpath unless path.parent.directory?
         if text?
-          path.write(content)
+          path.write(content, universal_newline: true)
         else
           path.write(content, 0, mode: "wb")
         end

--- a/test/shopify-cli/theme/file_test.rb
+++ b/test/shopify-cli/theme/file_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/file"
+
+module ShopifyCLI
+  module Theme
+    class FileTest < Minitest::Test
+      def setup
+        super
+        @file = File.new("path", root)
+        @file.stubs(:path).returns(path)
+      end
+
+      def test_read_when_file_is_a_text
+        @file.stubs(:text?).returns(true)
+
+        @path.expects(:read).with(universal_newline: true)
+        @file.read
+      end
+
+      def test_read_when_file_is_not_a_text
+        @file.stubs(:text?).returns(false)
+
+        @path.expects(:read).with(mode: "rb")
+        @file.read
+      end
+
+      def test_write_when_file_parent_is_not_a_directory
+        @path.parent.stubs(:directory?).returns(false)
+        @path.stubs(:write)
+
+        @path.parent.expects(:mkpath)
+        @file.write("content")
+      end
+
+      def test_write_when_file_parent_is_a_directory
+        @path.parent.stubs(:directory?).returns(true)
+        @path.stubs(:write)
+
+        @path.parent.expects(:mkpath).never
+        @file.write("content")
+      end
+
+      def test_write_when_file_is_a_text
+        @path.parent.stubs(:directory?).returns(true)
+        @file.stubs(:text?).returns(true)
+
+        @path.expects(:write).with("content", universal_newline: true)
+        @file.write("content")
+      end
+
+      def test_write_when_file_is_not_a_text
+        @path.parent.stubs(:directory?).returns(true)
+        @file.stubs(:text?).returns(false)
+
+        @path.expects(:write).with("content", 0, mode: "wb")
+        @file.write("content")
+      end
+
+      private
+
+      def path
+        @path = mock
+        @path.stubs(:parent).returns(mock)
+        @path
+      end
+
+      def root
+        @root = mock
+        @root.stubs(:expand_path).returns(ShopifyCLI::ROOT)
+        @root
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

In some scenarios, the `theme pull` adds new empty lines for Windows users.


### WHAT is this pull request doing?

When users set the end of line sequence on VSCode to CRLF, Ruby IO#read (`[...]theme/file.rb`) produces CRCRLF sequences, adding empty lines.

With the issue living either on the Ruby IO side or on VSCode, we have to abstract that from partners. So, this PR relies on the `universal_newline` decorator for normalizing end of line sequences as LF (this PR proposes this alternative).


### How to test your changes?

These steps require two systems to proceed, a Unix and a Windows.

- [On Unix] Create a theme with `shopify theme init`
- [On Unix] Publish this theme with `shopify theme push -u`
- [On Windows] Pull the theme above with `shopify theme pull -i THEME_ID`
- [On Unix] Open the `sections/announcement-bar.liquid` file with VSCode
- [On Unix] Change the end of line sequence to CRLF
- [On Windows] Pull the change above with `shopify theme pull -i THEME_ID`
- [On Windows] Open the `sections/announcement-bar.liquid` and notice the blank lines are no longer created

**Before this PR:**
![before](https://user-images.githubusercontent.com/1079279/149782792-f266637a-032d-4911-856f-138ef82ced6c.gif)

**After this PR:**
![after](https://user-images.githubusercontent.com/1079279/149782778-8f4539cf-ece6-4d01-92ad-969dc41f9b2c.gif)


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.