### PR TITLE
Simplify and fix Spin URL selection

### DIFF
--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -38,10 +38,7 @@ module ShopifyCLI
 
       # When true the CLI points to spin instances of services
       SPIN = "SPIN"
-      INFER_SPIN = "INFER_SPIN"
-      SPIN_WORKSPACE = "SPIN_WORKSPACE"
-      SPIN_NAMESPACE = "SPIN_NAMESPACE"
-      SPIN_HOST = "SPIN_HOST"
+      SPIN_INSTANCE = "SPIN_INSTANCE"
 
       # Deprecated, equivalent to using SPIN=1
       SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -39,6 +39,9 @@ module ShopifyCLI
       # When true the CLI points to spin instances of services
       SPIN = "SPIN"
       SPIN_INSTANCE = "SPIN_INSTANCE"
+      SPIN_WORKSPACE = "SPIN_WORKSPACE"
+      SPIN_NAMESPACE = "SPIN_NAMESPACE"
+      SPIN_HOST = "SPIN_HOST"
 
       # Deprecated, equivalent to using SPIN=1
       SPIN_PARTNERS = "SHOPIFY_APP_CLI_SPIN_PARTNERS"

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -8,7 +8,7 @@ module ShopifyCLI
     SPIN_OVERRIDE_ENV_NAMES = [
       Constants::EnvironmentVariables::SPIN_WORKSPACE,
       Constants::EnvironmentVariables::SPIN_NAMESPACE,
-      Constants::EnvironmentVariables::SPIN_HOST
+      Constants::EnvironmentVariables::SPIN_HOST,
     ]
 
     def self.ruby_version(context: Context.new)
@@ -97,9 +97,9 @@ module ShopifyCLI
         env_variables[name]
       end
 
-      return if tokens.all? { |token| token.nil? }
+      return if tokens.all?(&:nil?)
 
-      if tokens.any? { |token| token.nil? }
+      if tokens.any?(&:nil?)
         raise "To manually target a spin instance, you must set #{SPIN_OVERRIDE_ENV_NAMES}"
       else
         tokens.join(".")

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -108,13 +108,13 @@ module ShopifyCLI
       if ENV.key?("SPIN_INSTANCE")
         %x(spin show -o fqdn 2> /dev/null).strip
       elsif infer_spin?(env_variables: env_variables)
-        instances = JSON.parse(%x(exe/spin list --json --output created,fqdn))
-
-        last_created_instance = instances.min_by do |instance|
-          DateTime.parse(instance["created"])
+        instances = begin 
+          JSON.parse(%x(spin show --latest --json))
+        rescue JSON::ParserError => e
+          raise "Failed to process spin output: #{e}. Ensure 'spin show --latest --json' returns valid output"
         end
 
-        last_created_instance["fqdn"]
+        instances["fqdn"]
       else
         raise ShopifyCLI:: Abort, "SPIN_INSTANCE or INFER_SPIN must be specified" unless ENV.key?("SPIN_INSTANCE")
       end

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -110,9 +110,9 @@ module ShopifyCLI
       elsif infer_spin?(env_variables: env_variables)
         instances = JSON.parse(%x(exe/spin list --json --output created,fqdn))
 
-        last_created_instance = instances.sort do |instance_a, instance_b|
-          DateTime.parse(instance_b["created"]) <=> DateTime.parse(instance_a["created"]) 
-        end.first
+        last_created_instance = instances.min_by do |instance|
+          DateTime.parse(instance["created"])
+        end
 
         last_created_instance["fqdn"]
       else

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -108,13 +108,14 @@ module ShopifyCLI
       if ENV.key?("SPIN_INSTANCE")
         %x(spin show -o fqdn 2> /dev/null).strip
       elsif infer_spin?(env_variables: env_variables)
-        instances = begin 
+        instance = begin 
           JSON.parse(%x(spin show --latest --json))
         rescue JSON::ParserError => e
           raise "Failed to process spin output: #{e}. Ensure 'spin show --latest --json' returns valid output"
         end
 
-        instances["fqdn"]
+        raise "Spin output didn't contain expected key fqdn. Actual output of 'spin show --latest --json': #{instance}"
+        instance["fqdn"]
       else
         raise ShopifyCLI:: Abort, "SPIN_INSTANCE or INFER_SPIN must be specified" unless ENV.key?("SPIN_INSTANCE")
       end

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -105,9 +105,9 @@ module ShopifyCLI
     end
 
     def self.spin_url(env_variables: ENV)
