### PR TITLE
Fix Theme::Syncer `download_file!` handling of file deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2030](https://github.com/Shopify/shopify-cli/pull/2030): Fix Theme::Syncer handling of file deletions in `download_file!`
+
 ## Version 2.11.0
 
 ### Fixed

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -168,7 +168,7 @@ module ShopifyCLI
           # Delete local files not present remotely
           missing_files = @theme.theme_files
             .reject { |file| checksums.key?(file.relative_path.to_s) }.uniq
-            .reject { |file| ignore_path?(file) }
+            .reject { |file| ignore_file?(file) }
           missing_files.each do |file|
             @ctx.debug("rm #{file.relative_path}")
             file.delete
@@ -195,7 +195,7 @@ module ShopifyCLI
         # Already enqueued
         return if @pending.include?(operation)
 
-        if ignore?(operation)
+        if ignore_operation?(operation)
           @ctx.debug("ignore #{operation.file_path}")
           return
         end
@@ -253,13 +253,17 @@ module ShopifyCLI
         response
       end
 
-      def ignore?(operation)
+      def ignore_operation?(operation)
         path = operation.file_path
         ignore_path?(path)
       end
 
-      def ignore_path?(file_or_path)
-        path = file_or_path.respond_to?(:path) ? file_or_path.path : file_or_path
+      def ignore_file?(file)
+        path = file.path
+        ignore_path?(path)
+      end
+
+      def ignore_path?(path)
         ignored_by_ignore_filter?(path) || ignored_by_include_filter?(path)
       end
 

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -42,7 +42,7 @@ module ShopifyCLI
         # Latest theme assets checksums. Updated on each upload.
         @checksums = {}
 
-        # Checksums of assets with errors. 
+        # Checksums of assets with errors.
         @error_checksums = []
       end
 
@@ -168,7 +168,7 @@ module ShopifyCLI
           # Delete local files not present remotely
           missing_files = @theme.theme_files
             .reject { |file| checksums.key?(file.relative_path.to_s) }.uniq
-            .reject { |file| @ignore_filter&.ignore?(file) }
+            .reject { |file| ignore_path?(file) }
           missing_files.each do |file|
             @ctx.debug("rm #{file.relative_path}")
             file.delete
@@ -255,6 +255,11 @@ module ShopifyCLI
 
       def ignore?(operation)
         path = operation.file_path
+        ignore_path?(path)
+      end
+
+      def ignore_path?(file_or_path)
+        path = file_or_path.respond_to?(:path) ? file_or_path.path : file_or_path
         ignored_by_ignore_filter?(path) || ignored_by_include_filter?(path)
       end
 

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -287,7 +287,7 @@ module ShopifyCLI
       def test_download_theme_with_ignores
         @syncer.ignore_filter = mock("IgnoreFilter")
         @syncer.ignore_filter.stubs(:ignore?).returns(false)
-        @syncer.ignore_filter.expects(:ignore?).with(@theme["assets/generated.css.liquid"]).returns(true)
+        @syncer.ignore_filter.expects(:ignore?).with(@theme["assets/generated.css.liquid"].path).returns(true)
 
         @syncer.start_threads
         @syncer.checksums.replace(@theme.theme_files.map { |file| [file.relative_path.to_s, file.checksum] }.to_h)


### PR DESCRIPTION
### WHY are these changes introduced?

These updates fix an issue where a local `package.json` file was being deleted despite being in the `.shopifyignore` file. 

In the Theme::Syncer `download_theme!` method, the files are actually `ShopifyCLI::Theme::File` objects that are getting passed to the IgnoreFilter, so the `match?` method is being called on a string representation of the File object rather than the actual `path` of the File object that should be compared. Because of that the package.json file was not matched and therefore not ignored.

### WHAT is this pull request doing?
This PR:
- updates `download_file!` method to use similar "ignore" handling as the `enqueue` method... using `ignore?` method added in #1892
- extracts `ignore_path?` method from `ignore?` method so it can be called separately from an `operation` argument
- updates `ignore_path?` to check for a `File` object (via checking for a `path` method) and extracts the path from that if it exists

#### alternatively...
The check for the File object could be moved to the IgnoreFilter since `ignore_filter&.ignore?(path)` is called a lot of places, but that might be a little odd to do type-checking in a class that's ostensibly meant to operate on string-like objects.

### How to test your changes?
- have `package.json` in your project folder and remote dev theme that doesn't have `package.json` in it
- add `package.json` to `.shopifyignore` file
- run `theme pull -d` and see package.json delete
```
$ ls -la package.json 
-rw-r--r--  1 johnroyall  staff  3325 Feb  8 22:34 package.json
$ shopify theme pull -d
┏━━ Pulling theme files from Development (8b600b-Johns-MacBook-Pro) (#123318534282) on sections-preview.myshopify.com 
┃                                                                                                100%
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.64s) ━━
✓ Theme pulled successfully
$ git st
On branch develop
Your branch is up to date with 'origin/develop'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    package.json

no changes added to commit (use "git add" and/or "git commit -a")
```

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.