### PR TITLE
Fix: More defensive URL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#1983](https://github.com/Shopify/shopify-cli/pull/1983): Improve Windows compatibility
 * [#1928](https://github.com/Shopify/shopify-cli/pull/1928): Ensure script Wasm file sizes don't exceed the limit
+* [#2006](https://github.com/Shopify/shopify-cli/pull/2006): Fix: More defensive URL generation
 
 ## Version 2.10.1
 ### Fixed

--- a/lib/shopify_cli/github/issue_url_generator.rb
+++ b/lib/shopify_cli/github/issue_url_generator.rb
@@ -6,8 +6,13 @@ module ShopifyCLI
         labels = "type:bug"
 
         # take at most 5 lines from backtrace
-        stacktrace = error.backtrace.length < 5 ? error.backtrace : error.backtrace[0..4]
-        stacktrace_text = stacktrace.join("\n").to_s
+        stacktrace_text =
+          if error.backtrace # Sometimes errors seem to appear without backtrace, see https://github.com/Shopify/shopify-cli/issues/1972#issuecomment-1028013630
+            stacktrace = error.backtrace.length < 5 ? error.backtrace : error.backtrace[0..4]
+            stacktrace.join("\n").to_s
+          else
+            ""
+          end
         query = URI.encode_www_form({
           title: title,
           labels: labels,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of fixing #1972 

Currently if an error doesn't have a backtrace (which shouldn't happen under normal circumstances but seems to under certain edge cases), we lose the entire error, which is making it impossible to debug that issue.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

If there's no error backtrace, just use `""` for the backtrace text.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Need to generate an error which triggers the message, `✗ An unexpected error occured.`

In `IssueURLGenerator::error_url`, before hitting the affected LOC, add `error.set_backtrace(nil)`

Also need to make sure `ExceptionReporter` reports even in `development`

Try with and without the change.

Before:

<img width="1753" alt="Screen Shot 2022-02-02 at 17 10 40" src="https://user-images.githubusercontent.com/6288426/152181025-1b600916-ed96-49ee-a416-0c9b841eada0.png">

After:

<img width="528" alt="Screen Shot 2022-02-02 at 17 10 52" src="https://user-images.githubusercontent.com/6288426/152181076-96104f67-b1f1-4860-934d-3d2d7e55e38d.png">

It's not awesome since either way we don't see the stack trace, but at least we'll end up not totally crashing on an unrelated error.


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).