### PR TITLE
Improve Nokogiri LoadError message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2030](https://github.com/Shopify/shopify-cli/pull/2030): Fix Theme::Syncer handling of file deletions in `download_file!`
+* [#2070](https://github.com/Shopify/shopify-cli/pull/2070): Improve Nokogiri LoadError message
 
 ## Version 2.11.2
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2030](https://github.com/Shopify/shopify-cli/pull/2030): Fix Theme::Syncer handling of file deletions in `download_file!`
-* [#2070](https://github.com/Shopify/shopify-cli/pull/2070): Improve Nokogiri LoadError message
 
 ## Version 2.11.2
 ### Fixed

--- a/bin/shopify
+++ b/bin/shopify
@@ -16,10 +16,14 @@ module Kernel
     raise if name == "#{RUBY_VERSION.split(".")[0, 2].join(".")}/ffi_c"
     # Special case for nokogiri, which might install the wrong architecture
     if name == "nokogiri/nokogiri"
-      STDERR.puts "[Note] Nokogiri is failing to load, which most likely means " \
-        "it is installed with the wrong architecture for your system. This link " \
-        "has instructions for how to install the correct version for your system: " \
-        "https://nokogiri.org/tutorials/installing_nokogiri.html"
+      STDERR.puts(<<~MESSAGE)
+        The Nokogiri gem is failing to load, due to an installation or architecture issue.
+
+        To fix this, reinstall Nokogiri.
+
+        • Installation guide: https://nokogiri.org/tutorials/installing_nokogiri.html
+
+      MESSAGE
       STDERR.puts e.full_message
       exit(1)
     end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Followup to #2019

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
The previous PR didn't have a properly reviewed error message. This brings the message in line with our voice.
<img width="1768" alt="Screen Shot 2022-02-17 at 12 03 41" src="https://user-images.githubusercontent.com/6288426/154452673-6e308a1f-c1fd-4aa3-ad4a-34ad8945d0e9.png">

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Not an easy way to test it properly without deliberately installing the wrong Nokogiri. I generated the preview image above by changing `require` to pretend it failed to load nokogiri and raise a LoadError.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).