### PR TITLE
Warn users when they are using a Node/Ruby version that's outside of a default range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#1945](https://github.com/Shopify/shopify-cli/pull/1945): Check Node and Ruby versions and warn the user if their environment's version might be incompatible with the version the command expects.
+
 ## Version 2.10.2
 ### Fixed
 * [#1983](https://github.com/Shopify/shopify-cli/pull/1983): Improve Windows compatibility

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -8,6 +8,9 @@ module Extension
 
       prerequisite_task ensure_project_type: :extension
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       YARN_BUILD_COMMAND = %w(build)
       NPM_BUILD_COMMAND = %w(run-script build)
 

--- a/lib/project_types/extension/commands/check.rb
+++ b/lib/project_types/extension/commands/check.rb
@@ -4,6 +4,9 @@ require "theme_check"
 module Extension
   class Command
     class Check < ExtensionCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       class CheckOptions < ShopifyCLI::Options
         def initialize(ctx, theme_check)
           super()

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -5,6 +5,9 @@ module Extension
     class Create < ShopifyCLI::Command::SubCommand
       prerequisite_task :ensure_authenticated
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("--name=NAME") { |name| flags[:name] = name }
         parser.on("--template=TEMPLATE") { |template| flags[:template] = template }

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -6,6 +6,9 @@ module Extension
     class Push < ShopifyCLI::Command::SubCommand
       prerequisite_task ensure_project_type: :extension
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("--api-key=API_KEY") { |api_key| flags[:api_key] = api_key.gsub('"', "") }
         parser.on("--api-secret=API_SECRET") { |api_secret| flags[:api_secret] = api_secret.gsub('"', "") }

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -5,6 +5,9 @@ module Extension
     class Serve < ExtensionCommand
       prerequisite_task ensure_project_type: :extension
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       DEFAULT_PORT = 39351
 
       options do |parser, flags|

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -5,6 +5,9 @@ module Script
       prerequisite_task :ensure_authenticated
       prerequisite_task ensure_project_type: :script
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       def call(_args, _)
         Layers::Application::ConnectApp.call(ctx: @ctx, force: true)
       rescue StandardError => e

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -5,10 +5,6 @@ module Script
       prerequisite_task :ensure_authenticated
       prerequisite_task ensure_project_type: :script
 
-      recommend_node(
-        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
-        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
-      )
       recommend_default_ruby_range
 
       def call(_args, _)

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -5,7 +5,10 @@ module Script
       prerequisite_task :ensure_authenticated
       prerequisite_task ensure_project_type: :script
 
-      recommend_default_node_range
+      recommend_node(
+        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
+        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
+      )
       recommend_default_ruby_range
 
       def call(_args, _)

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -5,10 +5,6 @@ module Script
     class Create < ShopifyCLI::Command::SubCommand
       prerequisite_task :ensure_authenticated
 
-      recommend_node(
-        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
-        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
-      )
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -5,6 +5,9 @@ module Script
     class Create < ShopifyCLI::Command::SubCommand
       prerequisite_task :ensure_authenticated
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("--name=NAME") { |name| flags[:name] = name }
         parser.on("--api=API_NAME") { |ep_name| flags[:extension_point] = ep_name }

--- a/lib/project_types/script/commands/create.rb
+++ b/lib/project_types/script/commands/create.rb
@@ -5,7 +5,10 @@ module Script
     class Create < ShopifyCLI::Command::SubCommand
       prerequisite_task :ensure_authenticated
 
-      recommend_default_node_range
+      recommend_node(
+        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
+        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
+      )
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -5,6 +5,9 @@ module Script
     class Push < ShopifyCLI::Command::SubCommand
       prerequisite_task ensure_project_type: :script
 
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("--force") { |t| flags[:force] = t }
         parser.on("--api-key=API_KEY") { |api_key| flags[:api_key] = api_key.gsub('"', "") }

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -5,7 +5,10 @@ module Script
     class Push < ShopifyCLI::Command::SubCommand
       prerequisite_task ensure_project_type: :script
 
-      recommend_default_node_range
+      recommend_node(
+        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
+        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
+      )
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/check.rb
+++ b/lib/project_types/theme/commands/check.rb
@@ -4,6 +4,9 @@ require "theme_check"
 module Theme
   class Command
     class Check < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       class Options < ShopifyCLI::Options
         def initialize(theme_check)
           super()

--- a/lib/project_types/theme/commands/delete.rb
+++ b/lib/project_types/theme/commands/delete.rb
@@ -5,6 +5,9 @@ require "shopify_cli/theme/development_theme"
 module Theme
   class Command
     class Delete < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-a", "--show-all") { flags[:show_all] = true }

--- a/lib/project_types/theme/commands/init.rb
+++ b/lib/project_types/theme/commands/init.rb
@@ -3,6 +3,9 @@
 module Theme
   class Command
     class Init < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("-u", "--clone-url URL") { |url| flags[:clone_url] = url }
       end

--- a/lib/project_types/theme/commands/language_server.rb
+++ b/lib/project_types/theme/commands/language_server.rb
@@ -4,6 +4,9 @@ require "theme_check"
 module Theme
   class Command
     class LanguageServer < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       def call(*)
         ThemeCheck::LanguageServer.start
       end

--- a/lib/project_types/theme/commands/package.rb
+++ b/lib/project_types/theme/commands/package.rb
@@ -5,6 +5,9 @@ require "json"
 module Theme
   class Command
     class Package < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       THEME_DIRECTORIES = %w[
         assets
         config

--- a/lib/project_types/theme/commands/publish.rb
+++ b/lib/project_types/theme/commands/publish.rb
@@ -4,6 +4,9 @@ require "shopify_cli/theme/theme"
 module Theme
   class Command
     class Publish < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("-f", "--force") { flags[:force] = true }
       end

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -7,6 +7,9 @@ require "shopify_cli/theme/syncer"
 module Theme
   class Command
     class Pull < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -8,6 +8,9 @@ require "shopify_cli/theme/syncer"
 module Theme
   class Command
     class Push < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       options do |parser, flags|
         parser.on("-n", "--nodelete") { flags[:nodelete] = true }
         parser.on("-i", "--themeid=ID") { |theme_id| flags[:theme_id] = theme_id }

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -4,6 +4,9 @@ require "shopify_cli/theme/dev_server"
 module Theme
   class Command
     class Serve < ShopifyCLI::Command::SubCommand
+      recommend_default_node_range
+      recommend_default_ruby_range
+
       DEFAULT_HTTP_HOST = "127.0.0.1"
 
       options do |parser, flags|

--- a/lib/shopify_cli/command/sub_command.rb
+++ b/lib/shopify_cli/command/sub_command.rb
@@ -9,6 +9,8 @@ module ShopifyCLI
           cmd = new(@ctx)
           args = cmd.options.parse(@_options, args || [])
           return call_help(parent_command, command_name) if cmd.options.help
+          check_ruby_version
+          check_node_version
           run_prerequisites
 
           cmd.call(args, command_name)

--- a/lib/shopify_cli/commands/app/create.rb
+++ b/lib/shopify_cli/commands/app/create.rb
@@ -6,6 +6,9 @@ module ShopifyCLI
         subcommand :PHP, "php", "shopify_cli/commands/app/create/php"
         subcommand :Node, "node", "shopify_cli/commands/app/create/node"
 
+        recommend_default_node_range
+        recommend_default_ruby_range
+
         def call(_args, _command_name)
           @ctx.puts(self.class.help)
         end

--- a/lib/shopify_cli/commands/app/create/node.rb
+++ b/lib/shopify_cli/commands/app/create/node.rb
@@ -5,6 +5,9 @@ module ShopifyCLI
         class Node < ShopifyCLI::Command::AppSubCommand
           prerequisite_task :ensure_authenticated
 
+          recommend_default_node_range
+          recommend_default_ruby_range
+
           options do |parser, flags|
             parser.on("--name=NAME") { |t| flags[:name] = t }
             parser.on("--organization-id=ID") { |id| flags[:organization_id] = id }

--- a/lib/shopify_cli/commands/app/create/rails.rb
+++ b/lib/shopify_cli/commands/app/create/rails.rb
@@ -5,6 +5,9 @@ module ShopifyCLI
         class Rails < ShopifyCLI::Command::AppSubCommand
           prerequisite_task :ensure_authenticated
 
+          recommend_default_node_range
+          recommend_default_ruby_range
+
           options do |parser, flags|
             parser.on("--name=NAME") { |t| flags[:name] = t }
             parser.on("--organization-id=ID") { |id| flags[:organization_id] = id }

--- a/lib/shopify_cli/commands/app/deploy.rb
+++ b/lib/shopify_cli/commands/app/deploy.rb
@@ -4,6 +4,9 @@ module ShopifyCLI
       class Deploy < ShopifyCLI::Command::AppSubCommand
         subcommand :Heroku, "heroku", "shopify_cli/commands/app/deploy/heroku"
 
+        recommend_default_node_range
+        recommend_default_ruby_range
+
         def call(args, _name)
           platform = args.shift
           case platform

--- a/lib/shopify_cli/commands/app/serve.rb
+++ b/lib/shopify_cli/commands/app/serve.rb
@@ -6,6 +6,9 @@ module ShopifyCLI
 
         prerequisite_task :ensure_env, :ensure_dev_store
 
+        recommend_default_ruby_range
+        recommend_default_node_range
+
         options do |parser, flags|
           parser.on("--host=HOST") do |h|
             flags[:host] = h.gsub('"', "")

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -58,6 +58,18 @@ module ShopifyCLI
       MONORAIL_REAL_EVENTS = "MONORAIL_REAL_EVENTS"
     end
 
+    module SupportedVersions
+      module Ruby
+        FROM = "2.7.0"
+        TO = "3.1.0"
+      end
+
+      module Node
+        FROM = "12.0.0"
+        TO = "17.0.0"
+      end
+    end
+
     module Identity
       CLIENT_ID_DEV = "e5380e02-312a-7408-5718-e07017e9cf52"
       CLIENT_ID = "fbdb2649-e327-4907-8f67-908d24cfd7e3"

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -60,8 +60,8 @@ module ShopifyCLI
 
     module SupportedVersions
       module Ruby
-        FROM = "2.7.0"
-        TO = "3.1.0"
+        FROM = "2.6.6"
+        TO = "3.0.2"
       end
 
       module Node

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -1,8 +1,24 @@
+require "semantic/semantic"
+
 module ShopifyCLI
   # The environment module provides an interface to get information from
   # the environment in which the CLI runs
   module Environment
     TRUTHY_ENV_VARIABLE_VALUES = ["1", "true", "TRUE", "yes", "YES"]
+
+    def self.ruby_version(context: Context.new)
+      out, err, stat = context.capture3('ruby -e "puts RUBY_VERSION"')
+      raise ShopifyCLI::Abort, err unless stat.success?
+      out = out.gsub('"', "")
+      ::Semantic::Version.new(out.chomp)
+    end
+
+    def self.node_version(context: Context.new)
+      out, err, stat = context.capture3("node", "--version")
+      raise ShopifyCLI::Abort, err unless stat.success?
+      out = out.gsub("v", "")
+      ::Semantic::Version.new(out.chomp)
+    end
 
     def self.interactive=(interactive)
       @interactive = interactive

--- a/lib/shopify_cli/exception_reporter.rb
+++ b/lib/shopify_cli/exception_reporter.rb
@@ -1,5 +1,10 @@
 module ShopifyCLI
   module ExceptionReporter
+    def self.report_error_silently(error)
+      return unless ReportingConfigurationController.reporting_enabled?
+      report_to_bugsnag(error: error)
+    end
+
     def self.report(error, _logs = nil, _api_key = nil, custom_metadata = {})
       context = ShopifyCLI::Context.new
       unless ShopifyCLI::Environment.development?
@@ -19,6 +24,10 @@ module ShopifyCLI
       return unless reportable_error?(error)
 
       return unless report?(context: context)
+      report_to_bugsnag(error: error, custom_metadata: custom_metadata)
+    end
+
+    def self.report_to_bugsnag(error:, custom_metadata: {})
       ENV["BUGSNAG_DISABLE_AUTOCONFIGURE"] = "1"
       require "bugsnag"
 

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -9,6 +9,8 @@ module Extension
       include TestHelpers::FakeUI
       def setup
         super
+        ShopifyCLI::Environment.stubs(:ruby_version).returns("2.7.5")
+        ShopifyCLI::Environment.stubs(:node_version).returns("12.0.0")
         ShopifyCLI::ProjectType.load_type(:extension)
         ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
       end

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -3,6 +3,74 @@ require "test_helper"
 
 module ShopifyCLI
   class EnvironmentTest < MiniTest::Test
+    def test_ruby_version_when_the_command_raises
+      # Given
+      context = TestHelpers::FakeContext.new
+      stat = mock("error", success?: false)
+      out = ""
+      err = "Error executing the command"
+      context.expects(:capture3)
+        .with('ruby -e "puts RUBY_VERSION"')
+        .returns([out, err, stat])
+
+      # When/Then
+      error = assert_raises ShopifyCLI::Abort do
+        Environment.ruby_version(context: context)
+      end
+      assert_equal err, error.message
+    end
+
+    def test_ruby_version
+      # Given
+      context = TestHelpers::FakeContext.new
+      stat = mock("success", success?: true)
+      out = '"3.2.1"'
+      err = ""
+      context.expects(:capture3)
+        .with('ruby -e "puts RUBY_VERSION"')
+        .returns([out, err, stat])
+
+      # When
+      got = Environment.ruby_version(context: context)
+
+      # Then
+      assert_equal ::Semantic::Version.new("3.2.1"), got
+    end
+
+    def test_node_version_when_the_command_raises
+      # Given
+      context = TestHelpers::FakeContext.new
+      stat = mock("error", success?: false)
+      out = ""
+      err = "Error executing the command"
+      context.expects(:capture3)
+        .with("node", "--version")
+        .returns([out, err, stat])
+
+      # When/Then
+      error = assert_raises ShopifyCLI::Abort do
+        Environment.node_version(context: context)
+      end
+      assert_equal err, error.message
+    end
+
+    def test_node_version
+      # Given
+      context = TestHelpers::FakeContext.new
+      stat = mock("success", success?: true)
+      out = "v3.2.1"
+      err = ""
+      context.expects(:capture3)
+        .with("node", "--version")
+        .returns([out, err, stat])
+
+      # When
+      got = Environment.node_version(context: context)
+
+      # Then
+      assert_equal ::Semantic::Version.new("3.2.1"), got
+    end
+
     def test_use_local_partners_instance_returns_true_when_the_env_variable_is_set
       # Given
       env_variables = {


### PR DESCRIPTION
### WHY are these changes introduced?

Some users are running into issues because the version of the interpreters that they are using (e.g. Node, Ruby), is incompatible with the CLI. When that happens, users are often presented with cryptic errors that bubble up from deep pieces in the dependency graph and that makes the issues not very actionable for them.

### WHAT is this pull request doing?
This PR doesn't prevent that scenario from happening because the runtime developers use is outside of our control, but prints a warning if we detect the version they are using might be incompatible with the CLI. This helps them pin-point their issue with the warning and try with a different version before opening a support ticket on our side.

### How to test your changes?
1. Check out the branch.
2. Switch to a Node version that's incompatible with the CLI, for example Node 17
3. Run any of the commands that have the check now, for example, `shopify-dev extension serve`.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.