### PR TITLE
Improve `theme pull`/`push` documentation of `only` and `ignore` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2092](https://github.com/Shopify/shopify-cli/pull/2092): Fix `RootHelper` parse logic to support options with an equal (e.g.: `option=value`)
 
 * [#2089](https://github.com/Shopify/shopify-cli/pull/2089): Use javy version 0.2.0
+* [#2205](https://github.com/Shopify/shopify-cli/pull/2105): Improve `theme pull`/`push` documentation of `only` and `ignore` options
 
 ## Version 2.12.0
 ### Added

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -65,8 +65,8 @@ module Theme
                 {{command:-j, --json}}             Output JSON instead of a UI.
                 {{command:-a, --allow-live}}       Allow push to a live theme.
                 {{command:-p, --publish}}          Publish as the live theme after uploading.
-                {{command:-o, --only}}             Upload only the specified files (Multiple flags allowed).
-                {{command:-x, --ignore}}           Skip uploading the specified files (Multiple flags allowed).
+                {{command:-o, --only}}             Upload only the specified files (Multiple patterns allowed).
+                {{command:-x, --ignore}}           Skip uploading the specified files (Multiple patterns allowed).
 
               Run without options to select theme from a list.
           HELP
@@ -202,8 +202,8 @@ module Theme
               {{command:-l, --live}}             Pull theme files from your remote live theme.
               {{command:-d, --development}}      Pull theme files from your remote development theme.
               {{command:-n, --nodelete}}         Runs the pull command without deleting local files.
-              {{command:-o, --only}}             Download only the specified files (Multiple flags allowed).
-              {{command:-x, --ignore}}           Skip downloading the specified files (Multiple flags allowed).
+              {{command:-o, --only}}             Download only the specified files (Multiple patterns allowed).
+              {{command:-x, --ignore}}           Skip downloading the specified files (Multiple patterns allowed).
 
             Run without options to select theme from a list.
           HELP


### PR DESCRIPTION
### WHY are these changes introduced?

After #2066, specifying multiple flags stopped working, but specifying multiple patterns for one flag is working fine as is .

After reviewing `BaseGlob` I think it's too tricky to support globs with no quotes and multiple flags (of the same kind). The logic to find the "option index" does not find the second flag when specified (https://github.com/Shopify/shopify-cli/pull/2066/files#diff-67cce61d7a647d3ad76a77505b4939a6b80046a843919d97e0ad97a30fb49287R13).

### WHAT is this pull request doing?
Since specifying multiple patterns for one flag is fine as is, this PR just updates the help messaging to indicate that multiple patterns are allowed for one flag rather than multiple flags of the same type being supported.

### How to test your changes?
N/A

### Post-release steps
- [ ] update `pull`/`push` docs https://shopify.dev/themes/tools/cli/theme-commands#pull `Specify multiple patterns to ignore by using the flag multiple times in a single command.`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.