### PR TITLE
Fix CORS (Cross-origin resource sharing) errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#1937](https://github.com/Shopify/shopify-cli/pull/1937): Fix `theme pull` to no longer add empty lines on Windows
+* [#1952](https://github.com/Shopify/shopify-cli/pull/1952): Fix CORS (cross-origin resource sharing) errors
 
 ## 2.9.0
 

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -3,6 +3,7 @@ require_relative "development_theme"
 require_relative "ignore_filter"
 require_relative "syncer"
 
+require_relative "dev_server/cdn_assets"
 require_relative "dev_server/cdn_fonts"
 require_relative "dev_server/hot_reload"
 require_relative "dev_server/header_hash"
@@ -36,6 +37,7 @@ module ShopifyCLI
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)
           @app = CdnFonts.new(@app, theme: theme)
+          @app = CdnAssets.new(@app, theme: theme)
           @app = LocalAssets.new(ctx, @app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, mode: mode, ignore_filter: ignore_filter)
           stopped = false

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -37,8 +37,8 @@ module ShopifyCLI
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)
           @app = CdnFonts.new(@app, theme: theme)
-          @app = CdnAssets.new(@app, theme: theme)
           @app = LocalAssets.new(ctx, @app, theme: theme)
+          @app = CdnAssets.new(@app, theme: theme)
           @app = HotReload.new(ctx, @app, theme: theme, watcher: watcher, mode: mode, ignore_filter: ignore_filter)
           stopped = false
           address = "http://#{host}:#{port}"

