### PR TITLE
Command flag to print ENV

### DIFF
--- a/lib/project_types/extension/commands/connect.rb
+++ b/lib/project_types/extension/commands/connect.rb
@@ -4,13 +4,27 @@ module Extension
     class Connect < ExtensionCommand
       prerequisite_task :ensure_authenticated
 
+      options do |parser, flags|
+        parser.on("--print") { |t| flags[:print] = t }
+      end
+
       def call(args, _)
         with_connect_form(args) do |form|
+          api_key = form.app.api_key
+          api_secret = form.app.secret
+          registration_id = form.registration.id
+          if options.flags.key?(:print)
+            @ctx.puts(<<~ENV)
+              API_KEY=#{api_key}
+              API_SECRET=#{api_secret}
+              EXTENSION_ID=#{registration_id}
+            ENV
+          end
           ExtensionProject.write_env_file(
             context: @ctx,
-            api_key: form.app.api_key,
-            api_secret: form.app.secret,
-            registration_id: form.registration.id,
+            api_key: api_key,
+            api_secret: api_secret,
+            registration_id: registration_id,
             registration_uuid: form.registration.uuid,
             title: form.registration.title
           )

--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -5,8 +5,13 @@ module Script
       prerequisite_task :ensure_authenticated
       prerequisite_task ensure_project_type: :script
 
+      options do |parser, flags|
+        parser.on("--print") { |t| flags[:print] = t }
+      end
+
       def call(_args, _)
-        Layers::Application::ConnectApp.call(ctx: @ctx, force: true)
+        print = options.flags.key?(:print)
+        Layers::Application::ConnectApp.call(ctx: @ctx, print: print, force: true)
       rescue StandardError => e
         UI::ErrorHandler.pretty_print_and_raise(e, failed_op: @ctx.message("script.connect.error.operation_failed"))
       end

--- a/lib/project_types/script/layers/application/connect_app.rb
+++ b/lib/project_types/script/layers/application/connect_app.rb
@@ -7,7 +7,7 @@ module Script
     module Application
       class ConnectApp
         class << self
-          def call(ctx:, force: false)
+          def call(ctx:, print: false, force: false)
             script_project_repo = Layers::Infrastructure::ScriptProjectRepository.new(ctx: ctx)
             script_project = script_project_repo.get
 
@@ -39,10 +39,20 @@ module Script
             scripts = script_service.get_app_scripts(extension_point_type: extension_point_type)
 
             uuid = Forms::AskScriptUuid.ask(ctx, scripts, nil)&.uuid
+            api_key = app["apiKey"]
+            secret = app["apiSecretKeys"].first["secret"]
+
+            if print
+              ctx.puts(<<~ENV)
+                API_KEY=#{api_key}
+                API_SECRET=#{secret}
+                UUID=#{uuid}
+              ENV
+            end
 
             script_project_repo.create_env(
-              api_key: app["apiKey"],
-              secret: app["apiSecretKeys"].first["secret"],
+              api_key: api_key,
+              secret: secret,
               uuid: uuid
             )
             ctx.done(ctx.message("script.connect.connected", app["title"]))

--- a/test/project_types/script/commands/connect_test.rb
+++ b/test/project_types/script/commands/connect_test.rb
@@ -18,7 +18,7 @@ module Script
       end
 
       def test_calls_connect_app
-        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, force: true)
+        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, print: false, force: true)
         perform_command
       end
 

--- a/test/project_types/script/commands/connect_test.rb
+++ b/test/project_types/script/commands/connect_test.rb
@@ -32,6 +32,11 @@ module Script
         perform_command
       end
 
+      def test_prints_credentials
+        Script::Layers::Application::ConnectApp.expects(:call).with(ctx: @context, print: true, force: true)
+        run_cmd("script connect --print")
+      end
+
       private
 
       def perform_command


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

For CI environments, we need to be able to pass the credentials to a non-local environment. This allows the user to get the relevant credentials without opening their `.env` file.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds a `--print` flag to `shopify script/extension connect` to additionally print out the results.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Make a local script/extension as usual, and `shopify script/extension connect --print`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).