### PR TITLE
add task_runner interface

### DIFF
--- a/lib/project_types/script/layers/application/create_script.rb
+++ b/lib/project_types/script/layers/application/create_script.rb
@@ -47,7 +47,7 @@ module Script
           private
 
           def install_dependencies(ctx, language, script_name, project_creator)
-            task_runner = Infrastructure::Languages::TaskRunner.for(ctx, language, script_name)
+            task_runner = Infrastructure::Languages::TaskRunner.for(ctx, language)
             CLI::UI::Frame.open(ctx.message(
               "core.git.pulling_from_to",
               project_creator.sparse_checkout_repo,

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -10,7 +10,7 @@ module Script
             script_project = script_project_repo.get
             script_project.env = project.env
             task_runner = Infrastructure::Languages::TaskRunner
-              .for(ctx, script_project.language, script_project.script_name)
+              .for(ctx, script_project.language)
 
             extension_point = ExtensionPoints.get(type: script_project.extension_point_type)
 

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -4,14 +4,14 @@ module Script
   module Layers
     module Infrastructure
       module Languages
-        class AssemblyScriptTaskRunner
+        class AssemblyScriptTaskRunner < TaskRunner
           BYTECODE_FILE = "build/script.wasm"
           METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
 
           attr_reader :ctx, :script_name
 
-          def initialize(ctx, script_name)
+          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
             @ctx = ctx
             @script_name = script_name
           end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -9,13 +9,6 @@ module Script
           METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
 
-          attr_reader :ctx, :script_name
-
-          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
-            @ctx = ctx
-            @script_name = script_name
-          end
-
           def build
             compile
             bytecode

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -5,6 +5,8 @@ module Script
     module Infrastructure
       module Languages
         class TaskRunner
+          attr_reader :ctx, :script_name
+
           def self.for(ctx, language, script_name)
             task_runners = {
               "assemblyscript" => AssemblyScriptTaskRunner,
@@ -14,6 +16,11 @@ module Script
 
             raise Errors::TaskRunnerNotFoundError unless task_runners[language]
             task_runners[language].new(ctx, script_name)
+          end
+
+          def initialize(ctx, script_name)
+            @ctx = ctx
+            @script_name = script_name
           end
 
           def build

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -32,7 +32,7 @@ module Script
             raise NotImplementedError
           end
 
-          def library_version(_library_version)
+          def library_version(_library_name)
             raise NotImplementedError
           end
         end

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -5,15 +5,35 @@ module Script
     module Infrastructure
       module Languages
         class TaskRunner
-          TASK_RUNNERS = {
-            "assemblyscript" => AssemblyScriptTaskRunner,
-            "typescript" => TypeScriptTaskRunner,
-            "wasm" => WasmTaskRunner,
-          }
-
           def self.for(ctx, language, script_name)
-            raise Errors::TaskRunnerNotFoundError unless TASK_RUNNERS[language]
-            TASK_RUNNERS[language].new(ctx, script_name)
+            task_runners = {
+              "assemblyscript" => AssemblyScriptTaskRunner,
+              "typescript" => TypeScriptTaskRunner,
+              "wasm" => WasmTaskRunner,
+            }
+
+            raise Errors::TaskRunnerNotFoundError unless task_runners[language]
+            task_runners[language].new(ctx, script_name)
+          end
+
+          def build
+            raise NotImplementedError
+          end
+
+          def dependencies_installed?
+            raise NotImplementedError
+          end
+
+          def install_dependencies
+            raise NotImplementedError
+          end
+
+          def metadata_file_location
+            raise NotImplementedError
+          end
+
+          def library_version(_library_version)
+            raise NotImplementedError
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -5,9 +5,9 @@ module Script
     module Infrastructure
       module Languages
         class TaskRunner
-          attr_reader :ctx, :script_name
+          attr_reader :ctx
 
-          def self.for(ctx, language, script_name)
+          def self.for(ctx, language)
             task_runners = {
               "assemblyscript" => AssemblyScriptTaskRunner,
               "typescript" => TypeScriptTaskRunner,
@@ -15,12 +15,11 @@ module Script
             }
 
             raise Errors::TaskRunnerNotFoundError unless task_runners[language]
-            task_runners[language].new(ctx, script_name)
+            task_runners[language].new(ctx)
           end
 
-          def initialize(ctx, script_name)
+          def initialize(ctx)
             @ctx = ctx
-            @script_name = script_name
           end
 
           def build

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -4,7 +4,7 @@ module Script
   module Layers
     module Infrastructure
       module Languages
-        class TypeScriptTaskRunner
+        class TypeScriptTaskRunner < TaskRunner
           BYTECODE_FILE = "build/index.wasm"
           METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
@@ -12,7 +12,7 @@ module Script
 
           attr_reader :ctx, :script_name
 
-          def initialize(ctx, script_name)
+          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
             @ctx = ctx
             @script_name = script_name
           end

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -10,13 +10,6 @@ module Script
           SCRIPT_SDK_BUILD = "npm run build"
           GEN_METADATA = "npm run gen-metadata"
 
-          attr_reader :ctx, :script_name
-
-          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
-            @ctx = ctx
-            @script_name = script_name
-          end
-
           def build
             compile
             bytecode

--- a/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
@@ -4,17 +4,21 @@ module Script
   module Layers
     module Infrastructure
       module Languages
-        class WasmTaskRunner
+        class WasmTaskRunner < TaskRunner
           BYTECODE_FILE = "script.wasm"
           attr_reader :ctx, :script_name
 
-          def initialize(ctx, script_name)
+          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
             @ctx = ctx
             @script_name = script_name
           end
 
           def dependencies_installed?
             true
+          end
+
+          def install_dependencies
+            nil
           end
 
           def library_version(_library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
@@ -17,9 +17,7 @@ module Script
             true
           end
 
-          def install_dependencies
-            nil
-          end
+          def install_dependencies; end
 
           def library_version(_library_name)
             nil

--- a/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/wasm_task_runner.rb
@@ -6,12 +6,6 @@ module Script
       module Languages
         class WasmTaskRunner < TaskRunner
           BYTECODE_FILE = "script.wasm"
-          attr_reader :ctx, :script_name
-
-          def initialize(ctx, script_name) # rubocop:disable Lint/MissingSuper
-            @ctx = ctx
-            @script_name = script_name
-          end
 
           def dependencies_installed?
             true

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -40,7 +40,7 @@ describe Script::Layers::Application::CreateScript do
     extension_point_repository.create_extension_point(extension_point_type)
     Script::Layers::Infrastructure::Languages::TaskRunner
       .stubs(:for)
-      .with(context, language, script_name)
+      .with(context, language)
       .returns(task_runner)
     Script::Layers::Infrastructure::Languages::ProjectCreator
       .stubs(:for)

--- a/test/project_types/script/layers/application/push_script_test.rb
+++ b/test/project_types/script/layers/application/push_script_test.rb
@@ -53,7 +53,7 @@ describe Script::Layers::Application::PushScript do
     Script::Layers::Infrastructure::MetadataRepository.stubs(:new).returns(metadata_repository)
     Script::Layers::Infrastructure::Languages::TaskRunner
       .stubs(:for)
-      .with(@context, library_language, script_name)
+      .with(@context, library_language)
       .returns(task_runner)
     ShopifyCLI::Environment.stubs(:interactive?).returns(true)
 

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -7,7 +7,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
 
   let(:ctx) { TestHelpers::FakeContext.new }
   let(:script_id) { "id" }
-  let(:script_name) { "foo" }
   let(:extension_point_config) do
     {
       "assemblyscript" => {
@@ -18,7 +17,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
   end
   let(:extension_point_type) { "discount" }
   let(:language) { "assemblyscript" }
-  let(:as_task_runner) { Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.new(ctx, script_name) }
+  let(:as_task_runner) { Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.new(ctx) }
   let(:command_runner) { Script::Layers::Infrastructure::CommandRunner }
 
   let(:package_json) do

--- a/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
@@ -4,8 +4,7 @@ require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::Languages::TaskRunner do
   describe "build" do
-    let(:script_name) { "script_name" }
-    subject { Script::Layers::Infrastructure::Languages::TaskRunner.for(@context, language, script_name) }
+    subject { Script::Layers::Infrastructure::Languages::TaskRunner.for(@context, language) }
 
     describe "when the script language and compile type match an entry in the registry" do
       let(:language) { "assemblyscript" }
@@ -13,7 +12,7 @@ describe Script::Layers::Infrastructure::Languages::TaskRunner do
       it "should return the entry from the registry" do
         Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner
           .expects(:new)
-          .with(@context, script_name)
+          .with(@context)
         subject
       end
     end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -5,10 +5,9 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
   include TestHelpers::FakeFS
 
   let(:ctx) { TestHelpers::FakeContext.new }
-  let(:script_name) { "foo" }
   let(:language) { "TypeScript" }
   let(:library_name) { "@shopify/extension-point-as-fake" }
-  let(:runner) { Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.new(ctx, script_name) }
+  let(:runner) { Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.new(ctx) }
   let(:command_runner) { Script::Layers::Infrastructure::CommandRunner }
   let(:package_json) do
     {

--- a/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
@@ -25,6 +25,14 @@ describe Script::Layers::Infrastructure::Languages::WasmTaskRunner do
     end
   end
 
+  describe ".install_dependencies" do
+    subject { runner.install_dependencies }
+
+    it "should always return nil" do
+      assert_nil subject
+    end
+  end
+
   describe ".metadata_file_location" do
     subject { runner.metadata_file_location }
 

--- a/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/wasm_task_runner_test.rb
@@ -5,9 +5,8 @@ describe Script::Layers::Infrastructure::Languages::WasmTaskRunner do
   include TestHelpers::FakeFS
 
   let(:ctx) { TestHelpers::FakeContext.new }
-  let(:script_name) { "foo" }
   let(:library_name) { nil }
-  let(:runner) { Script::Layers::Infrastructure::Languages::WasmTaskRunner.new(ctx, script_name) }
+  let(:runner) { Script::Layers::Infrastructure::Languages::WasmTaskRunner.new(ctx) }
 
   describe ".dependencies_installed?" do
     subject { runner.dependencies_installed? }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/2796

### WHAT is this pull request doing?

Converts the base task_runner into more of an interface and then makes the specific_task_runners inherit from it.

### How to test your changes?

Create / Push a script to ensure it all still works.
There's no real behaviour modification here.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.