--- a/lib/shopify_cli/theme/dev_server/cdn/cdn_helper.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn/cdn_helper.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      module Cdn
+        module CdnHelper
+          def proxy_request(env, uri, theme)
+            response = Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
+              req_class = Net::HTTP.const_get(method(env))
+
+              req = req_class.new(uri)
+              req.initialize_http_header(req_headers(theme))
+              req.body_stream = req_body(env)
+
+              http.request(req)
+            end
+
+            [
+              response.code.to_s,
+              {
+                "Content-Type" => response.content_type,
+                "Content-Length" => response.content_length.to_s,
+              },
+              [response.body],
+            ]
+          end
+
+          private
+
+          def method(env)
+            env["REQUEST_METHOD"].capitalize
+          end
+
+          def req_body(env)
+            env["rack.input"]
+          end
+
+          def req_headers(theme)
+            {
+              "Referer" => "https://#{theme.shop}",
+              "Transfer-Encoding" => "chunked",
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/cdn_assets.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn_assets.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "cdn/cdn_helper"
+require_relative "local_assets"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class CdnAssets
+        include Cdn::CdnHelper
+
+        ASSETS_PROXY_PATH = "/cdn_asset"
+        ASSETS_CDN = "//cdn.shopify.com"
+        ASSETS_CDN_REGEX = %r{((https?:)?#{ASSETS_CDN}(.*\.(css|js)))}
+
+        def initialize(app, theme:)
+          @app = app
+          @theme = theme
+        end
+
+        def call(env)
+          path = env["PATH_INFO"]
+
+          # Serve assets from CDN
+          return serve_asset(env, path) if path.start_with?(ASSETS_PROXY_PATH)
+
+          # Serve maps from CDN
+          return serve_path(env, path) if path.end_with?(".map")
+
+          # Proxy the request, and replace the URLs in the response
+          status, headers, body = @app.call(env)
+          body = replace_asset_urls(body)
+          [status, headers, body]
+        end
+
+        private
+
+        def serve_asset(env, path)
+          serve_path(env, path.gsub(%r{^#{ASSETS_PROXY_PATH}}, ""))
+        end
+
+        def serve_path(env, path)
+          query = env["QUERY_STRING"]
+          uri = asset_cdn_uri(path, query)
+
+          proxy_request(env, uri, @theme)
+        end
+
+        def asset_cdn_uri(path, query)
+          uri = URI.join("https:#{ASSETS_CDN}", path)
+          uri.query = query.split("&").last
+          uri
+        end
+
+        def replace_asset_urls(body)
+          replaced_body = body.join.gsub(ASSETS_CDN_REGEX) do |match|
+            if local_asset?(match)
+              match
+            else
+              match.gsub(%r{(https?:)?#{ASSETS_CDN}}, ASSETS_PROXY_PATH)
+            end
+          end
+
+          [replaced_body]
+        end
+
+        def local_asset?(path)
+          match = path.match(LocalAssets::ASSET_REGEX)
+          return false if match.nil?
+
+          path = Pathname.new(match[1])
+          @theme.static_asset_paths.include?(path)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/cdn_assets.rb
+++ b/lib/shopify_cli/theme/dev_server/cdn_assets.rb
@@ -11,7 +11,7 @@ module ShopifyCLI
 
         ASSETS_PROXY_PATH = "/cdn_asset"
         ASSETS_CDN = "//cdn.shopify.com"
-        ASSETS_CDN_REGEX = %r{((https?:)?#{ASSETS_CDN}(.*\.(css|js|map)))}
+        ASSETS_CDN_REGEX = %r{(https?:)?#{ASSETS_CDN}}
         ASSETS_SOURCE_MAP_REGEX = /\/[\/|\*]# sourceMappingURL\=(\/.*)/
 
         def initialize(app, theme:)
@@ -50,15 +50,7 @@ module ShopifyCLI
         end
 
         def replace_asset_urls(body)
-          replaced_body = body.join.gsub(ASSETS_CDN_REGEX) do |match|
-            if local_asset?(match)
-              match
-            else
-              match.gsub(%r{(https?:)?#{ASSETS_CDN}}, ASSETS_PROXY_PATH)
-            end
-          end
-
-          [replaced_body]
+          [body.join.gsub(ASSETS_CDN_REGEX, ASSETS_PROXY_PATH)]
         end
 
         def replace_source_map_url(body)
@@ -70,14 +62,6 @@ module ShopifyCLI
           return body if map_url.nil?
 
           [body_content.gsub(map_url, "#{ASSETS_PROXY_PATH}#{map_url}")]
-        end
-
-        def local_asset?(path)
-          match = path.match(LocalAssets::ASSET_REGEX)
-          return false if match.nil?
-
-          path = Pathname.new(match[1])
-          @theme.static_asset_paths.include?(path)
         end
       end
     end

--- a/lib/shopify_cli/theme/dev_server/local_assets.rb
+++ b/lib/shopify_cli/theme/dev_server/local_assets.rb
@@ -11,6 +11,10 @@ module ShopifyCLI
             @path = path
           end
 
+          def join
+            @path.read
+          end
+
           # Naive implementation. Only used in unit tests.
           def each
             yield @path.read

--- a/test/shopify-cli/theme/dev_server/cdn/cdn_helper_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn/cdn_helper_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/dev_server/cdn/cdn_helper"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      module Cdn
+        class CdnHelperTest < Minitest::Test
+          include Cdn::CdnHelper
+
+          def setup
+            super
+
+            @env = {
+              "REQUEST_METHOD" => "get",
+              "rack.input" => body_stream,
+            }
+            @headers = {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            }
+            @uri = URI("http://cdn.shopify/assets/base.css")
+          end
+
+          def test_proxy_request
+            expected_code = "200"
+            expected_content = "<expected content>"
+            expected_headers = {
+              "Content-Type" => "text/css",
+              "Content-Length" => "42",
+            }
+
+            stub_request(:get, "https://cdn.shopify/assets/base.css")
+              .with(body: body_stream.read, headers: @headers)
+              .to_return(status: 200,
+                         body: expected_content,
+                         headers: expected_headers)
+
+            actual_response = proxy_request(@env, @uri, theme)
+            expected_response = [expected_code, expected_headers, [expected_content]]
+
+            assert_equal(expected_response, actual_response)
+          end
+
+          private
+
+          def theme
+            theme_mock = mock("Theme")
+            theme_mock.stubs(:shop).returns("my-test-shop.myshopify.com")
+            theme_mock
+          end
+
+          def body_stream
+            body_mock = mock("Body")
+            body_mock.stubs(:read).returns("<content>")
+            body_mock
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/cdn_assets_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn_assets_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+require "rack/mock"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class CdnAssetsTest < Minitest::Test
+        def test_replace_cdn_css_in_reponse_body
+          original_html = <<~HTML
+            <html>
+              <head>
+                <link href="//cdn.shopify.com/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all">
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <link href="/cdn_asset/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all">
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_replace_cdn_js_in_reponse_body
+          original_html = <<~HTML
+            <html>
+              <head>
+                <script src="//cdn.shopify.com/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script>
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <script src="/cdn_asset/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script>
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_replace_two_cdn_css_files_on_same_line
+          original_html = <<~HTML
+            <html>
+              <head>
+                <link href="//cdn.shopify.com/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all"><link href="//cdn.shopify.com/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all">
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <link href="/cdn_asset/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all"><link href="/cdn_asset/s/files/AAAA/0000/1111/2222/t/3333/assets/base.css" rel="stylesheet" type="text/css" media="all">
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_replace_two_cdn_js_files_on_same_line
+          original_html = <<~HTML
+            <html>
+              <head>
+                <script src="//cdn.shopify.com/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script><script src="//cdn.shopify.com/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script>
+              </head>
+            </html>
+          HTML
+          expected_html = <<~HTML
+            <html>
+              <head>
+                <script src="/cdn_asset/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script><script src="/cdn_asset/s/files/AAAAA/0000/1111/2222/t/3333/compiled_assets/script.js"></script>
+              </head>
+            </html>
+          HTML
+          assert_equal(expected_html, serve(original_html).body)
+        end
+
+        def test_dont_replace_other_assets
+          original_html = <<~HTML
+            <html>
+              <head>
+              <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0457/3256/0918/t/2/assets/theme.css" />
+                <script src="https://cdn.shopify.com/s/files/1/0457/3256/0918/t/2/assets/theme.js"></script>
+              </head>
+            </html>
+          HTML
+          assert_equal(original_html, serve(original_html).body)
+        end
+
+        def test_serve_asset_from_cdn
+          expected_body = "<ASSET_FILE_FROM_CDN>"
+
+          stub_request(:get, "https://cdn.shopify.com/script.js")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 200, body: expected_body, headers: {})
+
+          response = serve(path: "/cdn_asset/script.js")
+          actual_body = response.body
+
+          assert_equal expected_body, actual_body
+        end
+
+        def test_serve_map_from_cdn
+          expected_body = "<MAP_FILE_FROM_CDN>"
+
+          stub_request(:get, "https://cdn.shopify.com/s/any/theme.css.min.map")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 200, body: expected_body, headers: {})
+
+          response = serve(path: "/s/any/theme.css.min.map")
+          actual_body = response.body
+
+          assert_equal expected_body, actual_body
+        end
+
+        def test_404_on_missing_cdn_asset
+          stub_request(:get, "https://cdn.shopify.com/not_found_resource.js")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 404, body: "Not found", headers: {})
+
+          response = serve(path: "/cdn_asset/not_found_resource.js")
+
+          assert_equal(404, response.status)
+          assert_equal("Not found", response.body)
+        end
+
+        def test_404_on_missing_cdn_map
+          stub_request(:get, "https://cdn.shopify.com/s/any/not_found_resource.map")
+            .with(headers: {
+              "Referer" => "https://my-test-shop.myshopify.com",
+              "Transfer-Encoding" => "chunked",
+            })
+            .to_return(status: 404, body: "Not found", headers: {})
+
+          response = serve(path: "/s/any/not_found_resource.map")
+
+          assert_equal(404, response.status)
+          assert_equal("Not found", response.body)
+        end
+
+        private
+
+        def serve(response_body = "", path: "/")
+          app = lambda do |_env|
+            [200, {}, [response_body]]
+          end
+          stack = CdnAssets.new(app, theme: theme)
+          request = Rack::MockRequest.new(stack)
+          request.get(path)
+        end
+
+        def root
+          @root ||= ShopifyCLI::ROOT + "/test/fixtures/theme"
+        end
+
+        def theme
+          return @theme if @theme
+          @theme = Theme.new(nil, root: root)
+          @theme.stubs(shop: "my-test-shop.myshopify.com")
+          @theme
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/cdn_assets_test.rb
+++ b/test/shopify-cli/theme/dev_server/cdn_assets_test.rb
@@ -79,18 +79,6 @@ module ShopifyCLI
           assert_equal(expected_html, serve(original_html).body)
         end
 
-        def test_dont_replace_other_assets
-          original_html = <<~HTML
-            <html>
-              <head>
-              <link rel="stylesheet" href="//cdn.shopify.com/s/files/1/0457/3256/0918/t/2/assets/theme.css" />
-                <script src="https://cdn.shopify.com/s/files/1/0457/3256/0918/t/2/assets/theme.js"></script>
-              </head>
-            </html>
-          HTML
-          assert_equal(original_html, serve(original_html).body)
-        end
-
         def test_serve_js_asset_from_cdn
           response_body = "<ASSET_FILE_FROM_CDN>" \
                           "//# sourceMappingURL=/script.js.map"


### PR DESCRIPTION
### WHY are these changes introduced?

Some assets don't load from the `LocalAssets` middleware because their path [doesn't match](https://github.com/Shopify/shopify-cli/blob/main/lib/shopify_cli/theme/dev_server/local_assets.rb#L7) or [is not a static](https://github.com/Shopify/shopify-cli/blob/main/lib/shopify_cli/theme/dev_server/local_assets.rb#L75) theme path. So, they load from the CDN, and cross-origin resource sharing errors happen.



### WHAT is this pull request doing?

Like the `CdnFonts` middleware, the `CdnAssets` requests assets to serve them locally. But, it checks if `LocalAssets` are not handling the file.



### How to test your changes?

- Run `shopify theme init` to create a new theme
- Import product data from [products.csv](https://gist.githubusercontent.com/karreiro/2cc4724245a11e2549cc7e6711def453/raw/a11c91bc0cab186af910cbd5126de24102597b34/products_export.csv) in your store
- Run `shopify theme serve`
- Interact with the **Classic Varsity Top** and observe the browser console

**Before this PR:**
<img width="1746" alt="before" src="https://user-images.githubusercontent.com/1079279/150500325-47aee8a0-3b72-4ae7-94ef-31f9119ac439.png">

**After this PR:**
<img width="1746" alt="after" src="https://user-images.githubusercontent.com/1079279/150500331-81f7d630-86ec-434f-bba8-58b4b60096cd.png">

<details><summary>Click here to check a details about the 404 error</summary>
<br>This error also happens in the preview store:
<img width="1746" alt="remote" src="https://user-images.githubusercontent.com/1079279/150500736-6d420af6-16c1-4e4c-834e-e1f58789c05f.png">
</details>



### Post-release steps

None.



### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.