### PR TITLE
Fix `theme pull` error message when development theme doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2030](https://github.com/Shopify/shopify-cli/pull/2030): Fix Theme::Syncer handling of file deletions in `download_file!`
+* [#2071](https://github.com/Shopify/shopify-cli/pull/2071): Fix `theme pull` error message when dev theme doesn't exist
 
 ## Version 2.11.2
 ### Fixed

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -75,7 +75,7 @@ module Theme
 
         if development
           dev_theme = ShopifyCLI::Theme::DevelopmentTheme.find(@ctx, root: root)
-          return dev_theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", 'development'))
+          return dev_theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", "development"))
         end
 
         select_theme(root)

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -75,7 +75,7 @@ module Theme
 
         if development
           dev_theme = ShopifyCLI::Theme::DevelopmentTheme.find(@ctx, root: root)
-          return dev_theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", dev_theme.name))
+          return dev_theme || @ctx.abort(@ctx.message("theme.pull.theme_not_found", 'development'))
         end
 
         select_theme(root)

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -133,6 +133,9 @@ module Theme
           .with(@ctx, root: ".")
           .returns(nil)
 
+        @ctx.expects(:message)
+          .with("theme.pull.theme_not_found", "development")
+
         @ctx.expects(:abort)
 
         @command.options.flags[:development] = true

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -128,6 +128,17 @@ module Theme
         @command.call([], "pull")
       end
 
+      def test_pull_development_theme_when_does_not_exist
+        ShopifyCLI::Theme::DevelopmentTheme.expects(:find)
+          .with(@ctx, root: ".")
+          .returns(nil)
+
+        @ctx.expects(:abort)
+
+        @command.options.flags[:development] = true
+        @command.call([], "pull")
+      end
+
       def test_pull_pass_nodelete_to_syncer
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: ".", identifier: 1234)


### PR DESCRIPTION
### WHY are these changes introduced?

fixes `NoMethodError: undefined method 'name'`
```
NoMethodError: undefined method `name' for nil:NilClass
    /Users/johnroyall/shopify-cli-kilgore5/lib/project_types/theme/commands/pull.rb:78:in `find_theme'
```

### WHAT is this pull request doing?
The dev_theme object will be nil if the theme is not found, so this PR just passes `development` as a string to the error message instead of trying to access the non-existent theme

### How to test your changes?
- delete dev theme
- run `SHOPIFY_CLI_STACKTRACE=1 shopify theme pull -d`
- see correct error message instead of NoMethodError

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.