-      if infer_spin?(env_variables: env_variables)
-        # TODO: Remove version check and delete spin-legacy branch
-        #  once spin2 becomes the installed "spin" binary by default
+      if ENV.key?("SPIN_INSTANCE")
+        %x(spin show -o fqdn 2> /dev/null).strip
+      elsif infer_spin?(env_variables: env_variables)
         instances = JSON.parse(%x(exe/spin list --json --output created,fqdn))
 
         last_created_instance = instances.sort do |instance_a, instance_b|
@@ -116,8 +116,7 @@ module ShopifyCLI
 
         last_created_instance["fqdn"]
       else
-        raise ShopifyCLI:: Abort, "SPIN_INSTANCE must be specified" unless ENV.key?("SPIN_INSTANCE")
-        %x(spin show -o fqdn 2> /dev/null).strip
+        raise ShopifyCLI:: Abort, "SPIN_INSTANCE or INFER_SPIN must be specified" unless ENV.key?("SPIN_INSTANCE")
       end
     end
 

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -108,14 +108,13 @@ module ShopifyCLI
       if ENV.key?("SPIN_INSTANCE")
         %x(spin show -o fqdn 2> /dev/null).strip
       elsif infer_spin?(env_variables: env_variables)
-        instance = begin 
-          JSON.parse(%x(spin show --latest --json))
-        rescue JSON::ParserError => e
-          raise "Failed to process spin output: #{e}. Ensure 'spin show --latest --json' returns valid output"
+        begin 
+          instance = JSON.parse(%x(spin show --latest --json))
+          raise "Missing expected key 'fqdn' from spin show. Actual response: #{instance}" unless instance.include?("fqdn")
+          instance["fqdn"]
+        rescue => e
+          raise "Failed to infer spin environment: #{e}. Try using SPIN_INSTANCE instead."
         end
-
-        raise "Spin output didn't contain expected key fqdn. Actual output of 'spin show --latest --json': #{instance}"
-        instance["fqdn"]
       else
         raise ShopifyCLI:: Abort, "SPIN_INSTANCE or INFER_SPIN must be specified" unless ENV.key?("SPIN_INSTANCE")
       end

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 module ShopifyCLI
   class EnvironmentTest < MiniTest::Test
-    def setup 
+    def setup
       super
       @mock_spin_instance = {
         "name": name,

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -142,10 +142,40 @@ module ShopifyCLI
       assert_equal "partners.shopify.com", got
     end
 
+    def test_spin_url_returns_complete_override
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "namespace",
+        Constants::EnvironmentVariables::SPIN_HOST.to_s => "host",
+      }
+
+      # When
+      got = Environment.partners_domain(env_variables: env_variables)
+
+      # Then
+      assert_equal "partners.abcd.namespace.host", got
+    end
+
+    def test_spin_url_raises_partial_override
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::SPIN.to_s => "1",
+        Constants::EnvironmentVariables::SPIN_WORKSPACE.to_s => "abcd",
+        Constants::EnvironmentVariables::SPIN_NAMESPACE.to_s => "namespace",
+      }
+
+      # When/Then
+      assert_raises(RuntimeError) do
+        Environment.partners_domain(env_variables: env_variables)
+      end
+    end
+
     def test_spin_url_returns_specified_instance_url
       # Given
       env_variables = {
-        Constants::EnvironmentVariables::SPIN_PARTNERS.to_s => "1",
+        Constants::EnvironmentVariables::SPIN.to_s => "1",
         Constants::EnvironmentVariables::SPIN_INSTANCE.to_s => "abcd",
       }
       Environment.expects(:spin_show).with.returns(@mock_spin_instance.to_json)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The latest update for the spin CLI removed the `spin info fqdn` feature that we relied upon to get the latest spin instance fqdn.

A previous PR put up a warning instructing users to find their spin fqdn manually, but it's nice for users to not have to look this up.

### WHAT is this pull request doing?

It refactors the spin code so that we don't have 3 separate ways to retrieve the spin url and a number of possible invalid configurations.

The new system:
- If you have `SPIN` set, we'll use the spin url returned by the spin tool
- If you've set `SPIN_WORKSPACE`, `SPIN_NAMESPACE`, and `SPIN_HOST` we'll use those instead of asking spin for the FQDN.
- If you set `SPIN_INSTANCE`, we'll call `spin show --json` and get that particular instance
- If you don't set `SPIN_INSTANCE`, we'll call `spin show --latest --json` which gets the latest instance

This means that you need the spin tool installed to target spin instances with the CLI, but that seems like a reasonable assumption. We can append to this as further use cases come up.

### How to test your changes?

Set `SPIN` to `1`

Try to login with `shopify login`. It should send you to the latest identity instance.

Set `SPIN_INSTANCE` to the name of a spin instance which isn't the latest.

Try to login with `shopify login`. It should send you to the instance specified.

### Post-release steps

This is for internal developers, so we don't need to do anything on release.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.