### PR TITLE
Perform node version checks with ToolVersionChecker module

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -78,6 +78,8 @@ module Script
           Project.project_filepath("layers/infrastructure/languages/wasm_project_creator.rb")
         autoload :WasmTaskRunner,
           Project.project_filepath("layers/infrastructure/languages/wasm_task_runner.rb")
+        autoload :ToolVersionChecker,
+          Project.project_filepath("layers/infrastructure/languages/tool_version_checker.rb")
       end
 
       module ApiClients

--- a/lib/project_types/script/commands/push.rb
+++ b/lib/project_types/script/commands/push.rb
@@ -5,10 +5,6 @@ module Script
     class Push < ShopifyCLI::Command::SubCommand
       prerequisite_task ensure_project_type: :script
 
-      recommend_node(
-        from: ::Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::MIN_NODE_VERSION,
-        to: ShopifyCLI::Constants::SupportedVersions::Node::TO
-      )
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -105,6 +105,17 @@ module Script
 
         class DependencyInstallError < ScriptProjectError; end
         class EmptyResponseError < ScriptProjectError; end
+
+        class InvalidEnvironmentError < ScriptProjectError
+          attr_reader :tool, :env_version, :minimum_version
+          def initialize(tool, env_version, minimum_version)
+            super()
+            @tool = tool
+            @env_version = env_version
+            @minimum_version = minimum_version
+          end
+        end
+
         class InvalidResponseError < ScriptProjectError; end
         class ForbiddenError < ScriptProjectError; end
         class InvalidContextError < ScriptProjectError; end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -5,18 +5,16 @@ module Script
     module Infrastructure
       module Languages
         class AssemblyScriptProjectCreator < ProjectCreator
-          MIN_NODE_VERSION = "14.5.0" # kept because task_runner uses this
-          NPM_SET_REGISTRY_COMMAND = "npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com"
-          NPM_SET_ENGINE_STRICT_COMMAND = "npm --userconfig ./.npmrc config set engine-strict true"
-
           def self.config_file
             "package.json"
           end
 
           def setup_dependencies
+            task_runner = Infrastructure::Languages::AssemblyScriptTaskRunner.new(ctx)
+            task_runner.ensure_environment
+
             super
-            command_runner.call(NPM_SET_REGISTRY_COMMAND)
-            command_runner.call(NPM_SET_ENGINE_STRICT_COMMAND)
+            task_runner.set_npm_config
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator.rb
@@ -11,10 +11,8 @@ module Script
 
           def setup_dependencies
             task_runner = Infrastructure::Languages::AssemblyScriptTaskRunner.new(ctx)
-            task_runner.ensure_environment
-
-            super
             task_runner.set_npm_config
+            super
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -5,9 +5,21 @@ module Script
     module Infrastructure
       module Languages
         class AssemblyScriptTaskRunner < TaskRunner
+          include ToolVersionChecker
+          TOOLS = {
+            "node" => {
+              "minimum_version" => "14.15.0",
+            },
+            "npm" => {
+              "minimum_version" => "5.2.0",
+            },
+          }
+
           BYTECODE_FILE = "build/script.wasm"
           METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
+          NPM_SET_REGISTRY_COMMAND = "npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com"
+          NPM_SET_ENGINE_STRICT_COMMAND = "npm --userconfig ./.npmrc config set engine-strict true"
 
           def build
             compile
@@ -15,7 +27,7 @@ module Script
           end
 
           def install_dependencies
-            check_node_version!
+            ensure_environment
 
             output, status = ctx.capture2e("npm install --no-audit --no-optional --legacy-peer-deps --loglevel error")
             raise Errors::DependencyInstallError, output unless status.success?
@@ -31,10 +43,21 @@ module Script
           end
 
           def library_version(library_name)
+            ensure_environment
             output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)
+          end
+
+          def set_npm_config
+            ensure_environment
+            CommandRunner.new(ctx: ctx).call(NPM_SET_REGISTRY_COMMAND)
+            CommandRunner.new(ctx: ctx).call(NPM_SET_ENGINE_STRICT_COMMAND)
+          end
+
+          def ensure_environment
+            check_tool_versions(TOOLS)
           end
 
           private
