### PR TITLE
Fix `theme serve` to accept parameters with multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 ### Fixed
 * [#1973](https://github.com/Shopify/shopify-cli/pull/1973): Fix `theme serve` to preview generated files (`*.css.liquid`)
+* [#2034](https://github.com/Shopify/shopify-cli/pull/2034): Fix `theme serve` to accept parameters with multiple values
 
 ## Version 2.11.0
 

--- a/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -43,9 +43,8 @@ module ShopifyCLI
           headers["Accept-Encoding"] = "none"
           headers["User-Agent"] = "Shopify CLI"
 
-          query = URI.decode_www_form(env["QUERY_STRING"]).to_h
+          query = URI.decode_www_form(env["QUERY_STRING"])
           replace_templates = build_replace_templates_param(env)
-
           response = if replace_templates.any?
             # Pass to SFR the recently modified templates in `replace_templates` body param
             headers["Authorization"] = "Bearer #{bearer_token}"
@@ -158,7 +157,7 @@ module ShopifyCLI
         def secure_session_id
           if secure_session_id_expired?
             @ctx.debug("Refreshing preview _secure_session_id cookie")
-            response = request("HEAD", "/", query: { preview_theme_id: @theme.id })
+            response = request("HEAD", "/", query: [[:preview_theme_id, @theme.id]])
             @secure_session_id = extract_secure_session_id_from_response_headers(response)
             @last_session_cookie_refresh = Time.now
           end
@@ -189,9 +188,9 @@ module ShopifyCLI
           response_headers
         end
 
-        def request(method, path, headers: nil, query: {}, form_data: nil, body_stream: nil)
+        def request(method, path, headers: nil, query: [], form_data: nil, body_stream: nil)
           uri = URI.join("https://#{@theme.shop}", path)
-          uri.query = URI.encode_www_form(query.merge(_fd: 0, pb: 0))
+          uri.query = URI.encode_www_form(query + [[:_fd, 0], [:pb, 0]])
 
           @ctx.debug("Proxying #{method} #{uri}")
 

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -138,6 +138,24 @@ module ShopifyCLI
           })
         end
 
+        def test_query_parameters_with_two_values
+          stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0&value=A&value=B")
+            .with(headers: default_proxy_headers)
+            .to_return(status: 200, body: "", headers: {})
+
+          stub_session_id_request
+
+          URI.expects(:encode_www_form)
+            .with([[:preview_theme_id, "123456789"], [:_fd, 0], [:pb, 0]])
+            .returns("_fd=0&pb=0&preview_theme_id=123456789")
+
+          URI.expects(:encode_www_form)
+            .with([["value", "A"], ["value", "B"], [:_fd, 0], [:pb, 0]])
+            .returns("_fd=0&pb=0&value=A&value=B")
+
+          request.get("/?value=A&value=B")
+        end
+
         def test_storefront_redirect_headers_are_rewritten
           stub_request(:get, "https://dev-theme-server-store.myshopify.com/?_fd=0&pb=0")
             .with(headers: default_proxy_headers)


### PR DESCRIPTION
### WHY are these changes introduced?

When users open URLs with multiple occurrences of the same parameter (`?param=A&param=B`), they lose one of the values (`A` or `B`).

### WHAT is this pull request doing?

This PR changes the proxy to no longer convert query parameters into a hash map so users do not lose values anymore.

### How to test your changes?

- Run `shopify theme serve`
- Navigate to the collections page
- Apply multiple filters

**Before this PR**
<img width="1757" alt="before" src="https://user-images.githubusercontent.com/1079279/153184099-bef9a4e3-2413-4144-8811-cde9e5991512.png">

**After this PR**
<img width="1757" alt="after" src="https://user-images.githubusercontent.com/1079279/153184125-535b215d-218d-45bb-944a-5cc1cda30db1.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.