### PR TITLE
Fix intermittent error ("can't add a new key into hash during iteration") in the `theme push` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#2103](https://github.com/Shopify/shopify-cli/pull/2103): Improve `shopify theme package` to include the `release-notes.md` file
 
+### Fixed
+* [#2112](https://github.com/Shopify/shopify-cli/pull/2112): Fix intermittent error ("can't add a new key into hash during iteration") in the `theme push` command
+
 ## Version 2.13.0
 
 ### Added

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -564,6 +564,29 @@ module ShopifyCLI
         @syncer.unlock_io!
       end
 
+      def test_update_checksums_without_checksums_mutex
+        api_value = { "key" => "key", "checksum" => "checksum" }
+        api_response = stub(values: [api_value])
+        checksums_mutex = stub(synchronize: nil)
+
+        @syncer.stubs(:checksums_mutex).returns(checksums_mutex)
+
+        @syncer.checksums.expects(:[]=).never
+        @syncer.checksums.expects(:reject!).never
+
+        @syncer.send(:update_checksums, api_response)
+      end
+
+      def test_update_checksums_with_checksums_mutex
+        api_value = { "key" => "key", "checksum" => "checksum" }
+        api_response = stub(values: [api_value])
+
+        @syncer.checksums.expects(:[]=).once
+        @syncer.checksums.expects(:reject!).once
+
+        @syncer.send(:update_checksums, api_response)
+      end
+
       private
 
       def time_freeze(&block)


### PR DESCRIPTION
### WHY are these changes introduced?

The error `"can't add a new key into hash during iteration"` appears intermittently when users run `shopify theme push`.

### WHAT is this pull request doing?

The error mentioned in the #1705 issue happens at the [`update_checksums` method](https://github.com/Shopify/shopify-cli/blob/main/lib/shopify_cli/theme/syncer.rb#L315) (in the `ShopifyCLI::Theme::Syncer` class):
```ruby
def update_checksums(api_response)
  api_response.values.flatten.each do |asset|
    if asset["key"]
      @checksums[asset["key"]] = asset["checksum"] # <-------------------------- It's raised here
    end
  end

  # [...]
  @checksums.reject! { |key, _| @checksums.key?("#{key}.liquid") } # <---------- Notice
end
```

Here's a simpler reproducer of the same error (with multiple threads modifying with the same Hash):
```ruby
hash = {}

modify_hash = -> do
  hash[rand(1..99).to_s] = rand(1..99).to_s
  hash.reject! { |k, _v| k == rand(1..99).to_s }
end

t1 = Thread.new do
  loop do
    sleep(0.00005 * 1)
    modify_hash.call
  end
end

t2 = Thread.new do
  loop do
    sleep(0.00005 * 2)
    modify_hash.call
  end
end

t3 = Thread.new do
  loop do
    sleep(0.00005 * 3)
    modify_hash.call
  end
end

t1.join
t2.join
t3.join
```

This PR adds a semaphore to coordinate changes in the `@checksums` object (shared across multiple threads).

### How to test your changes?

- Run `shopify-dev theme push -u -t <name>` many times with different names in the `-t` flag
- Notice the intermittent error no longer happens

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.