### PR TITLE
Send `input.graphql` to script service

### DIFF
--- a/lib/project_types/script/graphql/app_script_set.graphql
+++ b/lib/project_types/script/graphql/app_script_set.graphql
@@ -11,6 +11,7 @@ mutation AppScriptSet(
   $configurationDefinition: String!,
   $moduleUploadUrl: String!,
   $library: LibraryInput,
+  $inputQuery: String,
 ) {
   appScriptSet(
     uuid: $uuid
@@ -25,6 +26,7 @@ mutation AppScriptSet(
     configurationDefinition: $configurationDefinition,
     moduleUploadUrl: $moduleUploadUrl,
     library: $library,
+    inputQuery: $inputQuery,
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -46,6 +46,7 @@ module Script
                 script_config: package.script_config,
                 module_upload_url: module_upload_url,
                 library: package.library,
+                input_query: script_project.input_query,
               )
               if ShopifyCLI::Environment.interactive?
                 script_project_repo.update_env(uuid: uuid)

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -16,6 +16,7 @@ module Script
         property! :language, accepts: String
 
         property :script_config, accepts: ScriptConfig
+        property :input_query, accepts: String
 
         def initialize(*)
           super

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -10,6 +10,7 @@ module Script
         property :initial_directory, accepts: String
 
         MUTABLE_ENV_VALUES = %i(uuid)
+        INPUT_QUERY_PATH = "input.graphql"
 
         def create_project_directory
           raise Infrastructure::Errors::ScriptProjectAlreadyExistsError, directory if ctx.dir_exist?(directory)
@@ -43,7 +44,7 @@ module Script
             env: project.env,
             script_name: script_name,
             extension_point_type: extension_point_type,
-            language: language
+            language: language,
           )
         end
 
@@ -56,7 +57,8 @@ module Script
             script_name: script_name,
             extension_point_type: extension_point_type,
             language: language,
-            script_config: script_config_repository.get!
+            script_config: script_config_repository.get!,
+            input_query: read_input_query,
           )
         end
 
@@ -171,6 +173,10 @@ module Script
             end
             repo
           end
+        end
+
+        def read_input_query
+          ctx.read(INPUT_QUERY_PATH) if ctx.file_exist?(INPUT_QUERY_PATH)
         end
 
         class ScriptConfigRepository

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -39,13 +39,7 @@ module Script
             language: language
           )
 
-          Domain::ScriptProject.new(
-            id: ctx.root,
-            env: project.env,
-            script_name: script_name,
-            extension_point_type: extension_point_type,
-            language: language,
-          )
+          build_script_project(script_config: nil)
         end
 
         def get
@@ -70,14 +64,7 @@ module Script
             end
           end
 
-          Domain::ScriptProject.new(
-            id: ctx.root,
-            env: project.env,
-            script_name: script_name,
-            extension_point_type: extension_point_type,
-            language: language,
-            script_config: script_config_repository.get!,
-          )
+          build_script_project
         end
 
         def create_env(api_key:, secret:, uuid:)
@@ -89,19 +76,19 @@ module Script
             }
           ).write(ctx)
 
-          Domain::ScriptProject.new(
-            id: ctx.root,
-            env: project.env,
-            script_name: script_name,
-            extension_point_type: extension_point_type,
-            language: language,
-            script_config: script_config_repository.get!,
-          )
+          build_script_project
         end
 
         def update_script_config(title:)
           script_config = script_config_repository.update!(title: title)
+          build_script_project(script_config: script_config)
+        end
 
+        private
+
+        def build_script_project(
+          script_config: script_config_repository.get!
+        )
           Domain::ScriptProject.new(
             id: ctx.root,
             env: project.env,
@@ -111,8 +98,6 @@ module Script
             script_config: script_config,
           )
         end
-
-        private
 
         def change_directory(directory:)
           ctx.chdir(directory)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -19,7 +19,8 @@ module Script
           metadata:,
           script_config:,
           module_upload_url:,
-          library:
+          library:,
+          input_query: nil
         )
           query_name = "app_script_set"
           variables = {
@@ -38,6 +39,7 @@ module Script
               language: library[:language],
               version: library[:version],
             },
+            inputQuery: input_query,
           }
           resp_hash = make_request(query_name: query_name, variables: variables)
           user_errors = resp_hash["data"]["appScriptSet"]["userErrors"]

