### PR TITLE
Update spin FQDN mechanism

### DIFF
--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -2,6 +2,7 @@ module ShopifyCLI
   module Constants
     module Paths
       ROOT = File.expand_path("../..", __dir__)
+      SPIN_FQDN = "/etc/spin/machine/fqdn"
     end
 
     module Files
@@ -38,10 +39,6 @@ module ShopifyCLI
 
       # When true the CLI points to spin instances of services
       SPIN = "SPIN"
-      INFER_SPIN = "INFER_SPIN"
-      SPIN_WORKSPACE = "SPIN_WORKSPACE"
-      SPIN_NAMESPACE = "SPIN_NAMESPACE"
-      SPIN_HOST = "SPIN_HOST"
 
       # Deprecated, equivalent to using SPIN=1
       SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -65,7 +65,7 @@ module ShopifyCLI
       if use_local_partners_instance?(env_variables: env_variables)
         "partners.myshopify.io"
       elsif use_spin?(env_variables: env_variables)
-        "partners.#{spin_url(env_variables: env_variables)}"
+        "partners.#{spin_url}"
       else
         "partners.shopify.com"
       end
@@ -88,15 +88,8 @@ module ShopifyCLI
       )
     end
 
-    def self.spin_url(env_variables: ENV)
-      if infer_spin?(env_variables: env_variables)
-        %x(spin info fqdn 2> /dev/null).strip
-      else
-        spin_workspace = spin_workspace(env_variables: env_variables)
-        spin_namespace = spin_namespace(env_variables: env_variables)
-        spin_host = spin_host(env_variables: env_variables)
-        "#{spin_workspace}.#{spin_namespace}.#{spin_host}"
-      end
+    def self.spin_url
+      File.read(Constants::Paths::SPIN_FQDN).strip if File.exist?(Constants::Paths::SPIN_FQDN)
     end
 
     def self.send_monorail_events?(env_variables: ENV)
@@ -112,24 +105,6 @@ module ShopifyCLI
 
     def self.env_variable_truthy?(variable_name, env_variables: ENV)
       TRUTHY_ENV_VARIABLE_VALUES.include?(env_variables[variable_name.to_s])
-    end
-
-    def self.spin_workspace(env_variables: ENV)
-      env_value = env_variables[Constants::EnvironmentVariables::SPIN_WORKSPACE]
-      return env_value unless env_value.nil?
-
-      if env_value.nil?
-        raise "No value set for #{Constants::EnvironmentVariables::SPIN_WORKSPACE}"
-      end
-    end
-
-    def self.spin_namespace(env_variables: ENV)
-      env_value = env_variables[Constants::EnvironmentVariables::SPIN_NAMESPACE]
-      return env_value unless env_value.nil?
-
-      if env_value.nil?
-        raise "No value set for #{Constants::EnvironmentVariables::SPIN_NAMESPACE}"
-      end
     end
 
     def self.spin_host(env_variables: ENV)

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 
 module ShopifyCLI
   class EnvironmentTest < MiniTest::Test
+    include TestHelpers::FakeFS
+
     def test_use_local_partners_instance_returns_true_when_the_env_variable_is_set
       # Given
       env_variables = {
@@ -71,74 +73,45 @@ module ShopifyCLI
       assert_equal "partners.myshopify.io", got
     end
 
-    def test_partners_domain_returns_the_right_value_when_spin_instance
+    def test_partners_domain_uses_spin
       # Given
+      Environment.stubs(spin_url: "some.fqdn.com")
       env_variables = {
-        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
-        Constants::EnvironmentVariables::SPIN_HOST.to_s => "us-dev.scvm.io",
+        Constants::EnvironmentVariables::SPIN.to_s => "1",
       }
 
       # When
       got = Environment.partners_domain(env_variables: env_variables)
 
       # Then
-      assert_equal "partners.abcd.my-namespace.us-dev.scvm.io", got
-    end
-
-    def test_partners_domain_returns_the_right_value_when_spin_instance_no_host
-      # Given
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
-      }
-
-      # When
-      got = Environment.partners_domain(env_variables: env_variables)
-
-      # Then
-      assert_equal "partners.abcd.my-namespace.us.spin.dev", got
+      assert_equal "partners.some.fqdn.com", got
     end
 
     def test_partners_domain_returns_the_right_value_when_production_instance
       # Given/When