@@ -54,19 +77,6 @@ module Script
           def library_version_from_npm_list(output, library_name)
             output.dig("dependencies", library_name, "version").tap do |version|
               raise Errors::APILibraryNotFoundError, library_name unless version
-            end
-          end
-
-          def check_node_version!
-            output, status = @ctx.capture2e("node", "--version")
-            raise Errors::DependencyInstallError, output unless status.success?
-
-            require "semantic/semantic"
-            version = ::Semantic::Version.new(output[1..-1])
-            unless version >= ::Semantic::Version.new(AssemblyScriptProjectCreator::MIN_NODE_VERSION)
-              raise Errors::DependencyInstallError,
-                "Node version must be >= v#{AssemblyScriptProjectCreator::MIN_NODE_VERSION}. "\
-                "Current version: #{output.strip}."
             end
           end
 

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -5,21 +5,15 @@ module Script
     module Infrastructure
       module Languages
         class AssemblyScriptTaskRunner < TaskRunner
-          include ToolVersionChecker
-          TOOLS = {
-            "node" => {
-              "minimum_version" => "14.15.0",
-            },
-            "npm" => {
-              "minimum_version" => "5.2.0",
-            },
-          }
+          NODE_MIN_VERSION = "14.15.0"
+          NPM_MIN_VERSION = "5.2.0"
 
           BYTECODE_FILE = "build/script.wasm"
           METADATA_FILE = "build/metadata.json"
           SCRIPT_SDK_BUILD = "npm run build"
           NPM_SET_REGISTRY_COMMAND = "npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com"
           NPM_SET_ENGINE_STRICT_COMMAND = "npm --userconfig ./.npmrc config set engine-strict true"
+          NPM_INSTALL_COMMAND = "npm install --no-audit --no-optional --legacy-peer-deps --loglevel error"
 
           def build
             compile
@@ -27,10 +21,10 @@ module Script
           end
 
           def install_dependencies
-            ensure_environment
+            npm_run(NPM_INSTALL_COMMAND)
 
-            output, status = ctx.capture2e("npm install --no-audit --no-optional --legacy-peer-deps --loglevel error")
-            raise Errors::DependencyInstallError, output unless status.success?
+          rescue Errors::SystemCallFailureError => e
+            raise Errors::DependencyInstallError, e.out
           end
 
           def dependencies_installed?
@@ -43,24 +37,31 @@ module Script
           end
 
           def library_version(library_name)
