### PR TITLE
Release Wasm Scripts Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#1866](https://github.com/Shopify/shopify-cli/pull/1866): Enforce git dependency
 * [#2009](https://github.com/Shopify/shopify-cli/pull/2009): Add localization support for Checkout Extensions
+* [#2076](https://github.com/Shopify/shopify-cli/pull/2076): Release Wasm Script Projects
 
 ### Fixed
 * [#2030](https://github.com/Shopify/shopify-cli/pull/2030): Fix Theme::Syncer handling of file deletions in `download_file!`

--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -9,7 +9,6 @@ payment_methods:
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
-      beta: true
       repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_methods:
   domain: 'checkout'
@@ -22,7 +21,6 @@ shipping_methods:
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
-      beta: true
       repo: "https://github.com/Shopify/scripts-apis-examples"
 merchandise_discount_types:
   beta: true
@@ -33,7 +31,6 @@ merchandise_discount_types:
       package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
-      beta: true
       repo: "https://github.com/Shopify/scripts-apis-examples"
 delivery_discount_types:
   beta: true
@@ -44,5 +41,4 @@ delivery_discount_types:
       package: "@shopify/scripts-discounts-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
-      beta: true
       repo: "https://github.com/Shopify/scripts-apis-examples"


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up to https://github.com/Shopify/shopify-cli/pull/2061
Fixes https://github.com/Shopify/script-service/issues/4320

### WHAT is this pull request doing?

Removes the beta flag on the wasm language.

### How to test your changes?

Do `shopify script create` with the `scripts_beta_languages` flag disabled.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.