### PR TITLE
use correct message key for script connect

### DIFF
--- a/lib/project_types/script/commands/connect.rb
+++ b/lib/project_types/script/commands/connect.rb
@@ -12,7 +12,7 @@ module Script
       end
 
       def self.help
-        ShopifyCLI::Context.new.message("connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
+        ShopifyCLI::Context.new.message("script.connect.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/4201

### WHAT is this pull request doing?

Currently, the `shopify script connect --help` commands outputs the string for "extensions", but we have a specific one available for scripts.

This PR uses the correct string.

### How to test your changes?

- Run `shopify script connect --help`.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.