--- a/test/project_types/script/layers/domain/script_project_test.rb
+++ b/test/project_types/script/layers/domain/script_project_test.rb
@@ -21,6 +21,7 @@ describe Script::Layers::Domain::ScriptProject do
       "title" => script_name,
     }
   end
+  let(:input_query) { "{ aField }" }
 
   describe ".new" do
     subject { Script::Layers::Domain::ScriptProject.new(**args) }
@@ -33,6 +34,7 @@ describe Script::Layers::Domain::ScriptProject do
         script_name: script_name,
         language: language,
         script_config: script_config,
+        input_query: input_query,
       }
     end
     let(:args) { all_args }
@@ -54,6 +56,7 @@ describe Script::Layers::Domain::ScriptProject do
         assert_equal script_name, subject.script_name
         assert_equal language, subject.language
         assert_equal script_config, subject.script_config
+        assert_equal input_query, subject.input_query
       end
     end
 

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -8,10 +8,10 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:instance) do
     Script::Layers::Infrastructure::ScriptProjectRepository.new(
-    ctx: ctx,
-    directory: directory,
-    initial_directory: ctx.root
-  )
+      ctx: ctx,
+      directory: directory,
+      initial_directory: ctx.root
+    )
   end
 
   let(:deprecated_ep_types) { [] }
@@ -115,11 +115,13 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     let(:current_project) do
       TestHelpers::FakeProject.new(directory: File.join(ctx.root, script_name), config: actual_config)
     end
+    let(:input_query) { nil }
 
     before do
       ShopifyCLI::Project.stubs(:has_current?).returns(true)
       ShopifyCLI::Project.stubs(:current).returns(current_project)
       ctx.write(script_config, script_config_content.to_json)
+      ctx.write("input.graphql", input_query) if input_query
     end
 
     describe "when project config is valid" do
@@ -153,6 +155,14 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         assert_equal script_config_content["version"], subject.script_config.version
         assert_equal script_config_content["version"], subject.script_config.version
         assert_equal script_config_content["configuration"].to_json, subject.script_config.configuration.to_json
+        assert_nil subject.input_query
+      end
+
+      describe "when input.graphql file is present" do
+        let(:input_query) { "{ aField }" }
+        it "populates the input_query field" do
+          assert_equal input_query, subject.input_query
+        end
       end
     end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -99,7 +99,7 @@ describe Script::Layers::Infrastructure::ScriptService do
         }
       end
 
-      it "should post the form without scope" do
+      it "returns the script's uuid" do
         assert_equal(uuid_from_server, subject)
       end
     end

--- a/test/project_types/script/test_helpers/fake_script_project_repository.rb
+++ b/test/project_types/script/test_helpers/fake_script_project_repository.rb
@@ -15,7 +15,7 @@ module TestHelpers
       @project = nil
     end
 
-    def create(script_name:, extension_point_type:, language:, env: nil)
+    def create(script_name:, extension_point_type:, language:, env: nil, input_query: nil)
       script_config = fake_script_config_repo.create({ "version" => 1, "title" => script_name })
 
       @project = Script::Layers::Domain::ScriptProject.new(
@@ -24,7 +24,8 @@ module TestHelpers
         script_name: script_name,
         extension_point_type: extension_point_type,
         language: language,
-        script_config: script_config
+        script_config: script_config,
+        input_query: input_query,
       )
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?

For fetch plans, we want to allow script authors to write a GraphQL query so that they can parametrize the input sent to their script.

### WHAT is this pull request doing?

Reads the content of `input.graphql` at the root of the script project directory, and sends it as the `inputQuery` param to script service's `appScriptSet` mutation.

I decided to not create `input.graphql` files on script create for now, because the feature isn't ready yet. It also brings a few questions that we can tackle later.

### How to test your changes?

Depending on when you're testing this, you may need to checkout `jb/fetch-plans-input-query` on script-service.

1. Create a `input.graphql` file at the root of your script project. Put whatever in there (it's not validated at the moment).
2. `shopify script push`
3. Script service's `app_scripts.input_query` should be populated with the content of `input.graphql`.

### For reviewers

Is `$root/input.graphql` a sensible location?

I also considered putting this in different location for TS and Rust, and reading the file from the `build` directory. I decided against that idea because: (1) there likely isn't 1 true place where such query would live in either TS or Rust projects, (2) it very much is a Script concept, not a language-specific concept, (3) this approach is simpler.

### Update checklist

- ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~ Not public facing yet, the GraphQL file is not automatically generated.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- ~I've included any post-release steps in the section above.~