-            ensure_environment
-            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
+            output = JSON.parse(npm_run("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)
           end
 
           def set_npm_config
-            ensure_environment
-            CommandRunner.new(ctx: ctx).call(NPM_SET_REGISTRY_COMMAND)
-            CommandRunner.new(ctx: ctx).call(NPM_SET_ENGINE_STRICT_COMMAND)
+            npm_run(NPM_SET_REGISTRY_COMMAND)
+            npm_run(NPM_SET_ENGINE_STRICT_COMMAND)
           end
 
           def ensure_environment
-            check_tool_versions(TOOLS)
+            return if defined?(@environment_checked)
+            @environment_checked = true
+
+            ToolVersionChecker.check_node(minimum_version: NODE_MIN_VERSION)
+            ToolVersionChecker.check_npm(minimum_version: NPM_MIN_VERSION)
           end
 
           private
+
+          def npm_run(cmd)
+            ensure_environment
+            CommandRunner.new(ctx: ctx).call(cmd)
+          end
 
           def library_version_from_npm_list_error_output(error, library_name)
             # npm list can return a failure status code, even when returning the correct data.
@@ -82,7 +83,7 @@ module Script
 
           def compile
             check_compilation_dependencies!
-            CommandRunner.new(ctx: ctx).call(SCRIPT_SDK_BUILD)
+            npm_run(SCRIPT_SDK_BUILD)
           end
 
           def check_compilation_dependencies!

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -48,6 +48,8 @@ module Script
             npm_run(NPM_SET_ENGINE_STRICT_COMMAND)
           end
 
+          private
+
           def ensure_environment
             return if defined?(@environment_checked)
             @environment_checked = true
@@ -55,8 +57,6 @@ module Script
             ToolVersionChecker.check_node(minimum_version: NODE_MIN_VERSION)
             ToolVersionChecker.check_npm(minimum_version: NPM_MIN_VERSION)
           end
-
-          private
 
           def npm_run(cmd)
             ensure_environment

--- a/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner.rb
@@ -21,7 +21,7 @@ module Script
           end
 
           def install_dependencies
-            npm_run(NPM_INSTALL_COMMAND)
+            run_cmd_with_env_check(NPM_INSTALL_COMMAND)
 
           rescue Errors::SystemCallFailureError => e
             raise Errors::DependencyInstallError, e.out
@@ -37,15 +37,15 @@ module Script
           end
 
           def library_version(library_name)
-            output = JSON.parse(npm_run("npm -s list --json"))
+            output = JSON.parse(run_cmd_with_env_check("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)
           end
 
           def set_npm_config
-            npm_run(NPM_SET_REGISTRY_COMMAND)
-            npm_run(NPM_SET_ENGINE_STRICT_COMMAND)
+            run_cmd_with_env_check(NPM_SET_REGISTRY_COMMAND)
+            run_cmd_with_env_check(NPM_SET_ENGINE_STRICT_COMMAND)
           end
 
           private
@@ -58,7 +58,7 @@ module Script
             ToolVersionChecker.check_npm(minimum_version: NPM_MIN_VERSION)
           end
 
-          def npm_run(cmd)
+          def run_cmd_with_env_check(cmd)
             ensure_environment
             CommandRunner.new(ctx: ctx).call(cmd)
           end
@@ -83,7 +83,7 @@ module Script
 
           def compile
             check_compilation_dependencies!
-            npm_run(SCRIPT_SDK_BUILD)
+            run_cmd_with_env_check(SCRIPT_SDK_BUILD)
           end
 
           def check_compilation_dependencies!

--- a/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
@@ -1,0 +1,24 @@
+module Script
+  module Layers
+    module Infrastructure
+      module Languages
+        module ToolVersionChecker
+          def check_tool_versions(tools)
+            tools.each do |tool, properties|
+              env_version = case tool
+              when "node"
+                ShopifyCLI::Environment.node_version
+              when "npm"
+                ShopifyCLI::Environment.npm_version
+              end
+
+              next if env_version >= ::Semantic::Version.new(properties["minimum_version"])
+              raise Errors::DependencyInstallError, "Your environment #{tool} version, #{env_version},"\
+                " is too low. It must be greater than #{properties["minimum_version"]}."
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
@@ -13,8 +13,7 @@ module Script
               end
 
               next if env_version >= ::Semantic::Version.new(properties["minimum_version"])
-              raise Errors::DependencyInstallError, "Your environment #{tool} version, #{env_version},"\
-                " is too low. It must be greater than #{properties["minimum_version"]}."
+              raise Errors::InvalidEnvironmentError.new(tool, env_version, properties["minimum_version"])
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/tool_version_checker.rb
@@ -2,18 +2,21 @@ module Script
   module Layers
     module Infrastructure
       module Languages
-        module ToolVersionChecker
-          def check_tool_versions(tools)
-            tools.each do |tool, properties|
-              env_version = case tool
-              when "node"
-                ShopifyCLI::Environment.node_version
-              when "npm"
-                ShopifyCLI::Environment.npm_version
-              end
+        class ToolVersionChecker
+          class << self
+            def check_node(minimum_version:)
+              check_version("node", ShopifyCLI::Environment.node_version, minimum_version)
+            end
 
-              next if env_version >= ::Semantic::Version.new(properties["minimum_version"])
-              raise Errors::InvalidEnvironmentError.new(tool, env_version, properties["minimum_version"])
+            def check_npm(minimum_version:)
+              check_version("npm", ShopifyCLI::Environment.npm_version, minimum_version)
+            end
+
+            private
+
+            def check_version(tool, env_version, minimum_version)
+              return if env_version >= ::Semantic::Version.new(minimum_version)
+              raise Errors::InvalidEnvironmentError.new(tool, env_version, minimum_version)
             end
           end
         end

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_project_creator.rb
@@ -5,18 +5,16 @@ module Script
     module Infrastructure
       module Languages
         class TypeScriptProjectCreator < ProjectCreator
-          MIN_NODE_VERSION = "14.15.0"
-          NPM_SET_REGISTRY_COMMAND = "npm --userconfig ./.npmrc config set @shopify:registry https://registry.npmjs.com"
-          NPM_SET_ENGINE_STRICT_COMMAND = "npm --userconfig ./.npmrc config set engine-strict true"
-
           def self.config_file
             "package.json"
           end
 
           def setup_dependencies
+            task_runner = Infrastructure::Languages::TypeScriptTaskRunner.new(ctx)
+            task_runner.ensure_environment
+
             super
-            command_runner.call(NPM_SET_REGISTRY_COMMAND)
-            command_runner.call(NPM_SET_ENGINE_STRICT_COMMAND)
+            task_runner.set_npm_config
 
             if ctx.file_exist?("yarn.lock")
               ctx.rm("yarn.lock")

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_project_creator.rb
@@ -11,10 +11,9 @@ module Script
 
           def setup_dependencies
             task_runner = Infrastructure::Languages::TypeScriptTaskRunner.new(ctx)
-            task_runner.ensure_environment
+            task_runner.set_npm_config
 
             super
-            task_runner.set_npm_config
 
             if ctx.file_exist?("yarn.lock")
               ctx.rm("yarn.lock")

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -38,8 +38,7 @@ module Script
           end
 
           def library_version(library_name)
-            ensure_environment
-            output = JSON.parse(CommandRunner.new(ctx: ctx).call("npm -s list --json"))
+            output = JSON.parse(npm_run("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -22,7 +22,7 @@ module Script
           end
 
           def install_dependencies
-            npm_run(NPM_INSTALL_COMMAND)
+            run_cmd_with_env_check(NPM_INSTALL_COMMAND)
 
           rescue Errors::SystemCallFailureError => e
             raise Errors::DependencyInstallError, e.out
@@ -38,15 +38,15 @@ module Script
           end
 
           def library_version(library_name)
-            output = JSON.parse(npm_run("npm -s list --json"))
+            output = JSON.parse(run_cmd_with_env_check("npm -s list --json"))
             library_version_from_npm_list(output, library_name)
           rescue Errors::SystemCallFailureError => error
             library_version_from_npm_list_error_output(error, library_name)
           end
 
           def set_npm_config
-            npm_run(NPM_SET_REGISTRY_COMMAND)
-            npm_run(NPM_SET_ENGINE_STRICT_COMMAND)
+            run_cmd_with_env_check(NPM_SET_REGISTRY_COMMAND)
+            run_cmd_with_env_check(NPM_SET_ENGINE_STRICT_COMMAND)
           end
 
           private
@@ -59,7 +59,7 @@ module Script
             ToolVersionChecker.check_npm(minimum_version: NPM_MIN_VERSION)
           end
 
-          def npm_run(cmd)
+          def run_cmd_with_env_check(cmd)
             ensure_environment
             CommandRunner.new(ctx: ctx).call(cmd)
           end
@@ -84,8 +84,8 @@ module Script
 
           def compile
             check_compilation_dependencies!
-            npm_run(SCRIPT_SDK_BUILD)
-            npm_run(GEN_METADATA)
+            run_cmd_with_env_check(SCRIPT_SDK_BUILD)
+            run_cmd_with_env_check(GEN_METADATA)
           end
 
           def check_compilation_dependencies!

--- a/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/typescript_task_runner.rb
@@ -49,6 +49,8 @@ module Script
             npm_run(NPM_SET_ENGINE_STRICT_COMMAND)
           end
 
+          private
+
           def ensure_environment
             return if defined?(@environment_checked)
             @environment_checked = true
@@ -56,8 +58,6 @@ module Script
             ToolVersionChecker.check_node(minimum_version: NODE_MIN_VERSION)
             ToolVersionChecker.check_npm(minimum_version: NPM_MIN_VERSION)
           end
-
-          private
 
           def npm_run(cmd)
             ensure_environment

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -115,7 +115,7 @@ module Script
 
           invalid_environment_cause: "Your environment %{tool} version, %{env_version}, "\
                                      "is too low. It must be greater than %{minimum_version}.",
-          invalid_environment_help: "Update your %{tool}",
+          invalid_environment_help: "Update %{tool}.",
 
           failed_api_request_cause: "Something went wrong while communicating with Shopify.",
           failed_api_request_help: "Try again.",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -113,6 +113,10 @@ module Script
           dependency_install_cause: "Something went wrong while installing the needed dependencies.",
           dependency_install_help: "Correct the errors.",
 
+          invalid_environment_cause: "Your environment %{tool} version, %{env_version}, "\
+                                     "is too low. It must be greater than %{minimum_version}.",
+          invalid_environment_help: "Update your %{tool}",
+
           failed_api_request_cause: "Something went wrong while communicating with Shopify.",
           failed_api_request_help: "Try again.",
 

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -114,7 +114,7 @@ module Script
           dependency_install_help: "Correct the errors.",
 
           invalid_environment_cause: "Your environment %{tool} version, %{env_version}, "\
-                                     "is too low. It must be greater than %{minimum_version}.",
+                                     "is too low. It must be at least %{minimum_version}.",
           invalid_environment_help: "Update %{tool}.",
 
           failed_api_request_cause: "Something went wrong while communicating with Shopify.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -237,6 +237,19 @@ module Script
             ),
             help_suggestion: ShopifyCLI::Context.message("script.error.graphql_error_help"),
           }
+        when Layers::Infrastructure::Errors::InvalidEnvironmentError
+          {
+            cause_of_error: ShopifyCLI::Context.message(
+              "script.error.invalid_environment_cause",
+              tool: e.tool,
+              env_version: e.env_version,
+              minimum_version: e.minimum_version,
+            ),
+            help_suggestion: ShopifyCLI::Context.message(
+              "script.error.invalid_environment_help",
+              tool: e.tool,
+            ),
+          }
         when Layers::Infrastructure::Errors::SystemCallFailureError
           {
             cause_of_error: ShopifyCLI::Context

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -25,6 +25,12 @@ module ShopifyCLI
       ::Semantic::Version.new(out.chomp)
     end
 
+    def self.npm_version(context: Context.new)
+      out, err, stat = context.capture3("npm", "--version")
+      raise ShopifyCLI::Abort, err unless stat.success?
+      ::Semantic::Version.new(out.chomp)
+    end
+
     def self.interactive=(interactive)
       @interactive = interactive
     end

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
@@ -51,8 +51,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .once
 
       Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.any_instance
-        .expects(:ensure_environment)
-      Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.any_instance
         .expects(:set_npm_config)
 
       subject

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_project_creator_test.rb
@@ -6,7 +6,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
   include TestHelpers::FakeFS
 
   let(:context) { TestHelpers::FakeContext.new }
-  let(:fake_capture2e_response) { [nil, OpenStruct.new(success?: true)] }
 
   let(:extension_point_type) { "payment_methods" }
   let(:extension_point_config) do
@@ -51,14 +50,10 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator
         .with
         .once
 
-      context
-        .expects(:capture2e)
-        .with(Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator::NPM_SET_REGISTRY_COMMAND)
-        .returns(fake_capture2e_response)
-      context
-        .expects(:capture2e)
-        .with(Script::Layers::Infrastructure::Languages::AssemblyScriptProjectCreator::NPM_SET_ENGINE_STRICT_COMMAND)
-        .returns(fake_capture2e_response)
+      Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.any_instance
+        .expects(:ensure_environment)
+      Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner.any_instance
+        .expects(:set_npm_config)
 
       subject
     end

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -198,10 +198,10 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     subject { as_task_runner.install_dependencies }
 
     before do
-      ShopifyCLI::Environment.stubs(:node_version)
-        .returns(::Semantic::Version.new("14.15.0"))
-      ShopifyCLI::Environment.stubs(:npm_version)
-        .returns(::Semantic::Version.new("5.2.0"))
+      ShopifyCLI::Environment.stubs(
+        node_version: ::Semantic::Version.new("14.15.0"),
+        npm_version: ::Semantic::Version.new("5.2.0")
+      )
     end
 
     describe "when node version is above minimum" do

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -263,10 +263,13 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
   describe ".ensure_environment" do
     subject { as_task_runner.ensure_environment }
 
-    it "should call check_tool_versions with tools" do
-      as_task_runner
-        .expects(:check_tool_versions)
-        .with(as_task_runner.class::TOOLS)
+    it "should call ToolVersionChecker with tools" do
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .expects(:check_node)
+        .with(minimum_version: as_task_runner.class::NODE_MIN_VERSION)
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .expects(:check_npm)
+        .with(minimum_version: as_task_runner.class::NPM_MIN_VERSION)
       subject
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -216,7 +216,18 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     describe "when node version is below minimum" do
       it "should raise error" do
         ShopifyCLI::Environment.expects(:node_version)
-          .returns(::Semantic::Version.new("14.14.0"))
+          .returns(::Semantic::Version.new(decrement_version(as_task_runner.class::NODE_MIN_VERSION)))
+
+        assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
+          subject
+        end
+      end
+    end
+
+    describe "when npm version is below minimum" do
+      it "should raise error" do
+        ShopifyCLI::Environment.expects(:npm_version)
+          .returns(::Semantic::Version.new(decrement_version(as_task_runner.class::NPM_MIN_VERSION)))
 
         assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
           subject
@@ -258,5 +269,12 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
 
       subject
     end
+  end
+
+  private
+
+  def decrement_version(version)
+    major, minor, patch = version.split(".")
+    [major.to_i - 1, minor, patch].join(".")
   end
 end

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -259,18 +259,4 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
       subject
     end
   end
-
-  describe ".ensure_environment" do
-    subject { as_task_runner.ensure_environment }
-
-    it "should call ToolVersionChecker with tools" do
-      Script::Layers::Infrastructure::Languages::ToolVersionChecker
-        .expects(:check_node)
-        .with(minimum_version: as_task_runner.class::NODE_MIN_VERSION)
-      Script::Layers::Infrastructure::Languages::ToolVersionChecker
-        .expects(:check_npm)
-        .with(minimum_version: as_task_runner.class::NPM_MIN_VERSION)
-      subject
-    end
-  end
 end

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -29,6 +29,13 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
     }
   end
 
+  before do
+    ShopifyCLI::Environment.stubs(
+      node_version: ::Semantic::Version.new(as_task_runner.class::NODE_MIN_VERSION),
+      npm_version: ::Semantic::Version.new(as_task_runner.class::NPM_MIN_VERSION)
+    )
+  end
+
   describe ".build" do
     subject { as_task_runner.build }
 
@@ -196,13 +203,6 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
 
   describe ".install_dependencies" do
     subject { as_task_runner.install_dependencies }
-
-    before do
-      ShopifyCLI::Environment.stubs(
-        node_version: ::Semantic::Version.new("14.15.0"),
-        npm_version: ::Semantic::Version.new("5.2.0")
-      )
-    end
 
     describe "when node version is above minimum" do
       it "should install using npm" do

--- a/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/assemblyscript_task_runner_test.rb
@@ -218,7 +218,7 @@ describe Script::Layers::Infrastructure::Languages::AssemblyScriptTaskRunner do
         ShopifyCLI::Environment.expects(:node_version)
           .returns(::Semantic::Version.new("14.14.0"))
 
-        assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError do
+        assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
           subject
         end
       end

--- a/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
@@ -32,7 +32,7 @@ describe Script::Layers::Infrastructure::Languages::ToolVersionChecker do
         ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
         ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("1.0.0"))
 
-        assert_raises(Script::Layers::Infrastructure::Errors::DependencyInstallError) { subject }
+        assert_raises(Script::Layers::Infrastructure::Errors::InvalidEnvironmentError) { subject }
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
@@ -3,41 +3,53 @@
 require "project_types/script/test_helper"
 
 describe Script::Layers::Infrastructure::Languages::ToolVersionChecker do
-  let(:checker) { ToolVersionCheckerTester.new }
-  let(:tools) do
-    {
-      "node" => {
-        "minimum_version" => "1.0.0",
-      },
-      "npm" => {
-        "minimum_version" => "2.0.0",
-      },
-    }
-  end
+  describe ".check_node" do
+    subject do
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .check_node(minimum_version: minimum_version)
+    end
 
-  describe ".check_tool_versions" do
-    subject { checker.check_tool_versions(tools) }
+    describe "when version is acceptable" do
+      let(:minimum_version) { "1.0.0" }
 
-    describe "when all tool versions acceptable" do
       it "should return true" do
         ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
-        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("2.0.0"))
-
         subject
       end
     end
 
-    describe "when some tool versions are outdated" do
-      it "should raise DependencyInstallError" do
-        ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
-        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("1.0.0"))
+    describe "when version is outdated" do
+      let(:minimum_version) { "5.0.0" }
 
+      it "should should raise DependencyInstallError" do
+        ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
         assert_raises(Script::Layers::Infrastructure::Errors::InvalidEnvironmentError) { subject }
       end
     end
   end
-end
 
-class ToolVersionCheckerTester
-  include Script::Layers::Infrastructure::Languages::ToolVersionChecker
+  describe ".check_npm" do
+    subject do
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .check_npm(minimum_version: minimum_version)
+    end
+
+    describe "when version is acceptable" do
+      let(:minimum_version) { "1.0.0" }
+
+      it "should return true" do
+        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("1.0.0"))
+        subject
+      end
+    end
+
+    describe "when version is outdated" do
+      let(:minimum_version) { "5.0.0" }
+
+      it "should should raise DependencyInstallError" do
+        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("1.0.0"))
+        assert_raises(Script::Layers::Infrastructure::Errors::InvalidEnvironmentError) { subject }
+      end
+    end
+  end
 end

