### PR TITLE
Supports both spin-legacy and spin2 for Spin FQDN command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#1998](https://github.com/Shopify/shopify-cli/pull/1998): Add support for Rails 7
 * [#1945](https://github.com/Shopify/shopify-cli/pull/1945): Check Node and Ruby versions and warn the user if their environment's version might be incompatible with the version the command expects.
+* [#2011](https://github.com/Shopify/shopify-cli/pull/2011): Adds support for the Spin rewrite
 
 ## Version 2.10.2
 ### Fixed

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -106,7 +106,17 @@ module ShopifyCLI
 
     def self.spin_url(env_variables: ENV)
       if infer_spin?(env_variables: env_variables)
-        %x(spin info fqdn 2> /dev/null).strip
+        # TODO: Remove version check and delete spin-legacy branch
+        #  once spin2 becomes the installed "spin" binary by default
+        spin_version = %x(spin version 2> /dev/null).strip
+        if spin_version.start_with?("spin-")
+          # spin2
+          raise ShopifyCLI:: Abort, "SPIN_INSTANCE must be specified" unless ENV.key?("SPIN_INSTANCE")
+          %x(spin show -o fqdn 2> /dev/null).strip
+        else
+          # spin-legacy
+          %x(spin info fqdn 2> /dev/null).strip
+        end
       else
         spin_workspace = spin_workspace(env_variables: env_variables)
         spin_namespace = spin_namespace(env_variables: env_variables)


### PR DESCRIPTION
### WHY are these changes introduced?

This supports the rewrite of the Spin CLI, specifically for fetching the FQDN while authenticating to a Spin instance. Otherwise, once the rewrite becomes introduced across the company (planned for **tomorrow**), the Shopify CLI will become broken with Spin.

### WHAT is this pull request doing?

For now, I'm supporting both spin-legacy and spin2. This will be helpful as we transition the company's default installation for the `spin` binary. Once `spin2` has hit and become the default for perhaps a week, then we can delete any code pertaining to `spin-legacy`.

I've marked the `SPIN_INSTANCE` environment variable as required, since it is now needed to specify your current instance identifier.

### How to test your changes?

Assuming that `spin` still points to `spin-legacy` on your local machine, run some local `shopify` commands with the `SPIN=1 INFER_SPIN=1 SSL_VERIFY_NONE=1` variables prepended:

- Ensure that commands still work as intended against legacy

Then to test against `spin2`, change the `spin version` command in code to `spin2 version` and `spin show -o fqdn` to `spin2 show -o fqdn`:

- Ensure that there is an exception raised if `SPIN_INSTANCE` is not specified
- Ensure that commands work as intended when `SPIN_INSTANCE` has been specified/exported

### Post-release steps

None that I can think of.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.