### PR TITLE
Default dev entry main

### DIFF
--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -18,7 +18,7 @@ module Extension
       property! :type, accepts: String
 
       DEFAULT_BUILD_DIR = "build"
-      DEFAULT_MAIN = Dir['src/*'].lazy.grep(/index.[jt]sx?/).first
+      DEFAULT_MAIN = Dir["src/*"].lazy.grep(/index.[jt]sx?/).first
 
       def self.call(*args)
         new(*args).call


### PR DESCRIPTION
[Issue #210](https://github.com/Shopify/shopify-cli-extensions/issues/210) - Remove entrypoint configuration requirement