--- a/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/tool_version_checker_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Infrastructure::Languages::ToolVersionChecker do
+  let(:checker) { ToolVersionCheckerTester.new }
+  let(:tools) do
+    {
+      "node" => {
+        "minimum_version" => "1.0.0",
+      },
+      "npm" => {
+        "minimum_version" => "2.0.0",
+      },
+    }
+  end
+
+  describe ".check_tool_versions" do
+    subject { checker.check_tool_versions(tools) }
+
+    describe "when all tool versions acceptable" do
+      it "should return true" do
+        ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
+        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("2.0.0"))
+
+        subject
+      end
+    end
+
+    describe "when some tool versions are outdated" do
+      it "should raise DependencyInstallError" do
+        ShopifyCLI::Environment.expects(:node_version).returns(::Semantic::Version.new("1.0.0"))
+        ShopifyCLI::Environment.expects(:npm_version).returns(::Semantic::Version.new("1.0.0"))
+
+        assert_raises(Script::Layers::Infrastructure::Errors::DependencyInstallError) { subject }
+      end
+    end
+  end
+end
+
+class ToolVersionCheckerTester
+  include Script::Layers::Infrastructure::Languages::ToolVersionChecker
+end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
@@ -50,8 +50,6 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
         .once
 
       Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.any_instance
