### PR TITLE
Rename shopifile.yml to extension.config.yml

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -108,7 +108,7 @@ module Extension
         end
 
         def server_config_file
-          "shopifile.yml"
+          "extension.config.yml"
         end
 
         protected

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -41,7 +41,7 @@ module Extension
       end
 
       def test_runs_new_flow_if_development_server_supported
-        config_file = "shopifile.yml"
+        config_file = "extension.config.yml"
         type = "CHECKOUT_UI_EXTENSION"
         stub_project(type)
 


### PR DESCRIPTION
### WHY are these changes introduced?

For backwards compatibility reasons, we're renaming `shopifile.yml` to `extension.config.yml`. That's the name of the config that most extensions use today.

### WHAT is this pull request doing?

Changing the default values for the config file name for extensions from `shopifile.yml` to `extension.config.yml`.

### How to test your changes?

1. Ensure you have `shopify-extensions-cli` installed
    * `dev clone shopify-cli-extensions`
    * `make build`
    * `cd packages/shopify-cli-extensions && npm link`
2. Enable the development server beta: `shopify-local config feature extension_server_beta --enable`
3. Create a new extension with `shopify extension create`
4. Ensure that `extension.config.yml` exists and that `shopifile.yml` is absent
5. Run `npm link @shopify/shopify-cli-extensions`
6. Run `shopify extension build`
7. Ensure that the command finished successful and produced `build/main.js`

### Post-release steps

Since this is currently all behind a feature flag, no post installation steps are required.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.