### PR TITLE
ThemeAdminAPI wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2092](https://github.com/Shopify/shopify-cli/pull/2092): Fix `RootHelper` parse logic to support options with an equal (e.g.: `option=value`)
 
 * [#2089](https://github.com/Shopify/shopify-cli/pull/2089): Use javy version 0.2.0
+* [#2114](https://github.com/Shopify/shopify-cli/pull/2114): Fix `theme` command error messaging with `ThemeAdminAPI` wrapper
 
 ## Version 2.12.0
 ### Added

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -7,6 +7,8 @@ module Theme
           Suite of commands for developing Shopify themes. See {{command:%1$s theme <command> --help}} for usage of each command.
             Usage: {{command:%1$s theme [ %2$s ]}}
         HELP
+        ensure_user_error: "You are not authorized to edit themes on %s.",
+        ensure_user_try_this: "Make sure you are a user of that store, and allowed to edit themes.",
 
         init: {
           help: <<~HELP,

--- a/lib/shopify_cli/theme/dev_server/hot_reload/remote_file_reloader.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/remote_file_reloader.rb
@@ -28,6 +28,10 @@ module ShopifyCLI
 
           private
 
+          def api_client
+            @api_client ||= ThemeAdminAPI.new(@ctx, @theme.shop)
+          end
+
           def updated_file?(body, file)
             remote_checksum = body.dig("asset", "checksum")
             local_checksum = file.checksum
@@ -45,12 +49,8 @@ module ShopifyCLI
           end
 
           def fetch_asset(file)
-            ShopifyCLI::AdminAPI.rest_request(
-              @ctx,
-              shop: @theme.shop,
+            api_client.get(
               path: "themes/#{@theme.id}/assets.json",
-              method: "GET",
-              api_version: "unstable",
               query: URI.encode_www_form("asset[key]" => file.relative_path.to_s),
             )
           rescue ShopifyCLI::API::APIRequestNotFoundError

--- a/lib/shopify_cli/theme/development_theme.rb
+++ b/lib/shopify_cli/theme/development_theme.rb
@@ -45,11 +45,8 @@ module ShopifyCLI
       def exists?
         return false unless id
 
-        ShopifyCLI::AdminAPI.rest_request(
-          @ctx,
-          shop: shop,
-          path: "themes/#{id}.json",
-          api_version: "unstable",
+        api_client.get(
+          path: "themes/#{id}.json"
         )
       rescue ShopifyCLI::API::APIRequestNotFoundError
         false

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -7,13 +7,12 @@ require "forwardable"
 require_relative "syncer/error_reporter"
 require_relative "syncer/standard_reporter"
 require_relative "syncer/operation"
+require_relative "theme_admin_api"
 
 module ShopifyCLI
   module Theme
     class Syncer
       extend Forwardable
-
-      API_VERSION = "unstable"
 
       attr_reader :checksums
       attr_accessor :include_filter
@@ -44,6 +43,10 @@ module ShopifyCLI
 
         # Checksums of assets with errors.
         @error_checksums = []
+      end
+
+      def api_client
+        @api_client ||= ThemeAdminAPI.new(@ctx, @theme.shop)
       end
 
       def lock_io!
@@ -96,11 +99,8 @@ module ShopifyCLI
       end
 
       def fetch_checksums!
-        _status, response = ShopifyCLI::AdminAPI.rest_request(
-          @ctx,
-          shop: @theme.shop,
-          path: "themes/#{@theme.id}/assets.json",
-          api_version: API_VERSION,
+        _status, response = api_client.get(
+          path: "themes/#{@theme.id}/assets.json"
         )
         update_checksums(response)
       end
@@ -239,12 +239,8 @@ module ShopifyCLI
           asset[:attachment] = Base64.encode64(file.read)
         end
 
-        _status, body, response = ShopifyCLI::AdminAPI.rest_request(
-          @ctx,
-          shop: @theme.shop,
+        _status, body, response = api_client.put(
           path: "themes/#{@theme.id}/assets.json",
-          method: "PUT",
-          api_version: API_VERSION,
           body: JSON.generate(asset: asset)
         )
 
@@ -276,12 +272,8 @@ module ShopifyCLI
       end
 
       def get(file)
-        _status, body, response = ShopifyCLI::AdminAPI.rest_request(
-          @ctx,
-          shop: @theme.shop,
+        _status, body, response = api_client.get(
           path: "themes/#{@theme.id}/assets.json",
-          method: "GET",
-          api_version: API_VERSION,
           query: URI.encode_www_form("asset[key]" => file.relative_path.to_s),
         )
 
@@ -298,12 +290,8 @@ module ShopifyCLI
       end
 
       def delete(file)
-        _status, _body, response = ShopifyCLI::AdminAPI.rest_request(
-          @ctx,
-          shop: @theme.shop,
+        _status, _body, response = api_client.delete(
           path: "themes/#{@theme.id}/assets.json",
-          method: "DELETE",
-          api_version: API_VERSION,
           body: JSON.generate(asset: {
             key: file.relative_path.to_s
           })

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -46,8 +46,6 @@ module ShopifyCLI
       private
 
       def rest_request(**args)
-        puts "here in rest_request"
-
         ShopifyCLI::AdminAPI.rest_request(
           @ctx,
           shop: @shop,

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -66,7 +66,6 @@ module ShopifyCLI
 
         @ctx.abort(ensure_user_error, ensure_user_try_this)
       end
-
     end
   end
 end

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -1,0 +1,70 @@
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPI
+      API_VERSION = "unstable"
+
+      def initialize(ctx, shop = nil)
+        @ctx = ctx
+        @shop = shop || get_shop_or_abort
+      end
+
+      def get(path:, **args)
+        rest_request(
+          path: path,
+          **args
+        )
+      end
+
+      def put(path:, **args)
+        rest_request(
+          method: "PUT",
+          path: path,
+          **args
+        )
+      end
+
+      def post(path:, **args)
+        rest_request(
+          method: "POST",
+          path: path,
+          **args
+        )
+      end
+
+      def delete(path:, **args)
+        rest_request(
+          method: "DELETE",
+          path: path,
+          **args
+        )
+      end
+
+      def get_shop_or_abort
+        ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
+      end
+
+      private
+
+      def rest_request(**args)
+        puts "here in rest_request"
+
+        ShopifyCLI::AdminAPI.rest_request(
+          @ctx,
+          shop: @shop,
+          api_version: API_VERSION,
+          **args.compact
+        )
+      rescue ShopifyCLI::API::APIRequestForbiddenError,
+             ShopifyCLI::API::APIRequestUnauthorizedError
+        handle_permissions_error
+      end
+
+      def handle_permissions_error
+        # theme = ShopifyCLI::Theme::Theme.new(ctx)
+        # @ctx.abort(ctx.message("theme.ensure_user", theme.shop))
+        @ctx.abort(ctx.message("theme.ensure_user", get_shop_or_abort))
+      end
+
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -10,6 +10,7 @@ module ShopifyCLI
 
       def get(path:, **args)
         rest_request(
+          method: "GET",
           path: path,
           **args
         )

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -42,7 +42,7 @@ module ShopifyCLI
         )
       end
 
-      def get_shop_or_abort
+      def get_shop_or_abort # rubocop:disable Naming/AccessorMethodName
         ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
       end
 

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -3,6 +3,8 @@ module ShopifyCLI
     class ThemeAdminAPI
       API_VERSION = "unstable"
 
+      attr_reader :shop
+
       def initialize(ctx, shop = nil)
         @ctx = ctx
         @shop = shop || get_shop_or_abort

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -58,9 +58,7 @@ module ShopifyCLI
       end
 
       def handle_permissions_error
-        # theme = ShopifyCLI::Theme::Theme.new(ctx)
-        # @ctx.abort(ctx.message("theme.ensure_user", theme.shop))
-        @ctx.abort(ctx.message("theme.ensure_user", get_shop_or_abort))
+        @ctx.abort(@ctx.message("theme.ensure_user", get_shop_or_abort))
       end
 
     end

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -61,7 +61,10 @@ module ShopifyCLI
       end
 
       def handle_permissions_error
-        @ctx.abort(@ctx.message("theme.ensure_user", get_shop_or_abort))
+        ensure_user_error = @ctx.message("theme.ensure_user_error", get_shop_or_abort)
+        ensure_user_try_this = @ctx.message("theme.ensure_user_try_this")
+
+        @ctx.abort(ensure_user_error, ensure_user_try_this)
       end
 
     end

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -25,15 +25,16 @@ module ShopifyCLI
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
-          path: "themes.json",
+          api_version: "unstable",
           method: "POST",
+          path: "themes.json",
           body: JSON.generate({
             theme: {
               name: theme_name,
               role: "development",
             },
           }),
-          api_version: "unstable",
+
         ).returns([
           201,
           "theme" => {
@@ -57,22 +58,25 @@ module ShopifyCLI
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
-          path: "themes/#{theme_id}.json",
           api_version: "unstable",
+          method: "GET",
+          path: "themes/#{theme_id}.json",
+
         ).raises(ShopifyCLI::API::APIRequestNotFoundError)
 
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: shop,
-          path: "themes.json",
+          api_version: "unstable",
           method: "POST",
+          path: "themes.json",
           body: JSON.generate({
             theme: {
               name: theme_name,
               role: "development",
             },
           }),
-          api_version: "unstable",
+
         ).returns([
           201,
           "theme" => {

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -129,9 +129,11 @@ module ShopifyCLI
         @syncer.start_threads
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
+          api_version: "unstable",
+          method: "GET",
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
-          api_version: "unstable",
+
         ).returns([
           200,
           {
@@ -153,8 +155,10 @@ module ShopifyCLI
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
           shop: @theme.shop,
-          path: "themes/#{@theme.id}/assets.json",
           api_version: "unstable",
+          method: "GET",
+          path: "themes/#{@theme.id}/assets.json",
+
         ).returns([
           200,
           {
@@ -375,9 +379,10 @@ module ShopifyCLI
         # Checksum request
         ShopifyCLI::AdminAPI.expects(:rest_request).with(
           @ctx,
-          shop: @theme.shop,
-          path: "themes/#{@theme.id}/assets.json",
           api_version: "unstable",
+          method: "GET",
+          shop: @theme.shop,
+          path: "themes/#{@theme.id}/assets.json"
         ).returns([
           200,
           { "assets" => response_assets },

--- a/test/shopify-cli/theme/theme_admin_api_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/theme_admin_api"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminApiTest < Minitest::Test
+      def setup
+        super
+        @root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+        @ctx = TestHelpers::FakeContext.new(root: @root)
+        @shop = "dev-theme-server-store.myshopify.com"
+        @api_version = "unstable"
+        @api_client = ThemeAdminAPI.new(@ctx, @shop)
+      end
+
+      def test_sets_shop_if_not_passed_in
+        ShopifyCLI::AdminAPI.expects(:get_shop_or_abort)
+          .with(@ctx)
+          .returns(@shop)
+
+        theme_admin_api = ThemeAdminAPI.new(@ctx)
+
+        assert_equal(theme_admin_api.shop, @shop)
+      end
+
+      def test_get
+        path = "themes.json"
+        request_params = {
+          method: "GET",
+          path: path,
+        }
+
+        expect_correct_request_arguments(request_params)
+
+        @api_client.get(
+          path: path
+        )
+      end
+
+      def test_put
+        path = "themes/123.json"
+        body = JSON.generate(theme: {
+          role: "main",
+        })
+
+        request_params = {
+          method: "PUT",
+          path: path,
+          body: body
+        }
+
+        expect_correct_request_arguments(request_params)
+
+        @api_client.put(
+          path: path,
+          body: body
+        )
+      end
+
+      def test_post
+        path = "themes.json"
+        body = JSON.generate(theme: {
+          role: "main",
+        })
+
+        request_params = {
+          method: "POST",
+          path: path,
+          body: body
+        }
+
+        expect_correct_request_arguments(request_params)
+
+        @api_client.post(
+          path: path,
+          body: body
+        )
+      end
+
+      def test_delete
+        path = "themes/123.json"
+        request_params = {
+          method: "DELETE",
+          path: path,
+        }
+
+        expect_correct_request_arguments(request_params)
+
+        @api_client.delete(
+          path: path
+        )
+      end
+
+      def test_can_get_shop_or_abort
+        ShopifyCLI::AdminAPI.expects(:get_shop_or_abort)
+          .with(@ctx)
+          .returns(@shop)
+
+        @api_client.get_shop_or_abort
+      end
+
+      def test_correctly_all_maps_params_to_admin_api
+        request_params = {
+          method: "POST",
+          path: "themes.json",
+          query: "query",
+          body: JSON.generate({ theme: {}}),
+          token: "token123"
+        }
+
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .with(@ctx, shop: @shop, api_version: @api_version, **request_params)
+
+        @api_client.send(:rest_request, request_params)
+      end
+
+      def test_does_not_pass_nil_arguments
+        path = "themes.json"
+        body = nil
+
+        request_params = {
+          method: "POST",
+          path: path
+        }
+
+        expect_correct_request_arguments(request_params)
+
+        @api_client.post(
+          path: path,
+          body: body
+        )
+      end
+
+      def test_graceullly_handles_api_permissions_errors
+        path = "themes.json"
+        request_params = {
+          method: "POST",
+          path: path
+        }
+
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .with(@ctx, shop: @shop, api_version: @api_version, **request_params)
+          .raises(ShopifyCLI::API::APIRequestForbiddenError)
+
+        @api_client.expects(:get_shop_or_abort).returns(@shop)
+        @ctx.expects(:message).with("theme.ensure_user", @shop)
+        @ctx.expects(:abort)
+
+        @api_client.post(
+          path: path
+        )
+      end
+
+      private
+
+      def expect_correct_request_arguments(request_params)
+        ShopifyCLI::AdminAPI.expects(:rest_request)
+          .with(@ctx, shop: @shop, api_version: @api_version, **request_params)
+      end
+
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_test.rb
@@ -47,7 +47,7 @@ module ShopifyCLI
         request_params = {
           method: "PUT",
           path: path,
-          body: body
+          body: body,
         }
 
         expect_correct_request_arguments(request_params)
@@ -67,7 +67,7 @@ module ShopifyCLI
         request_params = {
           method: "POST",
           path: path,
-          body: body
+          body: body,
         }
 
         expect_correct_request_arguments(request_params)
@@ -105,8 +105,8 @@ module ShopifyCLI
           method: "POST",
           path: "themes.json",
           query: "query",
-          body: JSON.generate({ theme: {}}),
-          token: "token123"
+          body: JSON.generate({ theme: {} }),
+          token: "token123",
         }
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
@@ -121,7 +121,7 @@ module ShopifyCLI
 
         request_params = {
           method: "POST",
-          path: path
+          path: path,
         }
 
         expect_correct_request_arguments(request_params)
@@ -136,7 +136,7 @@ module ShopifyCLI
         path = "themes.json"
         request_params = {
           method: "POST",
-          path: path
+          path: path,
         }
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
@@ -159,7 +159,6 @@ module ShopifyCLI
         ShopifyCLI::AdminAPI.expects(:rest_request)
           .with(@ctx, shop: @shop, api_version: @api_version, **request_params)
       end
-
     end
   end
 end

--- a/test/shopify-cli/theme/theme_admin_api_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_test.rb
@@ -112,7 +112,7 @@ module ShopifyCLI
         ShopifyCLI::AdminAPI.expects(:rest_request)
           .with(@ctx, shop: @shop, api_version: @api_version, **request_params)
 
-        @api_client.send(:rest_request, request_params)
+        @api_client.send(:rest_request, **request_params)
       end
 
       def test_does_not_pass_nil_arguments

--- a/test/shopify-cli/theme/theme_admin_api_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_test.rb
@@ -144,8 +144,9 @@ module ShopifyCLI
           .raises(ShopifyCLI::API::APIRequestForbiddenError)
 
         @api_client.expects(:get_shop_or_abort).returns(@shop)
-        @ctx.expects(:message).with("theme.ensure_user", @shop)
-        @ctx.expects(:abort)
+        @ctx.expects(:message).with("theme.ensure_user_error", @shop).returns("ensure_user_error")
+        @ctx.expects(:message).with("theme.ensure_user_try_this").returns("ensure_user_try_this")
+        @ctx.expects(:abort).with("ensure_user_error", "ensure_user_try_this")
 
         @api_client.post(
           path: path


### PR DESCRIPTION
### WHY are these changes introduced?
Rework of #2072 (see https://github.com/Shopify/shopify-cli/pull/2072#issuecomment-1056626376)

Potentially addresses #2059, which seems to be where user is logged in but they have no theme edit permissions (or otherwise aren't correctly authenticated)

After updates in #2020 (https://github.com/Shopify/shopify-cli/commit/f3c3e78bb52dd214fbe5fe5738de443951e11015#diff-3cdbab84dd5036fc4a850add4e66246deec39779563f9bd7c5b2bff0559e6e3cR31), there is no `theme` object to access if there is a raised permissions error, so `theme.shop` raises an error in the rescue block (https://github.com/Shopify/shopify-cli/blob/main/lib/shopify_cli/theme/dev_server.rb#L83)

### WHAT is this pull request doing?
This PR creates `ThemeAdminAPI` as a wrapper around AdminAPI calls so that permissions errors can be handled there. All theme command calls to the AdminAPI are updated to use the ThemeAdminAPI wrapper.

Additionally this PR updates the error message format to use the `Error ... [message] / Try this... [message]` format.

### How to test your changes?
- be logged in to a store with no permissions
- run `SHOPIFY_CLI_STACKTRACE=1 bundle exec shopify theme serve`
  - see `You are not authorized to edit themes on...` error message instead of NoMethodError
- run `SHOPIFY_CLI_STACKTRACE=1 bundle exec shopify theme pull `
  - see  error message instead of 403 Error
<img width="844" alt="Screen Shot 2022-03-10 at PM 10 33 43" src="https://user-images.githubusercontent.com/608048/157797074-e1338530-c68d-4f73-b9d1-5c689ff9fdfe.png">

### Post-release steps
N/A so far

### Update checklist
- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.