### PR TITLE
[scripts] remove TaskRunner#compiled_type

### DIFF
--- a/lib/project_types/script/layers/application/build_script.rb
+++ b/lib/project_types/script/layers/application/build_script.rb
@@ -12,7 +12,6 @@ module Script
                   Infrastructure::PushPackageRepository.new(ctx: ctx).create_push_package(
                     script_project: script_project,
                     script_content: task_runner.build,
-                    compiled_type: task_runner.compiled_type,
                     metadata: task_runner.metadata,
                     library: library,
                   )

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -30,7 +30,6 @@ module Script
             UI::PrintingSpinner.spin(ctx, ctx.message("script.application.pushing")) do |p_ctx, spinner|
               package = Infrastructure::PushPackageRepository.new(ctx: p_ctx).get_push_package(
                 script_project: script_project,
-                compiled_type: task_runner.compiled_type,
                 metadata: task_runner.metadata,
                 library: library,
               )

--- a/lib/project_types/script/layers/domain/push_package.rb
+++ b/lib/project_types/script/layers/domain/push_package.rb
@@ -9,7 +9,6 @@ module Script
           :extension_point_type,
           :script_config,
           :script_content,
-          :compiled_type,
           :metadata,
           :library
 
@@ -18,7 +17,6 @@ module Script
           uuid:,
           extension_point_type:,
           script_content:,
-          compiled_type: nil,
           metadata:,
           script_config:,
           library:
@@ -27,7 +25,6 @@ module Script
           @uuid = uuid
           @extension_point_type = extension_point_type
           @script_content = script_content
-          @compiled_type = compiled_type
           @metadata = metadata
           @script_config = script_config
           @library = library

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -21,10 +21,6 @@ module Script
             bytecode
           end
 
-          def compiled_type
-            "wasm"
-          end
-
           def install_dependencies
             check_node_version!
 

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -22,10 +22,6 @@ module Script
             bytecode
           end
 
-          def compiled_type
-            "wasm"
-          end
-
           def install_dependencies
             check_node_version!
 

--- a/lib/project_types/script/layers/infrastructure/push_package_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/push_package_repository.rb
@@ -7,8 +7,8 @@ module Script
         include SmartProperties
         property! :ctx, accepts: ShopifyCLI::Context
 
-        def create_push_package(script_project:, script_content:, compiled_type:, metadata:, library:)
-          build_file_path = file_path(script_project.id, compiled_type)
+        def create_push_package(script_project:, script_content:, metadata:, library:)
+          build_file_path = file_path(script_project.id)
           write_to_path(build_file_path, script_content)
 
           Domain::PushPackage.new(
@@ -16,15 +16,14 @@ module Script
             uuid: script_project.uuid,
             extension_point_type: script_project.extension_point_type,
             script_content: script_content,
-            compiled_type: compiled_type,
             metadata: metadata,
             script_config: script_project.script_config,
             library: library
           )
         end
 
-        def get_push_package(script_project:, compiled_type:, metadata:, library:)
-          build_file_path = file_path(script_project.id, compiled_type)
+        def get_push_package(script_project:, metadata:, library:)
+          build_file_path = file_path(script_project.id)
           raise Domain::PushPackageNotFoundError unless ctx.file_exist?(build_file_path)
 
           script_content = ctx.binread(build_file_path)
@@ -46,8 +45,8 @@ module Script
           ctx.binwrite(path, content)
         end
 
-        def file_path(path_to_script, compiled_type)
-          "#{path_to_script}/build/script.#{compiled_type}"
+        def file_path(path_to_script)
+          "#{path_to_script}/build/script.wasm"
         end
       end
     end

--- a/test/project_types/script/layers/application/build_script_test.rb
+++ b/test/project_types/script/layers/application/build_script_test.rb
@@ -10,9 +10,8 @@ describe Script::Layers::Application::BuildScript do
     let(:script_name) { "name" }
     let(:op_failed_msg) { "msg" }
     let(:content) { "content" }
-    let(:compiled_type) { "wasm" }
     let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", false) }
-    let(:task_runner) { stub(compiled_type: compiled_type, metadata: metadata) }
+    let(:task_runner) { stub(metadata: metadata) }
     let(:script_project) { stub }
 
     let(:library_language) { "assemblyscript" }
@@ -63,7 +62,6 @@ describe Script::Layers::Application::BuildScript do
         Script::Layers::Infrastructure::PushPackageRepository.any_instance.expects(:create_push_package).with(
           script_project: script_project,
           script_content: content,
-          compiled_type: "wasm",
           metadata: metadata,
           library: library
         )

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -6,12 +6,11 @@ describe Script::Layers::Application::CreateScript do
   include TestHelpers::FakeFS
 
   let(:script_name) { "path" }