-        .expects(:ensure_environment)
-      Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.any_instance
         .expects(:set_npm_config)
 
       context.expects(:file_exist?)

--- a/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
@@ -6,7 +6,6 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
   include TestHelpers::FakeFS
 
   let(:context) { TestHelpers::FakeContext.new }
-  let(:fake_capture2e_response) { [nil, OpenStruct.new(success?: true)] }
 
   let(:extension_point_type) { "payment-methods" }
   let(:extension_point_config) do
@@ -49,6 +48,12 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
         .expects(:setup_dependencies)
         .with
         .once
+
+      Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.any_instance
+        .expects(:ensure_environment)
+      Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner.any_instance
+        .expects(:set_npm_config)
+
       context.expects(:file_exist?)
         .with("yarn.lock")
         .once
@@ -58,15 +63,6 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
         .with("package-lock.json")
         .once
         .returns(true)
-
-      context
-        .expects(:capture2e)
-        .with(Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::NPM_SET_REGISTRY_COMMAND)
-        .returns(fake_capture2e_response)
-      context
-        .expects(:capture2e)
-        .with(Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator::NPM_SET_ENGINE_STRICT_COMMAND)
-        .returns(fake_capture2e_response)
 
       context
         .expects(:rm)

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -127,7 +127,18 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     describe "when node version is below minimum" do
       it "should raise error" do
         ShopifyCLI::Environment.expects(:node_version)
