### PR TITLE
Stabilize the `ShopifyCLI::Theme::SyncerTest` class [2]

### DIFF
--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -347,8 +347,6 @@ module ShopifyCLI
           .returns([200, {}, {}])
 
         @syncer.upload_theme!(delay_low_priority_files: true)
-        # Still has pending assets to upload
-        refute_empty(@syncer)
 
         @syncer.wait!
         assert_empty(@syncer)


### PR DESCRIPTION
### WHY are these changes introduced?

The `ShopifyCLI::Theme::SyncerTest#test_upload_theme_with_delayed_low_priority_files` test is intermittently failing in the CI.


### WHAT is this pull request doing?

This PR removes the `refute_empty(@syncer)` check from the `ShopifyCLI::Theme::SyncerTest#test_upload_theme_with_delayed_low_priority_files` because:
- Sometimes the the `@syncer->@pending` variable is already empty when `upload_theme!` finishes
- The `ShopifyCLI::AdminAPI.expects(:rest_request).at_least(expected_size)` would fail if the `@syncer->@pending` were not getting operations


### How to test your changes?

- Run the following command in the `shopify-cli` repository directory:
  ```
  for i in {1..5000}; do; ruby -I test test/shopify-cli/theme/syncer_test.rb -n test_upload_theme_with_delayed_low_priority_files ; done;
   ```
- Notice that the `test_upload_theme_with_delayed_low_priority_files ` test no longer break intermittently

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above.