### PR TITLE
[Fix] Scan for regex pattern when checking Ruby version

### DIFF
--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -12,9 +12,9 @@ module ShopifyCLI
     ]
 
     def self.ruby_version(context: Context.new)
-      out, err, stat = context.capture3('ruby -e "puts RUBY_VERSION"')
+      out, err, stat = context.capture3("ruby", "-v")
       raise ShopifyCLI::Abort, err unless stat.success?
-      out = out.gsub('"', "")
+      out = out.scan(/\d+\.\d+\.\d+/).first
       ::Semantic::Version.new(out.chomp)
     end
 


### PR DESCRIPTION
In rare cases, using the entire output from Ruby may not work. This should fix it.

Fixes #2063

### How to test your changes?

```
> shopify version
2.11.2
```

### Update checklist

- [N/A] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [Y] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [Y] I've left the version number as is (we'll handle incrementing this when releasing).
- [N/A] I've included any post-release steps in the section above.