### PR TITLE
Improve app serve error message without dev stores

### DIFF
--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -690,7 +690,8 @@ module ShopifyCLI
             },
           },
           ensure_dev_store: {
-            could_not_verify_store: "Couldn't verify your store %s",
+            could_not_verify_store: "Couldn't verify your store. If you don't have a development store set up, "\
+              "please create one in your Partners dashboard and run `shopify app connect`.",
             convert_to_dev_store: <<~MESSAGE,
               Do you want to convert %s to a development store?
               Doing this will allow you to install your app, but the store will become {{bold:transfer-disabled}}.

--- a/test/shopify-cli/tasks/ensure_dev_store_test.rb
+++ b/test/shopify-cli/tasks/ensure_dev_store_test.rb
@@ -18,7 +18,7 @@ module ShopifyCLI
           EnsureDevStore.call(@context)
         end
         assert_includes exception.message, @context.message(
-          "core.tasks.ensure_dev_store.could_not_verify_store", "notther.myshopify.com"
+          "core.tasks.ensure_dev_store.could_not_verify_store"
         )
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/1149
Fixes https://github.com/Shopify/shopify-cli-planning/issues/49

### WHAT is this pull request doing?

Improve the error message shown when trying to serve an application without a development store.

### How to test your changes?

1. Login with a partner account with no development stores
2. Run `shopify app serve`
3. It should show `Couldn't verify your store. If you don't have a development store set up, please create one in your Partners dashboard and run "shopify app connect".`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.