-          .returns(::Semantic::Version.new("14.14.0"))
+          .returns(::Semantic::Version.new(decrement_version(runner.class::NODE_MIN_VERSION)))
+
+        assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
+          subject
+        end
+      end
+    end
+
+    describe "when npm version is below minimum" do
+      it "should raise error" do
+        ShopifyCLI::Environment.expects(:npm_version)
+          .returns(::Semantic::Version.new(decrement_version(runner.class::NPM_MIN_VERSION)))
 
         assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
           subject
@@ -259,5 +270,12 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
 
       subject
     end
+  end
+
+  private
+
+  def decrement_version(version)
+    major, minor, patch = version.split(".")
+    [major.to_i - 1, minor, patch].join(".")
   end
 end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -260,18 +260,4 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
       subject
     end
   end
-
-  describe ".ensure_environment" do
-    subject { runner.ensure_environment }
-
-    it "should call ToolVersionChecker with tools" do
-      Script::Layers::Infrastructure::Languages::ToolVersionChecker
-        .expects(:check_node)
-        .with(minimum_version: runner.class::NODE_MIN_VERSION)
-      Script::Layers::Infrastructure::Languages::ToolVersionChecker
-        .expects(:check_npm)
-        .with(minimum_version: runner.class::NPM_MIN_VERSION)
-      subject
-    end
-  end
 end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -264,10 +264,13 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
   describe ".ensure_environment" do
     subject { runner.ensure_environment }
 
