### PR TITLE
[Feature] Add new Theme CLI commands: `theme list` and `theme open`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+### Added
+* [#2087](https://github.com/Shopify/shopify-cli/pull/2087): Add new Theme CLI commands: `theme list` and `theme open`
 
 ## Version 2.12.0
 ### Added

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -14,6 +14,8 @@ module Theme
     subcommand :Check, "check", Project.project_filepath("commands/check")
     subcommand :Publish, "publish", Project.project_filepath("commands/publish")
     subcommand :Package, "package", Project.project_filepath("commands/package")
+    subcommand :Open, "open", Project.project_filepath("commands/open")
+    subcommand :List, "list", Project.project_filepath("commands/list")
     subcommand :LanguageServer, "language-server", Project.project_filepath("commands/language_server")
   end
   ShopifyCLI::Commands.register("Theme::Command", "theme")

--- a/lib/project_types/theme/commands/list.rb
+++ b/lib/project_types/theme/commands/list.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "shopify_cli/theme/theme"
+require "project_types/theme/presenters/themes_presenter"
+
+module Theme
+  class Command
+    class List < ShopifyCLI::Command::SubCommand
+      recommend_default_ruby_range
+
+      def call(_args, _name)
+        @ctx.puts(@ctx.message("theme.list.title", shop))
+
+        themes_presenter.all.each do |theme|
+          @ctx.puts("  #{theme}")
+        end
+      end
+
+      def self.help
+        @ctx.message("theme.list.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
+      end
+
+      private
+
+      def themes_presenter
+        Theme::Presenters::ThemesPresenter.new(@ctx, nil)
+      end
+
+      def shop
+        ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/open.rb
+++ b/lib/project_types/theme/commands/open.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/development_theme"
+
+module Theme
+  class Command
+    class Open < ShopifyCLI::Command::SubCommand
+      recommend_default_ruby_range
+
+      options do |parser, flags|
+        parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
+        parser.on("-l", "--live") { flags[:live] = true }
+        parser.on("-d", "--development") { flags[:development] = true }
+      end
+
+      def call(_args, _name)
+        theme = find_theme(**options.flags)
+
+        @ctx.puts(@ctx.message("theme.open.details", theme.name, theme.editor_url))
+        @ctx.open_url!(theme.preview_url)
+      end
+
+      def self.help
+        ShopifyCLI::Context.message("theme.open.help", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
+      end
+
+      def find_theme(theme: nil, live: nil, development: nil, **_args)
+        return theme_by_identifier(theme) if theme
+        return live_theme if live
+        return development_theme if development
+
+        select_theme
+      end
+
+      def theme_by_identifier(identifier)
+        theme = ShopifyCLI::Theme::Theme.find_by_identifier(@ctx, identifier: identifier)
+        theme || not_found_error(identifier)
+      end
+
+      def development_theme
+        theme = ShopifyCLI::Theme::DevelopmentTheme.find(@ctx)
+        theme || not_found_error("development")
+      end
+
+      def live_theme
+        ShopifyCLI::Theme::Theme.live(@ctx)
+      end
+
+      def not_found_error(identifier)
+        @ctx.abort(@ctx.message("theme.open.theme_not_found", identifier))
+      end
+
+      def select_theme
+        form = Forms::Select.ask(
+          @ctx,
+          [],
+          title: @ctx.message("theme.open.select"),
+          root: nil
+        )
+        form&.theme
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -87,7 +87,7 @@ module Theme
               {{info:View your theme:}}
               {{underline:%s}}
 
-              {{info:Customize this theme in the Online Store Editor:}}
+              {{info:Customize this theme in the Theme Editor:}}
               {{underline:%s}}
           DONE
           name: "Theme name",
@@ -130,7 +130,7 @@ module Theme
           SERVING
           customize_or_preview: <<~CUSTOMIZE_OR_PREVIEW,
 
-            Customize this theme in the Online Store Editor:
+            Customize this theme in the Theme Editor:
             {{green:%s}}
 
             Share this theme preview:
@@ -214,6 +214,35 @@ module Theme
             {{warning:The {{command:-i, --themeid}} flag is deprecated. Use {{command:-t, --theme}} instead.}}
           WARN
           theme_not_found: "Theme \"%s\" doesn't exist",
+        },
+        open: {
+          select: "Select a theme to open",
+          theme_not_found: "Theme \"%s\" doesn't exist",
+          details: <<~DETAILS,
+            {{*}} {{bold:%s}}
+
+            Customize your theme in the Theme Editor:
+            {{green:%s}}
+
+          DETAILS
+          help: <<~HELP,
+            {{command:%s theme open}}: Opens the preview of your remote theme.
+
+            Usage: {{command:%s theme open}}
+
+            Options:
+              {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of your theme.
+              {{command:-l, --live}}             Open your live theme.
+              {{command:-d, --development}}      Open your development theme.
+          HELP
+        },
+        list: {
+          title: "{{*}} List of {{bold:%s}} themes:",
+          help: <<~HELP,
+            {{command:%s theme list}}: Lists your remote themes.
+
+            Usage: {{command:%s theme list}}
+          HELP
         },
       },
     }.freeze

--- a/lib/project_types/theme/presenters/theme_presenter.rb
+++ b/lib/project_types/theme/presenters/theme_presenter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Theme
+  module Presenters
+    class ThemePresenter
+      extend Forwardable
+
+      COLOR_BY_ROLE = {
+        "live" => "green",
+        "unpublished" => "yellow",
+        "development" => "blue",
+      }
+
+      attr_reader :theme
+
+      def_delegators :theme, :id, :name, :role
+
+      def initialize(theme)
+        @theme = theme
+      end
+
+      def to_s(mode = :long)
+        case mode
+        when :short
+          "{{bold:#{name} #{theme_tags}}}"
+        when :long
+          "{{green:##{id}}} {{bold:#{name} #{theme_tags}}}"
+        else
+          inspect
+        end
+      end
+
+      private
+
+      def theme_tags
+        tags = ["{{#{tag_color}:[#{role}]}}"]
+        tags << "{{cyan:[yours]}}}}" if theme.current_development?
+        tags.join(" ")
+      end
+
+      def tag_color
+        COLOR_BY_ROLE[role] || "italic"
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/presenters/themes_presenter.rb
+++ b/lib/project_types/theme/presenters/themes_presenter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "theme_presenter"
+
+module Theme
+  module Presenters
+    class ThemesPresenter
+      ORDER_BY_ROLE = %w(live unpublished development)
+
+      def initialize(ctx, root)
+        @ctx = ctx
+        @root = root
+      end
+
+      def all
+        all_themes
+          .sort_by { |theme| order_by_role(theme) }
+          .map { |theme| ThemePresenter.new(theme) }
+      end
+
+      private
+
+      def order_by_role(theme)
+        ORDER_BY_ROLE.index(theme.role) || ORDER_BY_ROLE.size
+      end
+
+      def all_themes
+        ShopifyCLI::Theme::Theme.all(@ctx, root: @root)
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/list_test.rb
+++ b/test/project_types/theme/commands/list_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+
+module Theme
+  module Commands
+    class ListTest < MiniTest::Test
+      def setup
+        super
+        @command = Theme::Command::List.new(ctx)
+      end
+
+      def test_list
+        mock_admin_api_shop
+        mock_themes_presenter
+
+        io = capture_io do
+          @command.call([], "list")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} List of {{bold:dev-theme-server-store.myshopify.com}} themes:",
+          "  Theme 1",
+          "  Theme 2",
+          "  Theme 3",
+        ])
+      end
+
+      private
+
+      def mock_admin_api_shop
+        shop = "dev-theme-server-store.myshopify.com"
+        ShopifyCLI::AdminAPI.stubs(:get_shop_or_abort).returns(shop)
+      end
+
+      def mock_themes_presenter
+        Theme::Presenters::ThemesPresenter
+          .expects(:new)
+          .with(ctx, nil)
+          .returns(themes_presenter)
+      end
+
+      def ctx
+        @ctx ||= ShopifyCLI::Context.new
+      end
+
+      def themes_presenter
+        stub(all: [
+          stub(to_s: "Theme 1"),
+          stub(to_s: "Theme 2"),
+          stub(to_s: "Theme 3"),
+        ])
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/open_test.rb
+++ b/test/project_types/theme/commands/open_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+
+module Theme
+  module Commands
+    class OpenTest < MiniTest::Test
+      def setup
+        super
+        @command = Theme::Command::Open.new(ctx)
+      end
+
+      def test_open_without_flags
+        CLI::UI::Prompt.expects(:ask).returns(theme)
+
+        io = capture_io do
+          @command.call([], "open")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} {{bold:My test theme}}",
+
+          "\n\nCustomize your theme in the Theme Editor:",
+          "{{green:https://test.myshopify.io/editor}}",
+
+          "Please open this URL in your browser:",
+          "{{green:https://test.myshopify.io/preview}}",
+        ])
+      end
+
+      def test_open_with_theme_flag
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(ctx, identifier: 1234)
+          .returns(theme)
+
+        io = capture_io do
+          @command.options.flags[:theme] = 1234
+          @command.call([], "open")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} {{bold:My test theme}}",
+
+          "\n\nCustomize your theme in the Theme Editor:",
+          "{{green:https://test.myshopify.io/editor}}",
+
+          "Please open this URL in your browser:",
+          "{{green:https://test.myshopify.io/preview}}",
+        ])
+      end
+
+      def test_open_with_theme_flag_when_theme_does_not_exist
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(ctx, identifier: 1234)
+          .returns(nil)
+
+        error = assert_raises CLI::Kit::Abort do
+          @command.options.flags[:theme] = 1234
+          @command.call([], "open")
+        end
+
+        assert_equal("{{x}} Theme \"1234\" doesn't exist", error.message)
+      end
+
+      def test_open_with_live_flag
+        ShopifyCLI::Theme::Theme
+          .expects(:live)
+          .with(ctx)
+          .returns(theme)
+
+        io = capture_io do
+          @command.options.flags[:live] = true
+          @command.call([], "open")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} {{bold:My test theme}}",
+
+          "\n\nCustomize your theme in the Theme Editor:",
+          "{{green:https://test.myshopify.io/editor}}",
+
+          "Please open this URL in your browser:",
+          "{{green:https://test.myshopify.io/preview}}",
+        ])
+      end
+
+      def test_open_with_development_flag
+        ShopifyCLI::Theme::DevelopmentTheme
+          .expects(:find)
+          .with(ctx)
+          .returns(theme)
+
+        io = capture_io do
+          @command.options.flags[:development] = true
+          @command.call([], "open")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} {{bold:My test theme}}",
+
+          "\n\nCustomize your theme in the Theme Editor:",
+          "{{green:https://test.myshopify.io/editor}}",
+
+          "Please open this URL in your browser:",
+          "{{green:https://test.myshopify.io/preview}}",
+        ])
+      end
+
+      def test_open_with_development_flag_when_theme_does_not_exist
+        ShopifyCLI::Theme::DevelopmentTheme
+          .expects(:find)
+          .with(ctx)
+          .returns(nil)
+
+        error = assert_raises CLI::Kit::Abort do
+          @command.options.flags[:development] = true
+          @command.call([], "open")
+        end
+
+        assert_equal("{{x}} Theme \"development\" doesn't exist", error.message)
+      end
+
+      private
+
+      def theme
+        @theme ||= stub(
+          "Theme",
+          id: 1234,
+          name: "My test theme",
+          shop: "test.myshopify.io",
+          editor_url: "https://test.myshopify.io/editor",
+          preview_url: "https://test.myshopify.io/preview",
+          live?: false,
+        )
+      end
+
+      def ctx
+        @ctx ||= ShopifyCLI::Context.new
+      end
+    end
+  end
+end