-  let(:compiled_type) { "wasm" }
 
   let(:extension_point_repository) { TestHelpers::FakeExtensionPointRepository.new }
   let(:script_project_repository) { TestHelpers::FakeScriptProjectRepository.new(context) }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
-  let(:task_runner) { stub(compiled_type: compiled_type) }
+  let(:task_runner) { stub }
 
   let(:language) { "assemblyscript" }
   let(:extension_point_type) { "payment-methods" }

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -5,7 +5,6 @@ require "project_types/script/test_helper"
 describe Script::Layers::Application::PushScript do
   include TestHelpers::FakeFS
 
-  let(:compiled_type) { "wasm" }
   let(:api_key) { "api_key" }
   let(:force) { true }
   let(:use_msgpack) { true }
@@ -33,7 +32,7 @@ describe Script::Layers::Application::PushScript do
   let(:push_package_repository) { TestHelpers::FakePushPackageRepository.new }
   let(:extension_point_repository) { TestHelpers::FakeExtensionPointRepository.new }
   let(:script_project_repository) { TestHelpers::FakeScriptProjectRepository.new }
-  let(:task_runner) { stub(compiled_type: "wasm", metadata: metadata, library_version: library_version) }
+  let(:task_runner) { stub(metadata: metadata, library_version: library_version) }
   let(:ep) { extension_point_repository.get_extension_point(extension_point_type) }
   let(:uuid) { "uuid" }
   let(:url) { "https://some-bucket" }
@@ -52,7 +51,6 @@ describe Script::Layers::Application::PushScript do
     push_package_repository.create_push_package(
       script_project: script_project,
       script_content: "content",
-      compiled_type: compiled_type,
       metadata: metadata,
       library: library
     )

--- a/test/project_types/script/layers/domain/push_package_test.rb
+++ b/test/project_types/script/layers/domain/push_package_test.rb
@@ -10,7 +10,6 @@ describe Script::Layers::Domain::PushPackage do
   let(:api_key) { "fake_key" }
   let(:force) { false }
   let(:script_content) { "(module)" }
-  let(:compiled_type) { "wasm" }
   let(:metadata) { Script::Layers::Domain::Metadata.new("1", "0", true) }
   let(:library_language) { "assemblyscript" }
   let(:library_version) { "1.0.0" }
@@ -27,7 +26,6 @@ describe Script::Layers::Domain::PushPackage do
       extension_point_type: extension_point_type,
       script_config: script_config,
       script_content: script_content,
-      compiled_type: compiled_type,
       metadata: metadata,
       library: library
     )
@@ -44,7 +42,6 @@ describe Script::Layers::Domain::PushPackage do
       assert_equal extension_point_type, subject.extension_point_type
       assert_equal script_config, subject.script_config
       assert_equal script_content, subject.script_content
-      assert_equal compiled_type, subject.compiled_type
       assert_equal metadata, subject.metadata
       assert_equal library, subject.library
     end

--- a/test/project_types/script/test_helpers/fake_push_package_repository.rb
+++ b/test/project_types/script/test_helpers/fake_push_package_repository.rb
@@ -9,27 +9,25 @@ module TestHelpers
     def create_push_package(
       script_project:,
       script_content:,
-      compiled_type:,
       metadata:,
       library:
     )
-      id = id(script_project.script_name, compiled_type)
+      id = id(script_project.script_name)
       @cache[id] = Script::Layers::Domain::PushPackage.new(
         id: id,
         uuid: script_project.uuid,
         extension_point_type: script_project.extension_point_type,
         script_content: script_content,
-        compiled_type: compiled_type,
         metadata: metadata,
         script_config: script_project.script_config,
         library: library
       )
     end
 
-    def get_push_package(script_project:, compiled_type:, metadata:, library:)
+    def get_push_package(script_project:, metadata:, library:)
       _ = metadata
       _ = library
-      id = id(script_project.script_name, compiled_type)
+      id = id(script_project.script_name)
       if @cache.key?(id)
         @cache[id]
       else
@@ -39,8 +37,8 @@ module TestHelpers
 
     private
 
-    def id(script_name, compiled_type)
-      "#{script_name}.#{compiled_type}"
+    def id(script_name)
+      "#{script_name}.wasm"
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up from https://github.com/Shopify/shopify-cli/pull/1936#discussion_r789967471

The `compiled_type` method in our task_runners are not very useful anymore. It used to be there when we needed to support non-wasm executables (graalVM + static), but the CLI has no more knowledge of those types. 

The only thing that still uses the `compiled_type` method is the `push_package_repository`. Instead of the task_runner having to know the `compiled_type` and pass it into the `push_package_repository` everytime, its cheaper and simpler to assume we are working with `wasm`, so I hardcoded `wasm` in the `push_package_repository`. If we ever need to support non-wasm executables then this is easy to revert, but we will also probably have to change many other things first so this change doesn't matter much.

### How to test your changes?

Try pushing a script and make sure it succeeds.

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.