### PR TITLE
Gracefully handle unknow extension surface areas

### DIFF
--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -12,12 +12,20 @@ module Extension
           argo_configuration = extract_argo_configuration(attributes)
           next if argo_configuration.nil?
           surface_area = extract_surface_area(argo_configuration)
-          surface_area_configuration = fetch_surface_area_configuration(surface_area)
-          argo_configuration.merge!(surface_area_configuration)
+          if known_surface_area?(surface_area)
+            surface_area_configuration = fetch_surface_area_configuration(surface_area)
+            argo_configuration.merge!(surface_area_configuration)
+          else
+            clear_argo_configuration(attributes)
+          end
         end
       end
 
       private
+
+      def known_surface_area?(surface_area)
+        surface_area_configurations.keys.include?(surface_area.to_sym)
+      end
 
       def extract_argo_configuration(attributes)
         attributes.dig(:features, :argo)
@@ -33,6 +41,11 @@ module Extension
         surface_area_configurations.fetch(surface_area.to_sym) do
           raise UnknownSurfaceArea, "Unknown surface area: #{surface_area}"
         end
+      end
+
+      def clear_argo_configuration(attributes)
+        attributes[:name] = "#{attributes[:name]} (Warning: surface area not configured properly)"
+        attributes[:features][:argo] = nil
       end
 
       def surface_area_configurations

--- a/test/project_types/extension/tasks/configure_features_test.rb
+++ b/test/project_types/extension/tasks/configure_features_test.rb
@@ -20,13 +20,6 @@ module Extension
         end
       end
 
-      def test_fails_when_surface_is_unknown
-        result = ConfigureFeatures
-          .call(build_set_of_specification_attributes(surface: "unknown"))
-        assert_predicate(result, :failure?)
-        assert_kind_of(ConfigureFeatures::UnknownSurfaceArea, result.error)
-      end
-
       def test_fails_when_surface_is_unspecified
         attributes = build_set_of_specification_attributes.tap do |attrs|
           attrs.first[:features][:argo].delete(:surface)
@@ -66,10 +59,18 @@ module Extension
         assert_equal "@shopify/checkout-ui-extensions", result.value.dig(0, :features, :argo, :renderer_package_name)
       end
 
+      def test_gracefully_handles_unknown_surface_areas
+        set_of_attributes = build_set_of_specification_attributes(surface: "unknown-surface-area")
+        result = ConfigureFeatures.call(set_of_attributes)
+        assert_predicate(result, :success?)
+        assert_match(/Warning: surface area not configured properly/, result.value.dig(0, :name))
+      end
+
       private
 
       def build_set_of_specification_attributes(surface: "admin")
         [{
+          name: "Test extension",
           identifier: "test_extension",
           features: {
             argo: {


### PR DESCRIPTION
### WHY are these changes introduced?

Creating CLI extensions fails for Shopify Developers using Spin

### WHAT is this pull request doing?

Previously, extension surface areas that weren't properly configured would cause the CLI to error out. Now, the name of the extension gets updated with a warning that it is still under development. This will let Shopify developers working on new extensions know that further work is required while also not getting in the way when you create extension so a different type.

This issue should never occur in production. It surface because the extensions spin template activates beta flags for extensions that are still under development. One of these extensions still requires work in the CLI to be done to function properly. We now gracefully degrade if we know in advance that we can't proceed.

### How to test your changes?

As this is concerning a feature that isn't publicly released yet, please contact me for testing instructions.

### Post-release steps

None. This only affects developers at Shopify.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.
