### PR TITLE
Revert "Revert "[Scripts] Limit module file size""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+* [#1928](https://github.com/Shopify/shopify-cli/pull/1928): Ensure script Wasm file sizes don't exceed the limit
 
 ## Version 2.10.1
 ### Fixed

--- a/lib/project_types/script/graphql/module_upload_url_generate.graphql
+++ b/lib/project_types/script/graphql/module_upload_url_generate.graphql
@@ -1,6 +1,10 @@
 mutation moduleUploadUrlGenerate {
   moduleUploadUrlGenerate {
-    url
+    details {
+      url
+      headers
+      humanizedMaxSize
+    }
     userErrors {
       field
       message

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -159,6 +159,15 @@ module Script
         class ScriptUploadError < ScriptProjectError; end
         class ProjectConfigNotFoundError < ScriptProjectError; end
         class InvalidProjectConfigError < ScriptProjectError; end
+
+        class ScriptTooLargeError < ScriptProjectError
+          attr_reader :max_size
+
+          def initialize(max_size)
+            super()
+            @max_size = max_size
+          end
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -95,14 +95,16 @@ module Script
           response["data"]["appScripts"]
         end
 
-        def generate_module_upload_url
+        def generate_module_upload_details
           query_name = "module_upload_url_generate"
           variables = {}
           response = make_request(query_name: query_name, variables: variables)
           user_errors = response["data"]["moduleUploadUrlGenerate"]["userErrors"]
 
           raise Errors::GraphqlError, user_errors if user_errors.any?
-          response["data"]["moduleUploadUrlGenerate"]["url"]
+
+          data = response["data"]["moduleUploadUrlGenerate"]["details"]
+          { url: data["url"], headers: data["headers"], max_size: data["humanizedMaxSize"] }
         end
 
         private

--- a/lib/project_types/script/layers/infrastructure/script_uploader.rb
+++ b/lib/project_types/script/layers/infrastructure/script_uploader.rb
@@ -7,19 +7,32 @@ module Script
         end
 
         def upload(script_content)
-          @script_service.generate_module_upload_url.tap do |url|
-            url = URI(url)
+          upload_details = @script_service.generate_module_upload_details
+          url = URI(upload_details[:url])
 
-            https = Net::HTTP.new(url.host, url.port)
-            https.use_ssl = true
+          https = Net::HTTP.new(url.host, url.port)
+          https.use_ssl = true
 
-            request = Net::HTTP::Put.new(url)
-            request["Content-Type"] = "application/wasm"
-            request.body = script_content
+          request = Net::HTTP::Put.new(url)
+          request["Content-Type"] = "application/wasm"
 
-            response = https.request(request)
-            raise Errors::ScriptUploadError unless response.code == "200"
+          upload_details[:headers].each do |header, value|
+            request[header] = value
           end
+
+          request.body = script_content
+
+          response = https.request(request)
+          raise Errors::ScriptTooLargeError, upload_details[:max_size] if script_too_large?(response)
+          raise Errors::ScriptUploadError unless response.code == "200"
+
+          upload_details[:url]
+        end
+
+        private
+
+        def script_too_large?(response)
+          response.code == "400" && response.body.include?("EntityTooLarge")
         end
       end
     end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -140,6 +140,9 @@ module Script
           script_upload_cause: "Fail to upload script.",
           script_upload_help: "Try again.",
 
+          script_too_large_cause: "The size of your Wasm binary file is too large.",
+          script_too_large_help: "It must be less than %{max_size}.",
+
           api_library_not_found_cause: "Script can't be created because API library %{library_name} is missing from the dependencies",
           api_library_not_found_help: "This error can occur because the API library was removed from your system or there is a problem with dependencies in the repository.",
 

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -251,6 +251,11 @@ module Script
             cause_of_error: ShopifyCLI::Context.message("script.error.script_upload_cause"),
             help_suggestion: ShopifyCLI::Context.message("script.error.script_upload_help"),
           }
+        when Layers::Infrastructure::Errors::ScriptTooLargeError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.script_too_large_cause"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.script_too_large_help", max_size: e.max_size),
+          }
         when Layers::Infrastructure::Errors::APILibraryNotFoundError
           {
             cause_of_error: ShopifyCLI::Context

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -332,15 +332,21 @@ describe Script::Layers::Infrastructure::ScriptService do
     end
   end
 
-  describe ".generate_module_upload_url" do
+  describe ".generate_module_upload_details" do
     let(:user_errors) { [] }
     let(:url) { nil }
+    let(:headers) { {} }
+    let(:humanized_max_size) { "" }
     let(:response) do
       {
         "data" => {
           "moduleUploadUrlGenerate" => {
-            "url" => url,
             "userErrors" => user_errors,
+            "details" => {
+              "headers" => headers,
+              "url" => url,
+              "humanizedMaxSize" => humanized_max_size,
+            },
           },
         },
       }
@@ -350,13 +356,23 @@ describe Script::Layers::Infrastructure::ScriptService do
       api_client.stubs(:query).returns(response)
     end
 
-    subject { script_service.generate_module_upload_url }
+    subject { script_service.generate_module_upload_details }
 
     describe "when a url can be generated" do
       let(:url) { "http://fake.com" }
+      let(:headers) { { "header" => "value" } }
+      let(:humanized_max_size) { "123 Bytes" }
 
       it "returns a url" do
-        assert_equal url, subject
+        assert_equal url, subject[:url]
+      end
+
+      it "returns headers" do
+        assert_equal headers, subject[:headers]
+      end
+
+      it "returns max size" do
+        assert_equal humanized_max_size, subject[:max_size]
       end
     end
 

--- a/test/project_types/script/layers/infrastructure/script_uploader_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_uploader_test.rb
@@ -6,11 +6,17 @@ describe Script::Layers::Infrastructure::ScriptUploader do
     let(:instance) { Script::Layers::Infrastructure::ScriptUploader.new(script_service) }
     let(:script_content) { "(module)" }
     let(:url) { "https://some-bucket" }
+    let(:headers) { { "header" => "value" } }
+    let(:max_size) { "1234 Bytes" }
 
     subject { instance.upload(script_content) }
 
     before do
-      script_service.expects(:generate_module_upload_url).returns(url)
+      script_service.expects(:generate_module_upload_details).returns({
+        url: url,
+        headers: headers,
+        max_size: max_size,
+      })
     end
 
     describe "when fail to upload module" do
@@ -23,6 +29,24 @@ describe Script::Layers::Infrastructure::ScriptUploader do
 
       it "should raise an ScriptUploadError" do
         assert_raises(Script::Layers::Infrastructure::Errors::ScriptUploadError) { subject }
+      end
+    end
+
+    describe "when Wasm is too large" do
+      before do
+        stub_request(:put, url).with(
+          headers: { "Content-Type" => "application/wasm" },
+          body: script_content
+        ).to_return(
+          status: 400,
+          body: "<?xml version='1.0' encoding='UTF-8'?><Error><Code>EntityTooLarge</Code><Message>Your proposed " \
+            "upload is larger than the maximum object size specified in your Policy Document.</Message><Details>" \
+            "Content-length exceeds upper bound on range</Details></Error>",
+        )
+      end
+
+      it "should raise an ScriptTooLargeError" do
+        assert_raises(Script::Layers::Infrastructure::Errors::ScriptTooLargeError) { subject }
       end
     end
 


### PR DESCRIPTION
Reverts Shopify/shopify-cli#1955, effectively shipping [this PR](https://github.com/Shopify/shopify-cli/pull/1928) again.

This PR depends on the [backend PR](https://github.com/Shopify/script-service/pull/4158) being shipped around the same time. Because of this, when I originally merged it early, it broke dev for Scripts folks. The plan is to ship it tomorrow afternoon (Friday January 28) to be included in Monday's CLI release. The backend will be shipped when the CLI is released.