### PR TITLE
[scripts] fix some broken error messages

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -56,7 +56,7 @@ module Script
           no_script_config_file_help: "Create this file.",
 
           app_not_connected_cause: "The script is not connected to an app.",
-          app_not_connected_help: "Run {{command:%s script connect}}",
+          app_not_connected_help: "Run {{command:%{tool_name} script connect}}.",
 
           configuration_definition_error_cause: "In %{filename} there is a problem with the "\
                                                 "configuration. %{message}",

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -103,9 +103,9 @@ module Script
           metadata_schema_versions_missing_minor: "Invalid Script API metadata:" \
                                                   " 'schemaVersions' is missing the 'minor' field",
 
-          metadata_not_found_cause: "Can't find the script version file (%s).",
-          metadata_not_found_help: "Make sure your project is up-to-date and a script metadata file n" \
-                                   "is accessible at {path}.",
+          metadata_not_found_cause: "Can't find the script version file (%{filename}).",
+          metadata_not_found_help: "Make sure your project is up-to-date and a script metadata file " \
+                                   "is accessible at %{filename}.",
 
           build_error_cause: "Something went wrong while building the script.",
           build_error_help: "Correct the errors.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -173,7 +173,8 @@ module Script
         when Layers::Infrastructure::Errors::ScriptEnvAppNotConnectedError
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.app_not_connected_cause"),
-            help_suggestion: ShopifyCLI::Context.message("script.error.app_not_connected_help"),
+            help_suggestion: ShopifyCLI::Context.message("script.error.app_not_connected_help",
+              tool_name: ShopifyCLI::TOOL_NAME),
           }
         when Layers::Infrastructure::Errors::ScriptConfigMissingKeysError
           {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -107,8 +107,8 @@ module Script
           }
         when Layers::Domain::Errors::MetadataNotFoundError
           {
-            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause", e.filename),
-            help_suggestion: ShopifyCLI::Context.message("script.error.metadata_not_found_help"),
+            cause_of_error: ShopifyCLI::Context.message("script.error.metadata_not_found_cause", filename: e.filename),
+            help_suggestion: ShopifyCLI::Context.message("script.error.metadata_not_found_help", filename: e.filename),
           }
         when Layers::Domain::Errors::MissingScriptConfigFieldError
           {

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -151,6 +151,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when MetadataNotFoundError" do
+        let(:err) { Script::Layers::Domain::Errors::MetadataNotFoundError.new(filename: "filename") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when ScriptConfigParseError" do
         let(:err) do
           Script::Layers::Infrastructure::Errors::ScriptConfigParseError.new(
@@ -196,6 +203,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when DeprecatedEPError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::DeprecatedEPError.new("some_api") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when ScriptNotFoundError" do
         let(:err) { Script::Layers::Domain::Errors::ScriptNotFoundError.new("ep type", "name") }
         it "should call display_and_raise" do
@@ -235,6 +249,13 @@ describe Script::UI::ErrorHandler do
 
       describe "when ScriptConfigSyntaxError" do
         let(:err) { Script::Layers::Infrastructure::Errors::ScriptConfigSyntaxError.new("filename") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ScriptEnvAppNotConnectedError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptEnvAppNotConnectedError.new("filename") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end
@@ -316,6 +337,13 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when SystemCallFailureError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::SystemCallFailureError.new(out: "out", cmd: "cmd") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when ScriptRepushError" do
         let(:err) { Script::Layers::Infrastructure::Errors::ScriptRepushError.new("uuid") }
         it "should call display_and_raise" do
@@ -323,8 +351,63 @@ describe Script::UI::ErrorHandler do
         end
       end
 
-      describe "when DeprecatedEPError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::DeprecatedEPError.new("some_api") }
+      describe "when BuildScriptNotFoundError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::BuildScriptNotFoundError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when WebAssemblyBinaryNotFoundError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::WebAssemblyBinaryNotFoundError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ProjectConfigNotFoundError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ProjectConfigNotFoundError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when InvalidProjectConfigError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidProjectConfigError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ScriptUploadError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptUploadError.new }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when ScriptTooLargeError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::ScriptTooLargeError.new(max_size: "10") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when APILibraryNotFoundError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::APILibraryNotFoundError.new(library_name: "library") }
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
+      describe "when LanguageLibraryForAPINotFoundError" do
+        let(:err) do
+          Script::Layers::Infrastructure::Errors::LanguageLibraryForAPINotFoundError.new(
+            language: "lang",
+            api: "api"
+          )
+        end
+
         it "should call display_and_raise" do
           should_call_display_and_raise
         end

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -152,7 +152,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when MetadataNotFoundError" do
-        let(:err) { Script::Layers::Domain::Errors::MetadataNotFoundError.new(filename: "filename") }
+        let(:err) { Script::Layers::Domain::Errors::MetadataNotFoundError.new("filename") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced?

A couple of errors messages were malformed in https://github.com/Shopify/shopify-cli/pull/1997/files.

This passed CI because not every error class + message is tested in the `error_handler_test.rb`.

### WHAT is this pull request doing?

- Adds a test that the error_handler handles each error case properly. This means that if a broken error message happens again, we'll know about it. (But, we have to make sure each new error message adds a test here. Not sure if theres a way we can easily enforce that 🤔)
- Updates the broken messages so that they'll print properly. 

### How to test your changes?

Throw `Script::Layers::Infrastructure::Errors::ScriptEnvAppNotConnectedError` and `Layers::Domain::Errors::MetadataNotFoundError.new('path/to/file')` and make sure you can see the error messages.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).