--- a/test/project_types/theme/presenters/theme_presenter_test.rb
+++ b/test/project_types/theme/presenters/theme_presenter_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+require "project_types/theme/presenters/theme_presenter"
+
+module Theme
+  module Presenters
+    class ThemePresenterTest < MiniTest::Test
+      def test_to_s
+        expected = "{{green:#1234}} {{bold:My test theme {{yellow:[unpublished]}}}}"
+        actual = presenter.to_s
+
+        assert_equal(expected, actual)
+      end
+
+      def test_to_s_with_mode_short
+        expected = "{{bold:My test theme {{yellow:[unpublished]}}}}"
+        actual = presenter.to_s(:short)
+
+        assert_equal(expected, actual)
+      end
+
+      def test_to_s_with_live_theme
+        expected = "{{green:#1234}} {{bold:My test theme {{green:[live]}}}}"
+        actual = live_presenter.to_s
+
+        assert_equal(expected, actual)
+      end
+
+      def test_to_s_with_development_theme
+        expected = "{{green:#1234}} {{bold:My test theme {{blue:[development]}} {{cyan:[yours]}}}}}}"
+        actual = development_presenter.to_s
+
+        assert_equal(expected, actual)
+      end
+
+      def test_theme_delegators
+        assert_equal(1234, presenter.id)
+        assert_equal("My test theme", presenter.name)
+        assert_equal("unpublished", presenter.role)
+      end
+
+      private
+
+      def live_presenter
+        live_theme = theme(role: "live")
+        ThemePresenter.new(live_theme)
+      end
+
+      def development_presenter
+        development_theme = theme(role: "development", current_development?: true)
+        ThemePresenter.new(development_theme)
+      end
+
+      def presenter
+        ThemePresenter.new(theme)
+      end
+
+      def theme(options = {})
+        stub({
+          id: 1234,
+          name: "My test theme",
+          shop: "test.myshopify.io",
+          role: "unpublished",
+          editor_url: "https://test.myshopify.io/editor",
+          preview_url: "https://test.myshopify.io/preview",
+          current_development?: false,
+          live?: false,
+          **options,
+        })
+      end
+    end
+  end
+end

