### PR TITLE
Fix sending monorail events

### DIFF
--- a/lib/shopify_cli/commands/app/deploy.rb
+++ b/lib/shopify_cli/commands/app/deploy.rb
@@ -2,7 +2,6 @@ module ShopifyCLI
   module Commands
     class App
       class Deploy < ShopifyCLI::Command::AppSubCommand
-        subcommand :Heroku, "heroku", "shopify_cli/commands/app/deploy/heroku"
         prerequisite_task :ensure_git_dependency
 
         recommend_default_ruby_range

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -33,7 +33,7 @@ module ShopifyCLI
 
         # When
         got = Core::Monorail.full_command(create_command, ["rails"], resolved_command: ["create"])
-        
+
         # Then
         assert_equal ["create", "rails"], got
       end

--- a/test/shopify-cli/core/monorail_test.rb
+++ b/test/shopify-cli/core/monorail_test.rb
@@ -14,6 +14,30 @@ module ShopifyCLI
         super
       end
 
+      def test_full_command
+        # Given
+        create_subcommand_registry = mock("create_subcommand_registry")
+        create_command = mock("create_command")
+        create_command.stubs(:subcommand_registry)
+          .returns(create_subcommand_registry)
+        rails_subcommand_registry = mock("rails_subcommand_registry")
+        rails_command = mock("rails_command")
+        rails_command.stubs(:subcommand_registry).returns(rails_subcommand_registry)
+        create_subcommand_registry
+          .stubs(:lookup_command)
+          .with("rails")
+          .returns([rails_command, "rails"])
+        rails_subcommand_registry
+          .stubs(:lookup_command)
+          .returns(nil)
+
+        # When
+        got = Core::Monorail.full_command(create_command, ["rails"], resolved_command: ["create"])
+        
+        # Then
+        assert_equal ["create", "rails"], got
+      end
+
       def test_log_event_contains_schema_and_payload_values
         enable_reporting(true)
         ShopifyCLI::Shopifolk.expects(:acting_as_shopify_organization?).returns(true)


### PR DESCRIPTION
### WHY are these changes introduced?

When we have more than two levels of arguments, for example `shopify app create rails`, there's a bug that causes only the first two arguments to be sent, `app create`. @jesalerno84 spotted this one while gathering data around how many apps are created with the different templates.

### WHAT is this pull request doing?
Fix the implementation by traversing the commands' hierarchy.

### How to test your changes?
1. Comment out the line `executor.call(command, command_name, args)` in `entry_point.rb`
2. Add a log right below `full_command = self.full_command` in `monorail.rb` to print `full_command`.
3. Run `bin/shopify app create rails`.
4. `full_command` should represent the whole command.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).