### PR TITLE
Removes spin-legacy support

### DIFF
--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -106,17 +106,8 @@ module ShopifyCLI
 
     def self.spin_url(env_variables: ENV)
       if infer_spin?(env_variables: env_variables)
-        # TODO: Remove version check and delete spin-legacy branch
-        #  once spin2 becomes the installed "spin" binary by default
-        spin_version = %x(spin version 2> /dev/null).strip
-        if spin_version.start_with?("spin-")
-          # spin2
-          raise ShopifyCLI:: Abort, "SPIN_INSTANCE must be specified" unless ENV.key?("SPIN_INSTANCE")
-          %x(spin show -o fqdn 2> /dev/null).strip
-        else
-          # spin-legacy
-          %x(spin info fqdn 2> /dev/null).strip
-        end
+        raise ShopifyCLI:: Abort, "SPIN_INSTANCE must be specified" unless ENV.key?("SPIN_INSTANCE")
+        %x(spin show -o fqdn 2> /dev/null).strip
       else
         spin_workspace = spin_workspace(env_variables: env_variables)
         spin_namespace = spin_namespace(env_variables: env_variables)


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is a follow-up to #2011. Now that all Spin users have been upgraded to `spin2` automatially, there is no reason to continue supporting `spin-legacy`. Thus, that code has been deleted.

### WHAT is this pull request doing?

See above.

### How to test your changes?

Internal use of `shopify` should remain stable.

### Post-release steps

Nothing special that I can think of.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.