### PR TITLE
Improve `shopify theme package` to include the `release-notes.md` file

### DIFF
--- a/lib/project_types/theme/commands/package.rb
+++ b/lib/project_types/theme/commands/package.rb
@@ -15,6 +15,7 @@ module Theme
         sections
         snippets
         templates
+        release-notes.md
       ]
 
       def call(args, _name)

--- a/test/project_types/theme/commands/package_test.rb
+++ b/test/project_types/theme/commands/package_test.rb
@@ -17,7 +17,16 @@ module Theme
           "zip",
           "-r",
           "Example-1.0.0.zip",
-          *Theme::Command::Package::THEME_DIRECTORIES,
+          *%w[
+            assets
+            config
+            layout
+            locales
+            sections
+            snippets
+            templates
+            release-notes.md
+          ],
           chdir: theme_root
         )
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `release-notes.md` file is excluded when partners run `shopify theme package`. However, that file is a new requirement to support the Shopify theme update feature.


### WHAT is this pull request doing?

This PR changes the `Theme::Command::Package` class to include the `release-notes.md` file in the list of zipped assets.

Nitpick, but I've also changed the test to fail if something changes in the list of zipped assets.


### How to test your changes?

- Run `shopify-dev theme package` in a theme directory with a `release-notes.md` file
- Unzip the file created by the previous step
- Notice that the `release-notes.md` file is no longer excluded

![demo](https://user-images.githubusercontent.com/1079279/156207236-ad4e05cf-c331-4d3b-a33a-e7c3ea1fdd20.gif)


### Post-release steps

None.


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.