### PR TITLE
[Feature] Add l10n support to CheckoutUiExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+### Added
+* [#2009](https://github.com/Shopify/shopify-cli/pull/2009): Add localization support for Checkout Extensions
 
 ## Version 2.11.1
 ### Fixed

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -4,12 +4,24 @@ module Extension
   module Models
     module SpecificationHandlers
       class CheckoutUiExtension < Default
+        L10N_ERROR_PREFIX = "core.extension.push.checkout_ui_extension.localization.error"
+        L10N_FILE_SIZE_LIMIT = 16 * 1024 # 16kb
+        L10N_BUNDLE_SIZE_LIMIT = 256 * 1024 # 256kb
+        LOCALE_CODE_FORMAT = %r{
+          \A
+          (?<language>[a-zA-Z]{2,3}) # Language tag
+          (?:
+           -
+           (?<region>[a-zA-Z]{2}) # Optional region subtag
+          )?
+          \z}x
         PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name]
 
         def config(context)
           {
             **Features::ArgoConfig.parse_yaml(context, PERMITTED_CONFIG_KEYS),
             **argo.config(context, include_renderer_version: false),
+            **localization(context),
           }
         end
 
@@ -21,6 +33,108 @@ module Extension
           product = Tasks::GetProduct.call(context, shop)
           return unless product
           format("/cart/%<variant_id>d:%<quantity>d", variant_id: product.variant_id, quantity: 1)
+        end
+
+        private
+
+        def localization(context)
+          Dir.chdir(context.root) do
+            locale_filenames = Dir["locales/*"].select { |filename| valid_l10n_file?(filename) }
+            # Localization is optional
+            return {} if locale_filenames.empty?
+
+            validate_total_size(locale_filenames)
+            default_locale = single_default_locale(locale_filenames)
+
+            locale_filenames.map do |filename|
+              locale = basename_for_locale_filename(filename)
+              [locale.to_sym, Base64.strict_encode64(File.read(filename, mode: "rt", encoding: "UTF-8").strip)]
+            end
+              .yield_self do |encoded_files_by_locale|
+              {
+                localization: {
+                  default_locale: default_locale,
+                  translations: encoded_files_by_locale.to_h,
+                },
+              }
+            end
+          end
+        end
+
+        def validate_total_size(locale_filenames)
+          total_size = locale_filenames.sum { |filename| File.size(filename) }
+          if total_size > L10N_BUNDLE_SIZE_LIMIT
+            raise(
+              ShopifyCLI::Abort,
+              ShopifyCLI::Context.message(
+                "#{L10N_ERROR_PREFIX}.bundle_too_large",
+                CLI::Kit::Util.to_filesize(L10N_BUNDLE_SIZE_LIMIT)
+              )
+            )
+          end
+        end
+
+        def single_default_locale(locale_filenames)
+          default_locale_matches = locale_filenames.grep(/default/)
+          if default_locale_matches.size != 1
+            raise(ShopifyCLI::Abort, ShopifyCLI::Context.message("#{L10N_ERROR_PREFIX}.single_default_locale"))
+          end
+          basename_for_locale_filename(default_locale_matches.first)
+        end
+
+        def valid_l10n_file?(filename)
+          return false unless File.file?(filename)
+          return false unless File.dirname(filename) == "locales"
+
+          validate_file_extension(filename)
+          validate_file_locale_code(filename)
+          validate_file_size(filename)
+          validate_file_not_empty(filename)
+
+          true
+        end
+
+        def validate_file_extension(filename)
+          if File.extname(filename) != ".json"
+            raise(
+              ShopifyCLI::Abort, ShopifyCLI::Context.message("#{L10N_ERROR_PREFIX}.invalid_file_extension", filename)
+            )
+          end
+        end
+
+        def validate_file_locale_code(filename)
+          unless valid_locale_code?(basename_for_locale_filename(filename))
+            raise(
+              ShopifyCLI::Abort, ShopifyCLI::Context.message("#{L10N_ERROR_PREFIX}.invalid_locale_code", filename)
+            )
+          end
+        end
+
+        def validate_file_size(filename)
+          if File.size(filename) > L10N_FILE_SIZE_LIMIT
+            raise(
+              ShopifyCLI::Abort,
+              ShopifyCLI::Context.message(
+                "#{L10N_ERROR_PREFIX}.file_too_large",
+                filename,
+                CLI::Kit::Util.to_filesize(L10N_FILE_SIZE_LIMIT)
+              )
+            )
+          end
+        end
+
+        def validate_file_not_empty(filename)
+          if File.zero?(filename)
+            raise(ShopifyCLI::Abort, ShopifyCLI::Context.message("#{L10N_ERROR_PREFIX}.file_empty", filename))
+          end
+        end
+
+        def valid_locale_code?(locale_code)
+          LOCALE_CODE_FORMAT.match?(locale_code)
+        end
+
+        def basename_for_locale_filename(filename)
+          File.basename(File.basename(filename, ".json"), ".default")
         end
       end
     end

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -277,6 +277,24 @@ module ShopifyCLI
               HELP
           },
         },
