### PR TITLE
Exchange the token exposed through environment variables before using it

### DIFF
--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -81,7 +81,6 @@ module ShopifyCLI
     def exchange_partners_auth_token(subject_token)
       application = "partners"
       request_exchange_token(
-        name: application,
         audience: client_id_for_application(application),
         additional_scopes: APPLICATION_SCOPES[application],
         subject_token: subject_token,
@@ -212,17 +211,16 @@ module ShopifyCLI
     def request_and_save_exchange_token(name, audience, additional_scopes)
       return if name == "shopify" && !store.exists?(:shop)
       access_token = request_exchange_token(
-        name: name,
         audience: audience,
         additional_scopes: additional_scopes,
         subject_token: store.get(:identity_access_token),
-        destination: (name == "shopify") ? "https://#{store.get(:shop)}/admin" : nil
+        destination: name == "shopify" ? "https://#{store.get(:shop)}/admin" : nil
       )
       store.set("#{name}_exchange_token".to_sym => access_token)
       ctx.debug("#{name}_exchange_token: " + access_token)
     end
 
-    def request_exchange_token(name:, audience:, additional_scopes:, subject_token:, destination: nil)
+    def request_exchange_token(audience:, additional_scopes:, subject_token:, destination: nil)
       params = {
         grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
         requested_token_type: "urn:ietf:params:oauth:token-type:access_token",

--- a/lib/shopify_cli/partners_api.rb
+++ b/lib/shopify_cli/partners_api.rb
@@ -60,9 +60,10 @@ module ShopifyCLI
       private
 
       def api_client(ctx)
+        identity_auth = ShopifyCLI::IdentityAuth.new(ctx: ctx)
         new(
           ctx: ctx,
-          token: IdentityAuth.fetch_or_auth_partners_token(ctx: ctx),
+          token: identity_auth.fetch_or_auth_partners_token,
           url: "https://#{Environment.partners_domain}/api/cli/graphql",
         )
       end

--- a/test/shopify-cli/identity_auth_test.rb
+++ b/test/shopify-cli/identity_auth_test.rb
@@ -176,6 +176,23 @@ module ShopifyCLI
       )
     end
 
+    def test_fetch_or_auth_partners_token_when_environment_auth_token
+      # Given
+      env_auth_token = "token"
+      exchanged_token = "exchanged_token"
+      Environment.stubs(:auth_token).returns(env_auth_token)
+      stub_exchange_token_calls(
+        exchange_token: exchanged_token,
+        access_token: env_auth_token
+      )
+
+      # When
+      got = identity_auth_client.fetch_or_auth_partners_token
+
+      # Then
+      assert_equal "partners" + exchanged_token, got
+    end
+
     private
 
     def assert_expected_exchange_tokens(token_suffix:, client:)

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -19,7 +19,6 @@ module ShopifyCLI
 
     def test_query_fails_gracefully_when_unable_to_authenticate
       Shopifolk.stubs(:check).returns(false)
-      IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
@@ -31,10 +30,11 @@ module ShopifyCLI
 
       @identity_auth_client = mock
       ShopifyCLI::IdentityAuth
-        .expects(:new)
+        .stubs(:new)
         .with(ctx: @context).returns(@identity_auth_client)
       @identity_auth_client
         .expects(:reauthenticate)
+      @identity_auth_client.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
         PartnersAPI.query(@context, "query")

--- a/test/shopify-cli/partners_api_test.rb
+++ b/test/shopify-cli/partners_api_test.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     include TestHelpers::Project
 
     def test_query_calls_partners_api
-      IdentityAuth.expects(:fetch_or_auth_partners_token).with(ctx: @context).returns("token123")
+      IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
@@ -19,7 +19,7 @@ module ShopifyCLI
 
     def test_query_fails_gracefully_when_unable_to_authenticate
       Shopifolk.stubs(:check).returns(false)
-      IdentityAuth.expects(:fetch_or_auth_partners_token).with(ctx: @context).returns("token123").twice
+      IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
@@ -48,7 +48,7 @@ module ShopifyCLI
     end
 
     def test_query_fails_gracefully_without_partners_account
-      IdentityAuth.expects(:fetch_or_auth_partners_token).with(ctx: @context).returns("token123")
+      IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       api_stub = stub
       PartnersAPI.expects(:new).with(
@@ -62,7 +62,7 @@ module ShopifyCLI
     end
 
     def test_query
-      IdentityAuth.expects(:fetch_or_auth_partners_token).with(ctx: @context).returns("token123")
+      IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("token123")
 
       api_stub = stub
       PartnersAPI.expects(:new).with(

--- a/test/test_helpers/partners.rb
+++ b/test/test_helpers/partners.rb
@@ -2,7 +2,7 @@
 module TestHelpers
   module Partners
     def setup
-      ShopifyCLI::IdentityAuth.stubs(:fetch_or_auth_partners_token).returns("faketoken")
+      ShopifyCLI::IdentityAuth.any_instance.stubs(:fetch_or_auth_partners_token).returns("faketoken")
       super
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?
We were trying to use the token generated by partners directly and it didn't work. The reason being is that the token has the right audience, `partners`, but the client, `partners`, can't be use from a different client `shopify-cli`.

### WHAT is this pull request doing?
This PR changes the workflow to exchange the token before using it. That'll give us a token that can be used from the `shopify-cli`.

### How to test your changes?
1. Authenticate with the CLI.
2. Open a console with `bin/console`.
3. Run `ShopifyCLI::IdentityAuth.new(ctx: ShopifyCLI::Context.new).exchange_partners_auth_token(ShopifyCLI::DB.new.get(:identity_access_token))`
4. You should get a refreshed token the current local `:identity_access_token`.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.