### PR TITLE
Abort if Node is necessary and it's not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#1973](https://github.com/Shopify/shopify-cli/pull/1973): Fix `theme serve` to preview generated files (`*.css.liquid`)
 * [#2033](https://github.com/Shopify/shopify-cli/pull/2033): Pin Homebrew Ruby to 3.0
+* [#2032](https://github.com/Shopify/shopify-cli/pull/2032): Runtime error checking the Node version if Node is not present in the environment.
 
 ## Version 2.11.0
 

--- a/lib/project_types/theme/commands/check.rb
+++ b/lib/project_types/theme/commands/check.rb
@@ -4,7 +4,6 @@ require "theme_check"
 module Theme
   class Command
     class Check < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       class Options < ShopifyCLI::Options

--- a/lib/project_types/theme/commands/delete.rb
+++ b/lib/project_types/theme/commands/delete.rb
@@ -5,7 +5,6 @@ require "shopify_cli/theme/development_theme"
 module Theme
   class Command
     class Delete < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/init.rb
+++ b/lib/project_types/theme/commands/init.rb
@@ -3,7 +3,6 @@
 module Theme
   class Command
     class Init < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/language_server.rb
+++ b/lib/project_types/theme/commands/language_server.rb
@@ -4,7 +4,6 @@ require "theme_check"
 module Theme
   class Command
     class LanguageServer < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       def call(*)

--- a/lib/project_types/theme/commands/package.rb
+++ b/lib/project_types/theme/commands/package.rb
@@ -5,7 +5,6 @@ require "json"
 module Theme
   class Command
     class Package < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       THEME_DIRECTORIES = %w[

--- a/lib/project_types/theme/commands/publish.rb
+++ b/lib/project_types/theme/commands/publish.rb
@@ -4,7 +4,6 @@ require "shopify_cli/theme/theme"
 module Theme
   class Command
     class Publish < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -7,7 +7,6 @@ require "shopify_cli/theme/syncer"
 module Theme
   class Command
     class Pull < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -8,7 +8,6 @@ require "shopify_cli/theme/syncer"
 module Theme
   class Command
     class Push < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -4,7 +4,6 @@ require "shopify_cli/theme/dev_server"
 module Theme
   class Command
     class Serve < ShopifyCLI::Command::SubCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       DEFAULT_HTTP_HOST = "127.0.0.1"

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -100,14 +100,19 @@ module ShopifyCLI
       end
 
       def check_node_version
+        context = Context.new
+        if context.which("node").nil?
+          raise ShopifyCLI::Abort, context.message("core.errors.missing_node")
+        end
         check_version(
           Environment.node_version,
           range: @compatible_node_range,
-          runtime: "Node"
+          runtime: "Node",
+          context: context
         )
       end
 
-      def check_version(version, range:, runtime:)
+      def check_version(version, range:, runtime:, context: Context.new)
         return if Environment.test?
         return if range.nil?
 
@@ -116,7 +121,7 @@ module ShopifyCLI
         is_lower_than_top = version_without_pre_nor_build < Utilities.version_dropping_pre_and_build(range.to)
         return if is_higher_than_bottom && is_lower_than_top
 
-        Context.new.warn("Your environment #{runtime} version, #{version},"\
+        context.warn("Your environment #{runtime} version, #{version},"\
           " is outside of the range supported by the CLI,"\
           " #{range.from}..<#{range.to},"\
           " and might cause incompatibility issues.")

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -101,9 +101,10 @@ module ShopifyCLI
 
       def check_node_version
         context = Context.new
-        if context.which("node").nil?
+        if @compatible_node_range && context.which("node").nil?
           raise ShopifyCLI::Abort, context.message("core.errors.missing_node")
         end
+
         check_version(
           Environment.node_version,
           range: @compatible_node_range,

--- a/lib/shopify_cli/commands/app/create.rb
+++ b/lib/shopify_cli/commands/app/create.rb
@@ -6,9 +6,6 @@ module ShopifyCLI
         subcommand :PHP, "php", "shopify_cli/commands/app/create/php"
         subcommand :Node, "node", "shopify_cli/commands/app/create/node"
 
-        recommend_default_node_range
-        recommend_default_ruby_range
-
         def call(_args, _command_name)
           @ctx.puts(self.class.help)
         end

--- a/lib/shopify_cli/commands/app/create/rails.rb
+++ b/lib/shopify_cli/commands/app/create/rails.rb
@@ -7,7 +7,7 @@ module ShopifyCLI
 
           recommend_default_ruby_range
           recommend_default_node_range
-          
+
           options do |parser, flags|
             parser.on("--name=NAME") { |t| flags[:name] = t }
             parser.on("--organization-id=ID") { |id| flags[:organization_id] = id }

--- a/lib/shopify_cli/commands/app/create/rails.rb
+++ b/lib/shopify_cli/commands/app/create/rails.rb
@@ -5,7 +5,6 @@ module ShopifyCLI
         class Rails < ShopifyCLI::Command::AppSubCommand
           prerequisite_task :ensure_authenticated
 
-          recommend_default_node_range
           recommend_default_ruby_range
 
           options do |parser, flags|

--- a/lib/shopify_cli/commands/app/create/rails.rb
+++ b/lib/shopify_cli/commands/app/create/rails.rb
@@ -6,7 +6,8 @@ module ShopifyCLI
           prerequisite_task :ensure_authenticated
 
           recommend_default_ruby_range
-
+          recommend_default_node_range
+          
           options do |parser, flags|
             parser.on("--name=NAME") { |t| flags[:name] = t }
             parser.on("--organization-id=ID") { |id| flags[:organization_id] = id }

--- a/lib/shopify_cli/commands/app/deploy.rb
+++ b/lib/shopify_cli/commands/app/deploy.rb
@@ -4,7 +4,6 @@ module ShopifyCLI
       class Deploy < ShopifyCLI::Command::AppSubCommand
         subcommand :Heroku, "heroku", "shopify_cli/commands/app/deploy/heroku"
 
-        recommend_default_node_range
         recommend_default_ruby_range
 
         def call(args, _name)

--- a/lib/shopify_cli/commands/app/serve.rb
+++ b/lib/shopify_cli/commands/app/serve.rb
@@ -7,7 +7,6 @@ module ShopifyCLI
         prerequisite_task :ensure_env, :ensure_dev_store
 
         recommend_default_ruby_range
-        recommend_default_node_range
 
         options do |parser, flags|
           parser.on("--host=HOST") do |h|

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -15,6 +15,7 @@ module ShopifyCLI
       },
       core: {
         errors: {
+          missing_node: "Node is necessary for this command and was not found in the environment.",
           option_parser: {
             invalid_option: "The option {{command:%s}} is not supported.",
             missing_argument: "The required argument {{command:%s}} is missing.",

--- a/test/project_types/script/commands/connect_test.rb
+++ b/test/project_types/script/commands/connect_test.rb
@@ -8,6 +8,7 @@ module Script
       include TestHelpers::Partners
       include TestHelpers::FakeUI
       include TestHelpers::FakeFS
+      include TestHelpers::Command
 
       def setup
         super

--- a/test/project_types/script/commands/create_test.rb
+++ b/test/project_types/script/commands/create_test.rb
@@ -8,6 +8,7 @@ module Script
       include TestHelpers::Partners
       include TestHelpers::FakeUI
       include TestHelpers::FakeFS
+      include TestHelpers::Command
 
       def setup
         super

--- a/test/project_types/script/commands/javy_test.rb
+++ b/test/project_types/script/commands/javy_test.rb
@@ -8,6 +8,7 @@ module Script
     class JavyTest < MiniTest::Test
       include TestHelpers::FakeUI
       include TestHelpers::FakeFS
+      include TestHelpers::Command
 
       def setup
         super

--- a/test/test_helpers.rb
+++ b/test/test_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 module TestHelpers
+  autoload :Command, "test_helpers/command"
   autoload :Constants, "test_helpers/constants"
   autoload :FakeTask, "test_helpers/fake_task"
   autoload :FakeContext, "test_helpers/fake_context"

--- a/test/test_helpers/command.rb
+++ b/test/test_helpers/command.rb
@@ -1,0 +1,9 @@
+module TestHelpers
+  module Command
+    def setup
+      ShopifyCLI::Command.stubs(:check_node_version)
+      ShopifyCLI::Command.stubs(:check_node_version)
+      super
+    end
+  end
+end

--- a/test/test_helpers/command.rb
+++ b/test/test_helpers/command.rb
@@ -2,7 +2,7 @@ module TestHelpers
   module Command
     def setup
       ShopifyCLI::Command.stubs(:check_node_version)
-      ShopifyCLI::Command.stubs(:check_node_version)
+      ShopifyCLI::Command.stubs(:check_ruby_version)
       super
     end
   end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli/issues/2031

### WHY are these changes introduced?
The recent introduction of warnings to warn the user if their Node and Ruby might be incompatible with the CLI caused [errors](https://github.com/Shopify/shopify-cli/issues/2031) for users that don't have Node installed.

### WHAT is this pull request doing?
I extended the logic to account for that scenario an abort the execution in that case.

### How to test your changes?
1. Add `recommend_default_node_range` to `whoami.rb`
2. Simulate not having Node, for example changing the `if` statement to be true.
3. Run `bins/shopify whoami`.
4. You should see the error.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.