+        extension: {
+          push: {
+            checkout_ui_extension: {
+              localization: {
+                error: {
+                  bundle_too_large: "Total size of all locale files must be less than %s.",
+                  file_empty: "Locale file `%s` is empty.",
+                  file_too_large: "Locale file `%s` too large; size must be less than %s.",
+                  invalid_file_extension: "Invalid locale filename: `%s`; only .json files are allowed.",
+                  invalid_locale_code: "Invalid locale filename: `%s`; locale code should be 2 or 3 letters,"\
+                    " optionally followed by a two-letter region code, e.g. `fr-CA`.",
+                  single_default_locale: "There must be one and only one locale identified as the default locale,"\
+                    " e.g. `en.default.json`",
+                },
+              },
+            },
+          },
+        },
         error_reporting: {
           unhandled_error: {
             message: "{{x}} {{red:An unexpected error occured.}}",

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -8,6 +8,31 @@ module Extension
     module SpecificationHandlers
       class CheckoutUiExtensionTest < MiniTest::Test
         include ExtensionTestHelpers
+        VALID_L10N_FILENAMES = [
+          "FR-CA.json", # case-insensitive
+          "fr-CA.json", # case-insensitive
+          "FR-ca.json", # case-insensitive
+          "fr-ca.json", # case-insensitive
+          "fr.json", # language tag = 2 characters
+          "dsb.json", # language tag = 3 characters
+          "dsb-ab.json", # language tag = 3 characters + region code = 2 characters
+        ]
+
+        INVALID_L10N_FILENAMES = [
+          "french.json", # language tag > 3 characters
+          "f.json", # language tag < 2 characters
+          "fren-ca.json", # language tag > 3 characters + region code
+          "f-ca.json", # language tag < 2 characters + region code
+          "fr-can.json", # region code > 2 characters
+          "fr-c.json", # region code < 2 characters
+          "fr.defalt.json", # typo in default
+          "11-ca.json", # numbers in language tag
+          "fr-11.json", # numbers in region code
+          "fr.ca.json", # dot instead of dash
+          "fr_ca.json", # underscore instead of dash
+        ]
+
+        L10N_ERROR_PREFIX = "core.extension.push.checkout_ui_extension.localization.error"
 
         def setup
           super
@@ -20,6 +45,11 @@ module Extension
 
           @identifier = "CHECKOUT_UI_EXTENSION"
           @checkout_ui_extension = specifications[@identifier]
+          @context.root = Dir.mktmpdir
+        end
+
+        def teardown
+          FileUtils.remove_dir(@context.root)
         end
 
         def test_create_uses_standard_argo_create_implementation
@@ -89,6 +119,131 @@ module Extension
 
           resource_url = @checkout_ui_extension.build_resource_url(context: @context, shop: shop)
           assert_nil resource_url
+        end
+
+        def test_l10n_files_encoded
+          en_content = '{"laugh": "lol"}'
+          fr_content = '{"laugh": "mdr"}'
+          write("locales/fr.default.json", fr_content)
+          write("locales/en.json", en_content)
+
+          expected = {
+            localization: {
+              translations: {
+                fr: Base64.strict_encode64(fr_content),
+                en: Base64.strict_encode64(en_content),
+              },
+              default_locale: "fr",
+            },
+          }
+          assert_equal(expected, @checkout_ui_extension.config(@context))
+        end
+
+        def test_l10n_files_at_root_are_ignored
+          write("locales/fr.default.json", "{}")
+          write("wut.json", "{}")
+          config = @checkout_ui_extension.config(@context)
+          refute_includes(config[:localization][:translations], "wut")
+        end
+
+        def test_non_locale_files_are_ignored
+          assert_nothing_raised do
+            write("invalid-folder/fr.json", "{}")
+            config = @checkout_ui_extension.config(@context)
+            refute_includes(config, "localization")
+          end
+        end
+
+        def test_l10n_multiple_defaults
+          write("locales/fr.default.json", "{}")
+          write("locales/en.default.json", "{}")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.single_default_locale" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
+        def test_l10n_no_defaults
+          write("locales/fr.json", "{}")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.single_default_locale" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
+        def test_l10n_file_extension
+          write("locales/fr.txt", "hello")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.invalid_file_extension" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
+        def test_l10n_empty_file
+          write("locales/en.default.json", "")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.file_empty" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
+        def test_l10n_max_filesize
+          stub_const(CheckoutUiExtension, :L10N_FILE_SIZE_LIMIT, 50) do
+            write("locales/fr.json", "1" * 60)
+            assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.file_too_large" do
+              @checkout_ui_extension.config(@context)
+            end
+          end
+        end
+
+        def test_l10n_sum_max_filesize
+          stub_const(CheckoutUiExtension, :L10N_BUNDLE_SIZE_LIMIT, 50) do
+            write("locales/fr.json", "1" * 30)
+            write("locales/en.default.json", "1" * 30)
+            assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.bundle_too_large" do
+              @checkout_ui_extension.config(@context)
+            end
+          end
+        end
+
+        VALID_L10N_FILENAMES.each do |filename|
+          define_method("test_valid_l10n_filename_#{filename}") do
+            write("locales/en.default.json", "{}")
+            write("locales/#{filename}", "{}")
+
+            assert_nothing_raised do
+              @checkout_ui_extension.config(@context)
+            end
+          end
+        end
+
+        INVALID_L10N_FILENAMES.each do |filename|
+          define_method("test_invalid_l10n_filename_#{filename}") do
+            write("locales/en.default.json", "{}")
+            write("locales/#{filename}", "{}")
+            assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.invalid_locale_code" do
+              @checkout_ui_extension.config(@context)
+            end
+          end
+        end
+
+        private
+
+        def write(filename, content, mode: "w", encoding: "utf-8")
+          filename = File.join(@context.root, filename)
+          FileUtils.mkdir_p(File.dirname(filename))
+          File.write(filename, content, mode: mode, encoding: encoding)
+        end
+
+        def stub_const(object, name, value)
+          original = object.const_get(name)
+          silent_const_set(object, name, value)
+          yield
+        ensure
+          silent_const_set(object, name, original)
+        end
+
+        def silent_const_set(object, name, value)
+          old_verbose = $VERBOSE
+          $VERBOSE = nil
+          object.const_set(name, value)
+          $VERBOSE = old_verbose
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [internal issue](https://github.com/Shopify/checkout-web/issues/8565) <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
As part of the [Localized Checkout Ui Extensions](https://docs.google.com/document/d/1Qg9AGnkSLGx10zetJIrLfzvt554_AKb7HykUK5y1_mA/edit#heading=h.62oius9y1lvr) project, we must update the `shopify-cli` codebase to allow developers to submit localization files along with their code updates when the Shopify CLI `shopify extension push` command is executed. 

This change applies to the Checkout Extension type of extensions only, for now.

#### Screenshots

<details>
  <summary>Valid submission</summary>
  
  This will be what is shown in the CLI when we will have merged in the code in the Shopify backend that will support this new localization feature.
<img width="1154" alt="Screen Shot 2022-02-03 at 11 16 08 AM" src="https://user-images.githubusercontent.com/3000613/152386108-0e35b55e-8ac5-4bf7-b809-750ddeb426a2.png">
</details>

<details>
  <summary>Valid submission with unrecognized key warning</summary>

  This will be what is shown in the CLI before and until we will have merged in the code in the Shopify backend that will support this new localization feature.
<img width="585" alt="Screen Shot 2022-02-03 at 11 15 42 AM" src="https://user-images.githubusercontent.com/3000613/152386412-fd4bfb01-4690-434e-9ae1-c7472fbc6988.png">


  Note that attempting to publish an extension with this data pushed in before support has been added will fail.
  <img width="970" alt="Screen Shot 2022-02-03 at 10 41 04 AM" src="https://user-images.githubusercontent.com/3000613/152386377-3dc473b0-0c9a-4fc0-ba26-c166f5f169ac.png">
  
</details>

<details>
  <summary> Invalid submission: Invalid locale code</summary>
  
  This error appears if the locale code of a given file name is invalid.
<img width="1074" alt="Screen Shot 2022-02-07 at 4 25 42 PM" src="https://user-images.githubusercontent.com/3000613/152874601-ba8fa3b5-cb37-4f0a-a169-e82ad76cb2f2.png">

</details>

<details>
  <summary> Invalid submission: Invalid file extension</summary>
  
  This error appears if a file under the `/locales` folder has an extension type other than `.json`
<img width="550" alt="Screen Shot 2022-02-03 at 11 08 52 AM" src="https://user-images.githubusercontent.com/3000613/152386939-8166f1b1-4753-4b91-b5d6-d42bde84cdb1.png">

</details>

<details>
  <summary> Invalid submission: File too large</summary>
  
  This error appears if a localization file is larger than the declared limit
  <img width="572" alt="Screen Shot 2022-02-03 at 11 11 15 AM" src="https://user-images.githubusercontent.com/3000613/152387021-c68c1683-995f-4c50-b303-2d604be21ae5.png">

</details>

<details>
  <summary> Invalid submission: File empty</summary>
  
  This error appears if a localization file is completely empty
<img width="498" alt="Screen Shot 2022-02-07 at 4 25 24 PM" src="https://user-images.githubusercontent.com/3000613/152874570-8f4b85d6-df07-44fc-b9c6-c1562c2330fa.png">

</details>

<details>
  <summary> Invalid submission: Sum of all file sizes too large</summary>
  
  This error appears if the combined total size of all localization files exceeds the declared limit
<img width="417" alt="Screen Shot 2022-02-03 at 11 13 06 AM" src="https://user-images.githubusercontent.com/3000613/152387144-7f1c3508-7121-4da5-9133-5e0909b1f0fc.png">

</details>

<details>
  <summary> Invalid submission: No default / too many defaults</summary>
  
  This error appears if none of the provided locale files are declared as the default locale, or if more than one of them are.
  <img width="696" alt="Screen Shot 2022-02-03 at 11 14 01 AM" src="https://user-images.githubusercontent.com/3000613/152387246-17c78dd5-1af5-4a69-b08f-c532d87a2aa2.png">

</details>

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
- Follow [this procedure](https://docs.google.com/document/d/1aIh87r7HwdsngIKtZnuEW_PRmOsHQPI7ybVnPk3oX-U/edit#) completely to have a backend to execute the CLI push command against as well as a `CheckoutUiExtension` extension project setup.
- Create a `locales` directory at the root of the created extension project of type Checkout Extension
- Create .json files with a valid locale code as the basename. Ensure one of them is suffixed by `.default`, e.g. `en.default.json` and `fr.json`
- Execute the `shopify extension push` command.

Various simple validations exist, which can be tested by playing around with the filenames under `locales` and their content. Refer to the screenshots provided above.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.