### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#1900](https://github.com/Shopify/shopify-cli/pull/1900): Add `-d`/`--development` flag to Shopify theme pull command
-* [#1896](https://github.com/Shopify/shopify-cli/pull/1896): Release Typescript options for payment_methods and shipping_methods scripts
 * [#1891](https://github.com/Shopify/shopify-cli/pull/1891): Allow for additional arguments in `shopify push script` on CI.
 * [#1877](https://github.com/Shopify/shopify-cli/pull/1877): Add theme (`-t`/`--theme=NAME_OR_ID`) parameter to `theme push`/`theme pull` commands
 * [#1871](https://github.com/Shopify/shopify-cli/pull/1871): Add a new `--live-reload` parameter to the `theme serve` command


### PR DESCRIPTION
### WHY are these changes introduced?

A change was reverted in https://github.com/Shopify/shopify-cli/pull/1925, but the changelog record was added back in during https://github.com/Shopify/shopify-cli/pull/1926/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR12, probably during a merge conflict resolution.

However, that feature was not included with the recent release, so I am removing it from the changelog. I also removed it from [the release description](https://github.com/Shopify/shopify-cli/releases/tag/v2.9.0).

### WHAT is this pull request doing?

Remove a changelog entry that was not actually included in the release.

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above.