### PR TITLE
Stabilize the `ShopifyCLI::Theme::SyncerTest` class

### DIFF
--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -25,8 +25,6 @@ module ShopifyCLI
           .returns("12345678")
 
         File.any_instance.stubs(:write)
-
-        @syncer.start_threads
       end
 
       def teardown
@@ -35,6 +33,7 @@ module ShopifyCLI
       end
 
       def test_update_text_file
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
@@ -63,6 +62,7 @@ module ShopifyCLI
       end
 
       def test_update_binary_file
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
@@ -91,6 +91,7 @@ module ShopifyCLI
       end
 
       def test_delete_file
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
@@ -115,6 +116,7 @@ module ShopifyCLI
       end
 
       def test_upload_when_unmodified
+        @syncer.start_threads
         @syncer.checksums["assets/theme.css"] = @theme["assets/theme.css"].checksum
 
         ShopifyCLI::AdminAPI.expects(:rest_request).never
@@ -124,6 +126,7 @@ module ShopifyCLI
       end
 
       def test_fetch_checksums
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
@@ -146,6 +149,7 @@ module ShopifyCLI
       end
 
       def test_fetch_checksums_with_duplicate_liquid_assets
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
@@ -175,6 +179,7 @@ module ShopifyCLI
       end
 
       def test_update_checksum_after_upload
+        @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).returns([
           200,
           {
@@ -205,13 +210,15 @@ module ShopifyCLI
       end
 
       def test_logs_upload_error
-        @syncer.start_threads
-
         file = @theme.static_asset_files.first
-        @ctx.expects(:error).once
-        ShopifyCLI::AdminAPI.expects(:rest_request).raises(RuntimeError.new("oops"))
+        @ctx.expects(:error)
+
+        response_body = JSON.generate(errors: { message: "oops" })
+        ShopifyCLI::AdminAPI.stubs(:rest_request).raises(client_error(response_body))
 
         @syncer.enqueue_updates([file])
+
+        @syncer.start_threads
         @syncer.wait!
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `ShopifyCLI::Theme::SyncerTest` class is intermittently failing in the CI (the unstable tests are `test_theme_files_are_pending_during_upload` and `test_logs_upload_error`).


### WHAT is this pull request doing?

This PR:
- Removes the `@syncer.start_threads` from the setup, so it's not called twice in some methods anymore (which avoids the intermittent issue in the `test_theme_files_are_pending_during_upload` test
- Improves the mocking mechanism of the `test_logs_upload_error`


### How to test your changes?

- Run the following command in the `shopify-cli` repository directory:
  ```
   for i in {1..5000}; do; echo $i; ruby -I test test/shopify-cli/theme/syncer_test.rb ; done;
   ```
- Notice that the `test_logs_upload_error` and `test_theme_files_are_pending_during_upload` tests no longer break intermittently

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.