### PR TITLE
env vars are strings not arrays

### DIFF
--- a/vendor/deps/cli-kit/lib/cli/kit/system.rb
+++ b/vendor/deps/cli-kit/lib/cli/kit/system.rb
@@ -227,7 +227,7 @@ module CLI
         end
 
         def which(cmd, env)
-          exts = os == :windows ? env.fetch('PATHEXT', ['']).split(';') : ['']
+          exts = (os == :windows && env['PATHEXT']&.split(';')) || ['']
           env.fetch('PATH', '').split(File::PATH_SEPARATOR).each do |path|
             exts.each do |ext|
               exe = File.join(path, "#{cmd}#{ext}")


### PR DESCRIPTION
We were trying to `split` the resulting array, which failed!

This comes up in PHP apps because the subprocess doesn't have PATHEXT set.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1868 #1858 #1828 #1783 #1704 #1569 (perhaps more but those are the ones I found)

Apparently when we don't find a `$PATHEXT` env variable, we were substituting with an array instead of a string.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

We try to use `$PATHEXT` but if it's not present, just use `['']`.

Basically we were trying to do that before, but we now do the `split` only if we found a value.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

On Windows:

```
shopify app create php
shopify app serve
```


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).