### PR TITLE
[Feature] Support Locales directory in Theme App Extensions

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -6,10 +6,11 @@ module Extension
   module Models
     module SpecificationHandlers
       class ThemeAppExtension < Default
-        SUPPORTED_BUCKETS = %w(assets blocks snippets)
+        SUPPORTED_BUCKETS = %w(assets blocks snippets locales)
         BUNDLE_SIZE_LIMIT = 10 * 1024 * 1024 # 10MB
         LIQUID_SIZE_LIMIT = 100 * 1024 # 100kb
         SUPPORTED_ASSET_EXTS = %w(.jpg .js .css .png .svg)
+        SUPPORTED_LOCALE_EXTS = %w(.json)
 
         def create(directory_name, context, getting_started: false)
           context.root = File.join(context.root, directory_name)
@@ -88,6 +89,11 @@ module Extension
             unless SUPPORTED_ASSET_EXTS.include?(ext)
               raise Extension::Errors::InvalidFilenameError,
                 "Invalid filename: #{filename}; #{ext} is not supported"
+            end
+          elsif dirname == "locales"
+            unless SUPPORTED_LOCALE_EXTS.include?(ext)
+              raise Extension::Errors::InvalidFilenameError,
+                "Invalid filename: #{filename}; Only #{SUPPORTED_LOCALE_EXTS.join(", ")} allowed in #{dirname}"
             end
           elsif ext != ".liquid"
             raise Extension::Errors::InvalidFilenameError,

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -126,6 +126,15 @@ module Extension
           end
         end
 
+        def test_bad_locale_types
+          ThemeAppExtension::SUPPORTED_LOCALE_EXTS.each do |ext|
+            write("locales/test#{ext}1", "hello")
+            assert_raises Extension::Errors::InvalidFilenameError do
+              @spec.config(@context)
+            end
+          end
+        end
+
         def test_too_much_liquid
           stub_const(ThemeAppExtension, :LIQUID_SIZE_LIMIT, 50) do
             write("blocks/app1.liquid", "1" * 25)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
Theme app extensions will accept Locales directory. The new directory must only contain `.json` files.

### WHAT is this pull request doing?
This PR allows the CLI to identify Locales directory in theme app extension as valid directory.


<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.