### PR TITLE
Add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '31 3 * * *' # randomly chosen time of day
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-issue-stale: 90
+        days-before-pr-stale: 30
+        days-before-close: 10
+        stale-issue-message: |-
+          It seems this issue has been sitting for a while.
+
+          To help the CLI maintainers focus on problems users are still facing, I've been tasked with cleaning up issues that have gone untouched for too long, as they're likely out-of-date.
+
+          If this is still relevant, please post a comment within a week, and I'll be happy to leave this issue as is.
+
+          Have a great day!
+        stale-pr-message: |-
+          This PR hasn't been touched in some time. Is it still relevant?
+
+          If so, please comment within the next week. Otherwise, I'll assume this is no longer desired, and close the PR.
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        operations-per-run: 10 # temporary so we can ease into staling and see what happens


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

Warning:

![controversy](https://media3.giphy.com/media/CQ4zJvpvi57RiMYoiQ/giphy.gif?cid=790b7611131f5c5d327c6d7504de5204da0444e270c70931&rid=giphy.gif&ct=g)

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

We have a problem. Issues are always being opened up, and we can't fix all of them immediately, all the time.

Some issues have too little details, others aren't quite ready for a fix...

But the list has gotten very long, and GitHub issues is becoming a non-ideal way of maintaining a list of requests.

This is one weapon among many in addressing the issue. The goal isn't to silence anyone, but to make sure that any old issues which are no longer relevant won't be cluttering up the issues for too long.

Similarly, if the opener isn't going to follow up with communication, we have a much smaller chance of being able to fix their issue.

To that end, I've chosen a very long window - 90 days - where issues stay open without any complaint. By that point, 6 releases later, chances are we've either fixed the problem already, or forgotten about it. (And it can definitely happen that we ask, "We think we've fixed it, is your problem solved?" but then forget to go ahead and close the issue. Now there's something to catch those issues as well.)

I've also included an auto-close for PRs, which should help us make sure we finish what we start!

Remember, just 1 comment resets the timer, so it should almost never happen that something someone cares about actually gets closed!

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Adds [GitHub's stale-bot](https://github.com/actions/stale) to our actions

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
N/A

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

This will likely set off a 💣 for us. So I've limited to 10 operations per day. Hopefully that will be a manageable pace for clearing out the backlog.

We can always speed it up or slow it down, or halt entirely if it seems to be causing more trouble than it's worth.

### Update checklist

All N/A
- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).

- [x] I've included any post-release steps in the section above.