### PR TITLE
Remove unneeded Node requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2047](https://github.com/Shopify/shopify-cli/pull/2047): Fix the Homebrew installation
 * [#2019](https://github.com/Shopify/shopify-cli/pull/2019): Provide helpful link when nokogiri fails to load
+* [#2055](https://github.com/Shopify/shopify-cli/pull/2055): Remove unneeded Node requirements
 
 ## Version 2.11.1
 ### Fixed

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -8,9 +8,6 @@ module Extension
 
       prerequisite_task ensure_project_type: :extension
 
-      recommend_default_node_range
-      recommend_default_ruby_range
-
       YARN_BUILD_COMMAND = %w(build)
       NPM_BUILD_COMMAND = %w(run-script build)
 

--- a/lib/project_types/extension/commands/check.rb
+++ b/lib/project_types/extension/commands/check.rb
@@ -4,7 +4,6 @@ require "theme_check"
 module Extension
   class Command
     class Check < ExtensionCommand
-      recommend_default_node_range
       recommend_default_ruby_range
 
       class CheckOptions < ShopifyCLI::Options

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -5,7 +5,6 @@ module Extension
     class Create < ShopifyCLI::Command::SubCommand
       prerequisite_task :ensure_authenticated
 
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -6,7 +6,6 @@ module Extension
     class Push < ShopifyCLI::Command::SubCommand
       prerequisite_task ensure_project_type: :extension
 
-      recommend_default_node_range
       recommend_default_ruby_range
 
       options do |parser, flags|

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -5,7 +5,6 @@ module Extension
     class Serve < ExtensionCommand
       prerequisite_task ensure_project_type: :extension
 
-      recommend_default_node_range
       recommend_default_ruby_range
 
       DEFAULT_PORT = 39351

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -100,8 +100,10 @@ module ShopifyCLI
       end
 
       def check_node_version
+        return unless @compatible_node_range
+
         context = Context.new
-        if @compatible_node_range && context.which("node").nil?
+        if context.which("node").nil?
           raise ShopifyCLI::Abort, context.message("core.errors.missing_node")
         end
 

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -65,7 +65,7 @@ module ShopifyCLI
       end
 
       module Node
-        FROM = "12.0.0"
+        FROM = "14.5.0"
         TO = "17.0.0"
       end
     end

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -15,7 +15,7 @@ module ShopifyCLI
       },
       core: {
         errors: {
-          missing_node: "Node is necessary for this command and was not found in the environment.",
+          missing_node: "Node is required to continue. Install node here: https://nodejs.org/en/download.",
           option_parser: {
             invalid_option: "The option {{command:%s}} is not supported.",
             missing_argument: "The required argument {{command:%s}} is missing.",
@@ -42,7 +42,7 @@ module ShopifyCLI
             invalid_type: "The type %s is not supported. The only supported types are"\
               " {{command:[ rails | node | php ]}}",
             help: <<~HELP,
-            {{command:%s app create}}: Creates a ruby on rails app.
+            {{command:%s app create}}: Creates a new project in a subdirectory.
               Usage: {{command:%s app create [ rails | node | php ]}}
             HELP
             rails: {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2039

After adding a check to show the recommended versions for Ruby and Node in https://github.com/Shopify/shopify-cli/pull/1945 and https://github.com/Shopify/shopify-cli/pull/2032, we are now requiring Node for all the commands, even when they don't really need it.

### WHAT is this pull request doing?

- Fix the `check_version` method to only run it for the commands defining the recommended Node rage (`recommend_default_node_range`).
- Only check the Node versions for `app create rails` and `app create node`, as it was before.

We could add it as well for other commands like `app serve`, but we should check the type of app to avoid doing it for PHP. Also, we should carefully decide where we want to show it and check what operations really need it, so I'll leave it for another moment.

### How to test your changes?
**Without Node**:
1. Uninstall Node (or temporarily remove your node executable with something like `mv /usr/local/bin/node /usr/local/bin/node.bk`)
2. `shopify login`
3. It should not complain about the Node version

**With a wrong version**:
1. Install Node 12 (or change [Node::TO](https://github.com/Shopify/shopify-cli/blob/a6d7bb8e4f7fe6328a7c6784ca1458a07e1d9ce6/lib/shopify_cli/constants.rb#L69) to `12.0.0`)
2. `shopify extension push`
3. It should not complain about the Node version

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.