### PR TITLE
Fix the Homebrew template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2047](https://github.com/Shopify/shopify-cli/pull/2047): Fix the Homebrew installation.
+
 ## Version 2.11.1
 ### Fixed
 * [#1973](https://github.com/Shopify/shopify-cli/pull/1973): Fix `theme serve` to preview generated files (`*.css.liquid`)

--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -13,7 +13,7 @@ require "fileutils"
 class ShopifyCli < Formula
   module RubyBin
     def ruby_bin
-      Formula["ruby"].opt_bin
+      Formula["ruby@3.0"].opt_bin
     end
   end
 
@@ -24,7 +24,10 @@ class ShopifyCli < Formula
       ohai("Fetching shopify-cli from gem source")
       cache.cd do
         ENV["GEM_SPEC_CACHE"] = "#{cache}/gem_spec_cache"
-        system("#{ruby_bin}/gem", "fetch", "shopify-cli", "--version", gem_version)
+        _, err, status = Open3.capture3("#{ruby_bin}/gem", "fetch", "shopify-cli", "--version", gem_version)
+        unless status.success?
+          odie err
+        end
       end
     end
 


### PR DESCRIPTION
### WHY are these changes introduced?
The changes [in this PR](https://github.com/Shopify/shopify-cli/pull/2033) broke the installation through Homebrew because the `def ruby_bin` method is trying to get the path to the Ruby binary from the wrong formula. I've updated it to read it from the `ruby@3.0` and taken the opportunity to improve installation errors.

### WHAT is this pull request doing?
Fix the template that we use to generate the formula at release time.

### How to test your changes?

1. Add the changes to `/opt/homebrew/Library/Taps/shopify/homebrew-shopify/shopify-cli.rb`.
2. Uninstall the CLI with `brew uninstall shopify-cli`.
3. Run `brew install shopify-cli`.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above.