-    it "should call check_tool_versions with tools" do
-      runner
-        .expects(:check_tool_versions)
-        .with(runner.class::TOOLS)
+    it "should call ToolVersionChecker with tools" do
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .expects(:check_node)
+        .with(minimum_version: runner.class::NODE_MIN_VERSION)
+      Script::Layers::Infrastructure::Languages::ToolVersionChecker
+        .expects(:check_npm)
+        .with(minimum_version: runner.class::NPM_MIN_VERSION)
       subject
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -129,7 +129,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
         ShopifyCLI::Environment.expects(:node_version)
           .returns(::Semantic::Version.new("14.14.0"))
 
-        assert_raises Script::Layers::Infrastructure::Errors::DependencyInstallError do
+        assert_raises Script::Layers::Infrastructure::Errors::InvalidEnvironmentError do
           subject
         end
       end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_task_runner_test.rb
@@ -18,6 +18,13 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
     }
   end
 
+  before do
+    ShopifyCLI::Environment.stubs(
+      node_version: ::Semantic::Version.new(runner.class::NODE_MIN_VERSION),
+      npm_version: ::Semantic::Version.new(runner.class::NPM_MIN_VERSION)
+    )
+  end
+
   describe ".build" do
     subject { runner.build }
 
@@ -107,13 +114,6 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptTaskRunner do
 
   describe ".install_dependencies" do
     subject { runner.install_dependencies }