--- a/test/project_types/theme/presenters/themes_presenter_test.rb
+++ b/test/project_types/theme/presenters/themes_presenter_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+require "project_types/theme/presenters/themes_presenter"
+require "shopify_cli/theme/theme"
+
+module Theme
+  module Presenters
+    class ThemesPresenterTest < MiniTest::Test
+      def test_all
+        ShopifyCLI::Theme::Theme
+          .expects(:all)
+          .with(ctx, root: root)
+          .returns([
+            theme(0, role: "live"),
+            theme(1, role: "unpublished"),
+            theme(2, role: "development"),
+            theme(3, role: "unpublished"),
+            theme(4, role: "other"),
+            theme(5, role: "live"),
+            theme(6, role: "development"),
+          ])
+
+        presenter = ThemesPresenter.new(ctx, root)
+
+        actual_presenters = presenter.all.map(&:to_s)
+
+        assert_equal(7, actual_presenters.size)
+        assert_match(/Theme.*\[live\]/, actual_presenters[0])
+        assert_match(/Theme.*\[live\]/, actual_presenters[1])
+        assert_match(/Theme.*\[unpublished\]/, actual_presenters[2])
+        assert_match(/Theme.*\[unpublished\]/, actual_presenters[3])
+        assert_match(/Theme.*\[development\]/, actual_presenters[4])
+        assert_match(/Theme.*\[development\]/, actual_presenters[5])
+        assert_match(/Theme.*\[other\]/, actual_presenters[6])
+      end
+
+      private
+
+      def theme(id, attributes = {})
+        stub(id: id, name: "Theme #{id}", current_development?: false, **attributes)
+      end
+
+      def ctx
+        @ctx ||= ShopifyCLI::Context.new
+      end
+
+      def root
+        @root ||= "."
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Partners (#1867) need a command to list themes connected to their store and a command for opening the preview of a specific theme.

### WHAT is this pull request doing?

This PR introduces:
- the `theme list` command, which provides the list of themes connected to the current store; and
- the `theme open` command, which quickly provides a preview of the selected theme (this command accepts the following options: `-t, --theme=NAME_OR_ID`, `-l, --live`, and `-d, --development`).

From the code perspective, this PR introduces presenter classes to take care of the presenting logic. Thus, we've avoided duplication between `Theme::Forms::Select` and the new `Theme::Command::List`.

Also, this PR renames occurrences of the **Online Store Editor** term in favor of **Theme Editor**.

### How to test your changes?

- Run `shopify theme list` and see the list of themes
- Run `shopify theme list -h` and see the help message
- Run `shopify theme open` and select a theme
- Run `shopify theme open -d` and open the development theme
- Run `shopify theme open -l` and open the live theme
- Run `shopify theme open -h` and see the help message

<img width="60%" alt="list" src="https://user-images.githubusercontent.com/1079279/155564164-5b992efe-c1fa-4344-8103-4741cc3bf7c1.png">

<img width="60%" alt="open_d" src="https://user-images.githubusercontent.com/1079279/155564278-c7614455-d1fe-445a-b2b2-cfdea467e35b.png">

<details><summary><b>Click here</b> to see the other screenshots</summary>

<br />

**List**

<img width="60%" alt="list_help" src="https://user-images.githubusercontent.com/1079279/155564730-a619bf29-5b91-4877-a21c-4639e141d15e.png">

<br /><br />

**Open**

<img width="60%" alt="open_help" src="https://user-images.githubusercontent.com/1079279/155564771-0ed3e177-ef90-4e9d-a5b0-dfedc220a8e3.png">
<img width="60%" alt="open_t_name" src="https://user-images.githubusercontent.com/1079279/155564799-75fdcfbd-2659-4482-8ae9-50cb65966b0e.png">
<img width="60%" alt="open_t_id" src="https://user-images.githubusercontent.com/1079279/155564809-9f70d5c4-cc42-499f-9b3a-987edeaff39d.png">
<img width="60%" alt="open_l" src="https://user-images.githubusercontent.com/1079279/155564815-df32cd0e-76b7-4816-aa99-04cb0ed144ba.png">
<img width="60%" alt="open_l" src="https://user-images.githubusercontent.com/1079279/155564844-4a86c987-a15a-44d3-91c0-9c2534b34e5c.gif">

</details>


### Post-release steps

Include the `theme list` and the `theme open` commands in the [documentation](https://shopify.dev/themes/tools/cli/theme-commands).

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.