### PR TITLE
[ feature ] Update `theme serve` to accept `root` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+* [#2051](https://github.com/Shopify/shopify-cli/pull/2051): Update `theme serve` to accept `root` argument
+
 ### Fixed
 * [#2005](https://github.com/Shopify/shopify-cli/pull/2005): Fix PHP app serve on Windows environments
 
@@ -81,7 +83,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#1769](https://github.com/Shopify/shopify-cli/pull/1769): Fix `theme push --development --json` to output the proper exit code
 * [#1766](https://github.com/Shopify/shopify-cli/pull/1766): Fix `theme serve` failing with the `--host` property
 * [#1771](https://github.com/Shopify/shopify-cli/pull/1771): Fix `theme push --development --json` to output errors in the STDERR
-* [#1778](https://github.com/Shopify/shopify-cli/pull/1778): Fix ngrok installation check on Windows 
+* [#1778](https://github.com/Shopify/shopify-cli/pull/1778): Fix ngrok installation check on Windows
 * [#1798](https://github.com/Shopify/shopify-cli/pull/1798): Add `--live` option to the `theme pull` and the `theme push` commands
 * [#1788](https://github.com/Shopify/shopify-cli/pull/1788): Improve `theme serve` errors and add logs for successful operations
 * [#1794](https://github.com/Shopify/shopify-cli/pull/1794): Fix bug where hidden subcommands appear in the help menu.
@@ -90,7 +92,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#1722](https://github.com/Shopify/shopify-cli/pull/1722): Fix `theme serve` failing when the port is already being used
 * [#1751](https://github.com/Shopify/shopify-cli/pull/1751): A bug in the app creation flow that caused the CLI to abort when the form validation failed.
-* [#1750](https://github.com/Shopify/shopify-cli/pull/1750): Runtime errors in Windows' environments when the `PATHEXT` environment variable is not defined. 
+* [#1750](https://github.com/Shopify/shopify-cli/pull/1750): Runtime errors in Windows' environments when the `PATHEXT` environment variable is not defined.
 * [#1758](https://github.com/Shopify/shopify-cli/pull/1758): Fix tunnel creation for expired anonymous tunnels
 
 ## Version 2.7.0
@@ -108,7 +110,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#1678](https://github.com/Shopify/shopify-cli/pull/1678): Fix migrator's incompatibility with Ruby 2.5.
 * [#1690](https://github.com/Shopify/shopify-cli/pull/1690): Fix `extension push` command for `PRODUCT_SUBSCRIPTION` extensions
-  
+
 ### Changed
 * [#1678](https://github.com/Shopify/shopify-cli/pull/1678): Change the `@shopify/scripts-checkout-apis-temp` package name to `@shopify/scripts-discount-apis`.
 

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -16,10 +16,11 @@ module Theme
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
       end
 
-      def call(*)
+      def call(args, _name)
+        root = args.first || "."
         flags = options.flags.dup
         host = flags[:host] || DEFAULT_HTTP_HOST
-        ShopifyCLI::Theme::DevServer.start(@ctx, ".", host: host, **flags) do |syncer|
+        ShopifyCLI::Theme::DevServer.start(@ctx, root, host: host, **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
       rescue ShopifyCLI::Theme::DevServer::AddressBindingError

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -96,7 +96,7 @@ module Theme
           help: <<~HELP,
             Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.
 
-            Usage: {{command:%s theme serve}}
+            Usage: {{command:%s theme serve [ ROOT ]}}
 
             Options:
               {{command:--port=PORT}}        Local port to serve theme preview from.

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -7,54 +7,69 @@ module Theme
     class ServeTest < MiniTest::Test
       include TestHelpers::FakeUI
 
+      def setup
+        super
+        @ctx = ShopifyCLI::Context.new
+      end
+
       def test_serve_command
-        context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
 
-        Theme::Command::Serve.new(context).call
+        run_serve_command
       end
 
       def test_serve_command_raises_abort_when_cant_bind_address
-        context = ShopifyCLI::Context.new
         ShopifyCLI::Theme::DevServer
           .expects(:start)
-          .with(context, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
           .raises(ShopifyCLI::Theme::DevServer::AddressBindingError)
 
         assert_raises ShopifyCLI::Abort do
-          Theme::Command::Serve.new(context).call
+          run_serve_command
         end
       end
 
       def test_can_specify_bind_address
-        context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".", host: "0.0.0.0")
+        ShopifyCLI::Theme::DevServer.expects(:start).with(@ctx, ".", host: "0.0.0.0")
 
-        command = Theme::Command::Serve.new(context)
-        command.options.flags[:host] = "0.0.0.0"
-        command.call
+        run_serve_command do |command|
+          command.options.flags[:host] = "0.0.0.0"
+        end
       end
 
       def test_can_specify_port
-        context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
-          host: Theme::Command::Serve::DEFAULT_HTTP_HOST, port: 9293)
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, port: 9293)
 
-        command = Theme::Command::Serve.new(context)
-        command.options.flags[:port] = 9293
-        command.call
+        run_serve_command do |command|
+          command.options.flags[:port] = 9293
+        end
       end
 
       def test_can_specify_poll
-        context = ShopifyCLI::Context.new
-        ShopifyCLI::Theme::DevServer.expects(:start).with(context, ".",
-          host: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)
 
-        command = Theme::Command::Serve.new(context)
-        command.options.flags[:poll] = true
-        command.call
+        run_serve_command do |command|
+          command.options.flags[:poll] = true
+        end
+      end
+
+      def test_can_specify_root
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, "dist", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)
+
+        run_serve_command(["dist"])
+      end
+
+      private
+
+      def run_serve_command(args = [])
+        command = Theme::Command::Serve.new(@ctx)
+        yield(command) if block_given?
+        command.call(args, :serve)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `theme pull`/`push` accept a `[ ROOT ]` argument as the first argument, but `theme serve` does not.

### WHAT is this pull request doing?
- This PR 
  - updates `theme serve` to accept a root argument in the exact same way as `theme pull`/`push`.
  - slight refactor to `serve_test.rb` to simplify testing, while adding test case for this update.

### How to test your changes?
- have a dev theme setup and logged in
- `mkdir dist` inside your project folder
- `theme pull -d dist` to download the remote theme to the `dist` folder
- `theme serve dist` to serve the theme from the `dist` folder
- make a change to the theme (e.g. add random test class to body in `theme.liquid`) inside the `dist` folder and see the change served
<img width="1239" alt="Screen Shot 2022-02-14 at PM 11 37 45" src="https://user-images.githubusercontent.com/608048/153993611-38ed0e03-3b3d-468b-8d2e-7156270ceb43.png">


### Post-release steps
- [ ] update public docs (https://shopify.dev/themes/tools/cli/theme-commands#serve) for `theme serve` usage, and note that `theme serve` doesn't have to be run from inside the theme root.
<img width="1398" alt="Screen Shot 2022-02-14 at PM 11 07 17" src="https://user-images.githubusercontent.com/608048/153990979-a5e4a164-1b80-4d7e-8c32-c2cdad0d9d79.png">

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.