### PR TITLE
Added Windows install instructions to Shopify-CLI Installation Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+* [#1989](https://github.com/Shopify/shopify-cli/pull/1989): Added windows installation documentation more clear when installing pre-requisites needed.
 * [#1928](https://github.com/Shopify/shopify-cli/pull/1928): Ensure script Wasm file sizes don't exceed the limit
 
 ## Version 2.10.1

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -12,7 +12,7 @@ $ gem install shopify-cli
 
 - Go to the [Ruby Intstaller Kit](https://rubyinstaller.org/downloads/) download the latest version.
 - Run installer leave all boxes checked. Make sure to associate install with **PATH** Environment variable.
-- *A PC restart my be required* - Restart the terminal or PowerShell in *admin mode*.
+- *A PC restart may be required* - Restart the terminal or PowerShell in *admin mode*.
 - Run `gem install shopify-cli` 
 - After the installation is completed, run `shopify version`, if this outputs a version number you've successfully installed the CLI.
 - If a runtime issue occurs after the run of the command please refer to issue [#1990](https://github.com/Shopify/shopify-cli/issues/1990).

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -23,6 +23,7 @@ $ gem install shopify-cli
 - Run `brew tap shopify/shopify`
 - Run `brew install shopify-cli`
 - After the installation is completed, run `shopify version`, if this outputs a version number you've successfully installed the CLI.
+- If a runtime issue occurs after the run of the command please refer to issue [#1990](https://github.com/Shopify/shopify-cli/issues/1990).
 
 ### To upgrade Shopify CLI
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -8,6 +8,14 @@ The easiest method to install the Shopify CLI is through RubyGems:
 $ gem install shopify-cli
 ```
 
+## Installation for Windows Users
+
+- Go to the [Ruby Intstaller Kit](https://rubyinstaller.org/downloads/) download the latest version.
+- Run installer leave all boxes checked. Make sure to associate install with **PATH** Environment variable.
+- *A PC restart my be required* - Restart the terminal or PowerShell in *admin mode*.
+- Run `gem install shopify-cli` 
+- After the installation is completed, run `shopify version`, if this outputs a version number you've successfully installed the CLI.
+
 ## Installation for macOS Users
 
 - Make sure you have [Homebrew](https://brew.sh/) installed

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -15,6 +15,7 @@ $ gem install shopify-cli
 - *A PC restart my be required* - Restart the terminal or PowerShell in *admin mode*.
 - Run `gem install shopify-cli` 
 - After the installation is completed, run `shopify version`, if this outputs a version number you've successfully installed the CLI.
+- If a runtime issue occurs after the run of the command please refer to issue [#1990](https://github.com/Shopify/shopify-cli/issues/1990).
 
 ## Installation for macOS Users
 
@@ -23,7 +24,6 @@ $ gem install shopify-cli
 - Run `brew tap shopify/shopify`
 - Run `brew install shopify-cli`
 - After the installation is completed, run `shopify version`, if this outputs a version number you've successfully installed the CLI.
-- If a runtime issue occurs after the run of the command please refer to issue [#1990](https://github.com/Shopify/shopify-cli/issues/1990).
 
 ### To upgrade Shopify CLI
 


### PR DESCRIPTION
RubyGems does not specify installation for windows users who have no experience with ruby. Added installation instructions to be more specific.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
 
Clearer installation process for windows users.

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Updating installation documentation for windows users and nothing is specified on how to install RubyGems on their site with windows. As it's only for Linux Kernel-based systems.


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
N.A - Just easy steps to follow for windows users.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps
N.A


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x]  I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.