### PR TITLE
Default build_dir for extensions

### DIFF
--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -17,6 +17,8 @@ module Extension
       property  :tunnel_url, accepts: String
       property! :type, accepts: String
 
+      DEFAULT_BUILD_DIR = "build"
+
       def self.call(*args)
         new(*args).call
       end
@@ -31,7 +33,7 @@ module Extension
           type: type.upcase,
           user: Models::ServerConfig::User.new,
           development: Models::ServerConfig::Development.new(
-            build_dir: hash.dig("development", "build_dir"),
+            build_dir: hash.dig("development", "build_dir") || DEFAULT_BUILD_DIR,
             renderer: renderer,
             entries: Models::ServerConfig::DevelopmentEntries.new(
               main: hash.dig("development", "entries", "main")

--- a/test/project_types/extension/tasks/convert_server_config_test.rb
+++ b/test/project_types/extension/tasks/convert_server_config_test.rb
@@ -41,6 +41,24 @@ module Extension
         assert_equal(expected.to_hash, extension.to_hash)
       end
 
+      def test_server_config_converter_sets_default_build_directory
+        @config_file["development"].delete("build_dir")
+
+        result = Tasks::ConvertServerConfig.call(
+          api_key: @api_key,
+          context: @fake_context,
+          hash: @config_file,
+          registration_uuid: @registration_uuid,
+          store: @store,
+          title: @title,
+          tunnel_url: @tunnel_url,
+          type: @type
+        )
+
+        extension = result.extensions.first
+        assert_equal("build", extension.to_hash.dig("development", "build_dir"))
+      end
+
       def test_resource_url_included_if_one_given
         resource_url = "/cart/1:1"
         result = Tasks::ConvertServerConfig.call(


### PR DESCRIPTION
### WHY are these changes introduced?

To retain backwards compatibility and keep the `shopifile.yml` as slim as possible.

### WHAT is this pull request doing?

Make specifying the `build_dir` in the `shopifile.yml` optional. Default to `build`.

### How to test your changes?

1. Ensure you have `shopify-extensions-cli` installed
    * `dev clone shopify-cli-extensions`
    * `make build`
    * `cd packages/shopify-cli-extensions && npm link`
2. Enable the development server beta: `shopify-local config feature extension_server_beta --enable`
3. Create a new extension with `shopify extension create`
4. Remove the `build_dir` entry from `shopifile.yml`
5. Run `npm link @shopify/shopify-cli-extensions`
6. Run `shopify extension build`
7. Ensure that the command finished successful and produced `build/main.js`

### Post-release steps

None – all of this is still behind a feature flag.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.
