### PR TITLE
Update system.rb

### DIFF
--- a/vendor/deps/cli-kit/lib/cli/kit/system.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/system.rb
@@ -177,6 +177,8 @@ module CLI
           return :mac if /darwin/.match(RUBY_PLATFORM)
           return :linux if /linux/.match(RUBY_PLATFORM)
           return :windows if /mingw32/.match(RUBY_PLATFORM)
+           return :windows if /mingw/.match(RUBY_PLATFORM)
+  
 
           raise "Could not determine OS from platform #{RUBY_PLATFORM}"
         end


### PR DESCRIPTION
Second Error : 

>shopify login
X An unexpected error occured.
        To submit an issue include the stack trace.

C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/shopify-cli-2.10.0/vendor/deps/cli-kit/lib/cli/kit/system.rb:181:in `os': Could not determine OS from platform x64-mingw-ucrt (RuntimeError)
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/shopify-cli-2.10.0/vendor/deps/cli-kit/lib/cli/kit/system.rb:211:in `resolve_path'
        from C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/shopify-cli-2.10.0/vendor/deps/cli-kit/lib/cli/kit/system.rb:126:in `system'


After this shopify login working fine  in windows 64 bits operating system

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.