-
-    before do
-      ShopifyCLI::Environment.stubs(:node_version)
-        .returns(::Semantic::Version.new("14.15.0"))
-      ShopifyCLI::Environment.stubs(:npm_version)
-        .returns(::Semantic::Version.new("5.2.0"))
-    end
 
     describe "when node version is above minimum" do
       it "should install using npm" do

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -137,6 +137,20 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when InvalidEnvironmentError" do
+        let(:err) do
+          Script::Layers::Infrastructure::Errors::InvalidEnvironmentError.new(
+            "node",
+            ::Semantic::Version.new("14.15.0"),
+            "1.0.0",
+          )
+        end
+
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when InvalidLanguageError" do
         let(:err) { Script::Layers::Infrastructure::Errors::InvalidLanguageError.new("ruby", "payment_methods") }
         it "should call display_and_raise" do

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -79,6 +79,23 @@ module ShopifyCLI
       assert_equal ::Semantic::Version.new("3.2.1"), got
     end
 
+    def test_npm_version
+      # Given
+      context = TestHelpers::FakeContext.new
+      stat = mock("success", success?: true)
+      out = "8.4.1"
+      err = ""
+      context.expects(:capture3)
+        .with("npm", "--version")
+        .returns([out, err, stat])
+
+      # When
+      got = Environment.npm_version(context: context)
+
+      # Then
+      assert_equal ::Semantic::Version.new("8.4.1"), got
+    end
+
     def test_use_local_partners_instance_returns_true_when_the_env_variable_is_set
       # Given
       env_variables = {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/2202

### WHAT is this pull request doing?

Adds a new module which infra-layer classes can use to ensure the system tools have an appropriate version.

### How to test your changes?

create / push an assembly/typescript script project.
Tweak the various `MIN_{TOOL}_VERSION` in that language's project_creator and task_runner to observe the different behaviours.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.