### PR TITLE
Run theme-check as a code dependency, not a pseudo-CLI invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
 * [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update
+* [#2018](https://github.com/Shopify/shopify-cli/pull/2018): Run theme-check as a code dependency, not a pseudo-CLI invocation
 
 ## Version 2.15.2
 

--- a/lib/project_types/extension/commands/check.rb
+++ b/lib/project_types/extension/commands/check.rb
@@ -32,7 +32,12 @@ module Extension
 
       def call(*)
         if project.specification_identifier == "THEME_APP_EXTENSION"
-          @theme_check.run
+          begin
+            @theme_check.run!
+          rescue ThemeCheck::Cli::Abort, ThemeCheck::ThemeCheckError => e
+            raise ShopifyCLI::Abort,
+              ShopifyCLI::Context.message("theme.check.error", e.full_message)
+          end
         else
           @ctx.abort(@ctx.message("check.unsupported", project.specification_identifier))
         end

--- a/lib/project_types/theme/commands/check.rb
+++ b/lib/project_types/theme/commands/check.rb
@@ -24,7 +24,12 @@ module Theme
       end
 
       def call(*)
-        @theme_check.run
+        begin
+          @theme_check.run!
+        rescue ThemeCheck::Cli::Abort, ThemeCheck::ThemeCheckError => e
+          raise ShopifyCLI::Abort,
+            ShopifyCLI::Context.message("theme.check.error", e.full_message)
+        end
       end
 
       def self.help

--- a/lib/project_types/theme/commands/check.rb
+++ b/lib/project_types/theme/commands/check.rb
@@ -24,12 +24,10 @@ module Theme
       end
 
       def call(*)
-        begin
-          @theme_check.run!
-        rescue ThemeCheck::Cli::Abort, ThemeCheck::ThemeCheckError => e
-          raise ShopifyCLI::Abort,
-            ShopifyCLI::Context.message("theme.check.error", e.full_message)
-        end
+        @theme_check.run!
+      rescue ThemeCheck::Cli::Abort, ThemeCheck::ThemeCheckError => e
+        raise ShopifyCLI::Abort,
+          ShopifyCLI::Context.message("theme.check.error", e.full_message)
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -191,6 +191,7 @@ module Theme
             Check your theme for errors, suggestions, and best practices.
             Usage: {{command:%s check}}
           HELP
+          error: "Theme check failed with error:\n%s",
         },
         delete: {
           help: <<~HELP,

--- a/test/project_types/theme/commands/check_test.rb
+++ b/test/project_types/theme/commands/check_test.rb
@@ -9,7 +9,7 @@ module Theme
 
       def test_command_runs_theme_check
         context = ShopifyCLI::Context.new
-        ThemeCheck::Cli.any_instance.expects(:run)
+        ThemeCheck::Cli.any_instance.expects(:run!)
 
         Theme::Command::Check.new(context).call([])
       end
@@ -20,6 +20,20 @@ module Theme
 
         command = Theme::Command::Check.new(context)
         command.options.parse(nil, ["-l"])
+      end
+
+      def test_command_runs_theme_check_and_handles_error
+        context = ShopifyCLI::Context.new
+        error = ThemeCheck::Cli::Abort.new("There was a problem!")
+        ThemeCheck::Cli.any_instance.expects(:run!).raises(error)
+
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+          Theme::Command::Check.new(context).call([])
+        end
+
+        assert_message_output(io: io, expected_content: [
+          ShopifyCLI::Context.message('theme.check.error', error.full_message)
+        ])
       end
     end
   end

--- a/test/project_types/theme/commands/check_test.rb
+++ b/test/project_types/theme/commands/check_test.rb
@@ -32,7 +32,7 @@ module Theme
         end
 
         assert_message_output(io: io, expected_content: [
-          ShopifyCLI::Context.message('theme.check.error', error.full_message)
+          ShopifyCLI::Context.message("theme.check.error", error.full_message),
         ])
       end
     end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Partial fix to #1972 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

Whereas `theme-check` is designed to be used as a CLI, we're directly calling the code under the hood. The `#run` method we currently use is not really designed for our use case, as it includes `exit` which we don't want a dependency to do for us.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This commit switches to using `#run!` because that will at worst raise an error which we can bubble up in CLI-appropriate form.


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Have theme-check raise a `ThemeCheckError`


### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).