### PR TITLE
improve error message when failing to find wasm binary

### DIFF
--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -135,8 +135,8 @@ module Script
             "\nbuild: npx shopify-scripts-toolchain-as build --src src/shopify_main.ts --binary build/<script_name>.wasm --metadata build/metadata.json -- --lib node_modules --optimize --use Date=",
 
           web_assembly_binary_not_found: "Wasm binary not found.",
-          web_assembly_binary_not_found_suggestion: "Check that there is a valid Wasm binary in the root directory" \
-          "Your Wasm binary should match the script name: <script_name>.wasm",
+          web_assembly_binary_not_found_suggestion: "Check that a valid Wasm binary is present in the root directory. " \
+          "The Wasm binary's filename must be 'script.wasm'.",
 
           project_config_not_found: "Internal error - Script can't be created because the project's config file is missing from the repository.",
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/4398

### WHAT is this pull request doing?

Simple text change to make it more clean and clear.

### How to test your changes?

Easiest way is to:
- create a wasm project with `shopify script create`, 
- cd in, and 
- immediately attempt to `shopify script push`

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).