-      got = Environment.partners_domain
+      got = Environment.partners_domain(env_variables: {})
 
       # Then
       assert_equal "partners.shopify.com", got
     end
 
-    def test_spin_url_returns_the_right_value
-      # Given
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
-        Constants::EnvironmentVariables::SPIN_HOST.to_s => "us-dev.scvm.io",
-      }
-
-      # When
-      got = Environment.partners_domain(env_variables: env_variables)
-
-      # Then
-      assert_equal "partners.abcd.my-namespace.us-dev.scvm.io", got
+    def test_spin_url_is_nil_when_not_using_spin
+      assert_nil(Environment.spin_url)
     end
 
-    def test_spin_url_returns_the_right_value_no_host
-      # Given
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
-      }
+    def test_spin_url_reads_from_fqdn_file
+      FileUtils.mkdir_p(File.dirname(Constants::Paths::SPIN_FQDN))
+      File.write(Constants::Paths::SPIN_FQDN, "some.fqdn.com")
 
-      # When
-      got = Environment.partners_domain(env_variables: env_variables)
+      got = Environment.spin_url
 
-      # Then
-      assert_equal "partners.abcd.my-namespace.us.spin.dev", got
+      assert_equal "some.fqdn.com", got
+    end
+
+    def test_spin_url_is_nil_when_file_does_not_exist
+      got = Environment.spin_url
+
+      assert_nil got
     end
 
     def test_use_spin_is_true
@@ -159,57 +132,6 @@ module ShopifyCLI
       got = Environment.use_spin?(env_variables: env_variables)
 
       refute got
-    end
-
-    def test_infer_spin_is_false
-      env_variables = {
-        Constants::EnvironmentVariables::INFER_SPIN.to_s => nil,
-      }
-
-      got = Environment.infer_spin?(env_variables: env_variables)
-
-      refute got
-    end
-
-    def test_infer_spin_is_true
-      env_variables = {
-        Constants::EnvironmentVariables::INFER_SPIN.to_s => "1",
-      }
-
-      got = Environment.infer_spin?(env_variables: env_variables)
-
-      assert got
-    end
-
-    def test_raise_when_spin_workspace_missing
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => nil,
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "my-namespace",
-      }
-
-      assert_raises(RuntimeError) { Environment.spin_url(env_variables: env_variables) }
-    end
-
-    def test_raise_when_spin_namespace_missing
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "my-workspace",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => nil,
-      }
-
-      assert_raises(RuntimeError) { Environment.spin_url(env_variables: env_variables) }
-    end
-
-    def test_infer_when_spin_namespace_missing
-      env_variables = {
-        Constants::EnvironmentVariables::SPIN.to_s => "1",
-        Constants::EnvironmentVariables::INFER_SPIN.to_s => "1",
-        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "my-workspace",
-        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => nil,
-      }
-
-      Environment.spin_url(env_variables: env_variables)
     end
 
     def test_env_variable_truthy


### PR DESCRIPTION
### WHY are these changes introduced?

The CLI is broken when using isospin.

With the transition to isospin, we no longer have the
`SPIN_WORKSPACE`, `SPIN_NAMESPACE` or `SPIN_HOST` env var, which are
required (otherwise you get an exception when trying to login).

The documented workaround is to use INFER_SPIN=1, with which the CLI
uses the `spin` binary to get the FQDN. But that doesn't work either,
because the `spin` binary is not provided in isospin.

### WHAT is this pull request doing?

With this change, what I'm proposing is that we
1. use a single ENV var -- `SPIN` -- to detect whether we're on spin
2. read the FQDN from the file, as recommended by Burke

### How to test your changes?

Use spin (e.g. `spin create partners`), try `shopify login` with and without that branch.


### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.