### PR TITLE
Release 2.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.11.2
 ### Fixed
 * [#2047](https://github.com/Shopify/shopify-cli/pull/2047): Fix the Homebrew installation
 * [#2019](https://github.com/Shopify/shopify-cli/pull/2019): Provide helpful link when nokogiri fails to load

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.11.1)
+    shopify-cli (2.11.2)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.9.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.11.1"
+  VERSION = "2.11.2"
 end


### PR DESCRIPTION
### Fixed
* [#2047](https://github.com/Shopify/shopify-cli/pull/2047): Fix the Homebrew installation
* [#2019](https://github.com/Shopify/shopify-cli/pull/2019): Provide helpful link when nokogiri fails to load
* [#2055](https://github.com/Shopify/shopify-cli/pull/2055): Remove unneeded Node requirements