### PR TITLE
Fix `RootHelper` parse logic to support options with an equal (e.g.: `option=value`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+### Fixed
+* [#2092](https://github.com/Shopify/shopify-cli/pull/2092): Fix `RootHelper` parse logic to support options with an equal (e.g.: `option=value`)
 
 ## Version 2.12.0
 ### Added

--- a/lib/project_types/theme/commands/common/root_helper.rb
+++ b/lib/project_types/theme/commands/common/root_helper.rb
@@ -15,15 +15,16 @@ module Theme
 
           while next_index < argv.size
             element = argv[next_index]
-            option = option_by_key[element]
+            key, value = key_value_tuple(element)
+            option = option_by_key[key]
 
             return element if option.nil?
 
             # Skip the option argument
-            next_index += 1 unless option.arg.nil?
+            next_index += 1 if !option.arg.nil? && !value
 
             # PATTERN arguments take precedence over the `root`
-            if option.arg =~ /PATTERN/
+            if option.arg =~ /PATTERN/ && !value
               next_index += 1 while option_argument?(argv, next_index, option_by_key)
               next
             end
@@ -37,7 +38,7 @@ module Theme
         private
 
         def default_argv(options)
-          options.parser.default_argv
+          options.parser.default_argv.compact
         end
 
         def options_map(options)
@@ -57,7 +58,12 @@ module Theme
           return false unless next_index < argv.size
 
           element = argv[next_index]
-          option_by_key[element].nil?
+          key, _value = key_value_tuple(element)
+          option_by_key[key].nil?
+        end
+
+        def key_value_tuple(element)
+          element.split("=")
         end
       end
     end

--- a/test/project_types/theme/commands/common/root_helper_test.rb
+++ b/test/project_types/theme/commands/common/root_helper_test.rb
@@ -31,6 +31,28 @@ module Theme
           assert_equal(".", root_value(options, "pull"))
         end
 
+        def test_root_value_when_args_is_empty_and_options_include_equals
+          options = options_mock([
+            "theme",
+            "pull",
+            "-x=dir",
+            "-o=dir",
+          ])
+
+          assert_equal(".", root_value(options, "pull"))
+        end
+
+        def test_root_value_when_args_has_a_nil
+          options = options_mock([
+            "theme",
+            "pull",
+            nil,
+            "--theme=off",
+          ])
+
+          assert_equal(".", root_value(options, "pull"))
+        end
+
         def test_root_value_when_root_appears_after_an_option_without_arguments
           options = options_mock([
             "theme",
@@ -41,6 +63,19 @@ module Theme
             "dir",
             "-o",
             "dir",
+          ])
+
+          assert_equal("dir", root_value(options, "pull"))
+        end
+
+        def test_root_value_when_root_appears_after_an_option_without_arguments_and_options_include_equals
+          options = options_mock([
+            "theme",
+            "pull",
+            "-d",
+            "dir",
+            "-x=dir",
+            "-o=dir",
           ])
 
           assert_equal("dir", root_value(options, "pull"))
@@ -67,6 +102,22 @@ module Theme
           assert_equal("dir", root_value(options, "pull"))
         end
 
+        def test_root_value_when_root_appears_after_an_option_with_arguments_and_options_include_equals
+          options = options_mock([
+            "theme",
+            "pull",
+            "-d",
+            "--theme=1",
+            "dir",
+            "-x=sections/announcement-bar.liquid",
+            "-x=sections/apps.liquid",
+            "-o=layout/*",
+            "-o=other",
+          ])
+
+          assert_equal("dir", root_value(options, "pull"))
+        end
+
         def test_root_value_when_root_appears_after_an_option_with_a_list_of_arguments
           options = options_mock([
             "theme",
@@ -88,6 +139,24 @@ module Theme
           assert_equal("dir", root_value(options, "pull"))
         end
 
+        def test_root_value_when_root_appears_after_an_option_with_a_list_of_arguments_and_options_include_equals
+          options = options_mock([
+            "theme",
+            "pull",
+            "-d",
+            "-x",
+            "sections/announcement-bar.liquid",
+            "sections/announcement-bar.liquid",
+            "sections/announcement-bar.liquid",
+            "-o=layout/*",
+            "--theme=1",
+            "dir",
+            "-o=other",
+          ])
+
+          assert_equal("dir", root_value(options, "pull"))
+        end
+
         def test_root_value_when_args_root_is_equal_to_flags
           options = options_mock([
             "theme",
@@ -97,6 +166,18 @@ module Theme
             "dir",
             "-o",
             "dir",
+          ])
+
+          assert_equal("dir", root_value(options, "pull"))
+        end
+
+        def test_root_value_when_args_root_is_equal_to_flags_and_options_include_equals
+          options = options_mock([
+            "theme",
+            "pull",
+            "dir",
+            "-x=dir",
+            "-o=dir",
           ])
 
           assert_equal("dir", root_value(options, "pull"))


### PR DESCRIPTION
### WHY are these changes introduced?

Users may successfully run `shopify-dev theme serve --live-reload off`. However, they face an error when they try to run `shopify-dev theme serve --live-reload=off`.

### WHAT is this pull request doing?

This PR slightly changes the `RootHelper` parse logic to support flags with an `equal` character between the option key and value.

### How to test your changes?

- Go to a theme directory
- Run `shopify theme serve --live-reload=off`
- Notice the CLI no long raises an error

**Before this PR:**
<img width="50%" alt="1" src="https://user-images.githubusercontent.com/1079279/155687868-a7d6791d-666a-480e-89db-f9335ab53c0f.png">

**After this PR:**
<img width="50%" alt="2" src="https://user-images.githubusercontent.com/1079279/155687884-48eeb0d6-7467-4a7b-996c-99e7deeccbef.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.