### PR TITLE
Fix the hot-reload to work when the section name is not equal to the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2121](https://github.com/Shopify/shopify-cli/pull/2121): Fix the hot-reload to work when the section name is not equal to the type
+
 ## Version 2.15.1
 
 ### Added

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -37,7 +37,7 @@
       return domSections;
     }
 
-    return  querySelectDOMSections(name);
+    return querySelectDOMSections(name);
   }
 
   function isFullPageReloadMode(){

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -15,9 +15,29 @@
     eventSource.onerror = () => eventSource.close();
   }
 
+  function sectionNamesByType(type) {
+    const namespace = window.__SHOPIFY_CLI_ENV__;
+    return namespace.section_names_by_type[type] || [];
+  }
+
   function reloadMode() {
-    var namespace = window.__SHOPIFY_CLI_ENV__;
+    const namespace = window.__SHOPIFY_CLI_ENV__;
     return namespace.mode;
+  }
+
+  function querySelectDOMSections(idSuffix) {
+    const elements = document.querySelectorAll(`[id^='shopify-section'][id$='${idSuffix}']`);
+    return Array.from(elements);
+  }
+
+  function fetchDOMSections(name) {
+    const domSections = sectionNamesByType(name).flatMap((n) => querySelectDOMSections(n));
+    
+    if (domSections.length > 0) {
+      return domSections;
+    }
+
+    return  querySelectDOMSections(name);
   }
 
   function isFullPageReloadMode(){
@@ -104,11 +124,11 @@
     constructor(filename) {
       this.filename = filename;
       this.name = filename.split('/').pop().replace('.liquid', '');
-      this.element = document.querySelector(`[id^='shopify-section'][id$='${this.name}']`);
+      this.elements = fetchDOMSections(this.name);
     }
 
     valid() {
-      return this.filename.startsWith('sections/') && this.element;
+      return this.filename.startsWith('sections/') && this.elements.length > 0;
     }
 
     async refresh() {
@@ -119,9 +139,11 @@
         const response = await fetch(url);
         if (response.headers.get('x-templates-from-params') == '1') {
           const html = await response.text();
-          this.element.outerHTML = html;
 
-          console.log(`[HotReload] Reloaded ${this.name} section`);
+          this.elements.forEach((element) => {
+            element.outerHTML = html;
+            console.log(`[HotReload] Reloaded ${this.name} section`);
+          });
         } else {
           window.location.reload()
 

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -140,9 +140,9 @@
         if (response.headers.get('x-templates-from-params') == '1') {
           const html = await response.text();
 
+          console.log(`[HotReload] Reloaded ${this.name} sections`);
           this.elements.forEach((element) => {
             element.outerHTML = html;
-            console.log(`[HotReload] Reloaded ${this.name} section`);
           });
         } else {
           window.location.reload()

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -41,11 +41,11 @@
   }
 
   function isFullPageReloadMode(){
-    return reloadMode() === "full-page";
+    return reloadMode() === 'full-page';
   }
 
   function isReloadModeActive(){
-    return reloadMode() !== "off";
+    return reloadMode() !== 'off';
   }
 
   function isRefreshRequired(files) {
@@ -131,21 +131,21 @@
       return this.filename.startsWith('sections/') && this.elements.length > 0;
     }
 
-    async refresh() {
-      var url = new URL(window.location.href);
-      url.searchParams.append('section_id', this.name);
+    async refreshElement(element) {
+
+      const sectionId = element.id.replace(/^shopify-section-/, '');
+      const url = new URL(window.location.href);
+
+      url.searchParams.append('section_id', sectionId);
+
+      const response = await fetch(url);
 
       try {
-        const response = await fetch(url);
         if (response.headers.get('x-templates-from-params') == '1') {
           const html = await response.text();
-
-          console.log(`[HotReload] Reloaded ${this.name} sections`);
-          this.elements.forEach((element) => {
-            element.outerHTML = html;
-          });
+          element.outerHTML = html;
         } else {
-          window.location.reload()
+          window.location.reload();
 
           console.log(`[HotReload] Hot-reloading not supported, fully reloading ${this.name} section`);
         }
@@ -153,6 +153,11 @@
       } catch (e) {
         console.log(`[HotReload] Failed to reload ${this.name} section: ${e.message}`);
       }
+    }
+
+    async refresh() {
+      console.log(`[HotReload] Reloaded ${this.name} sections`);
+      this.elements.forEach(this.refreshElement);
     }
   }
 

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "hot_reload/remote_file_reloader"
+require_relative "hot_reload/sections_index"
 
 module ShopifyCLI
   module Theme
@@ -13,6 +14,7 @@ module ShopifyCLI
           @mode = mode
           @streams = SSE::Streams.new
           @remote_file_reloader = RemoteFileReloader.new(ctx, theme: @theme, streams: @streams)
+          @sections_index = SectionsIndex.new(@theme)
           @watcher = watcher
           @watcher.add_observer(self, :notify_streams_of_file_change)
           @ignore_filter = ignore_filter
@@ -78,7 +80,10 @@ module ShopifyCLI
         end
 
         def params_js
-          env = { mode: @mode }
+          env = {
+            mode: @mode,
+            section_names_by_type: @sections_index.section_names_by_type,
+          }
           <<~JS
             (() => {
               window.__SHOPIFY_CLI_ENV__ = #{env.to_json};

--- a/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class HotReload
+        class SectionsIndex
+          def initialize(theme)
+            @theme = theme
+          end
+
+          def section_names_by_type
+            index = {}
+
+            files.each do |file|
+              section_hash(file).each do |key, value|
+                name = key
+                type = value&.dig("type")
+
+                next if !name || !type
+
+                index[type] = [] unless index[type]
+                index[type] << name
+              end
+            end
+
+            index
+          end
+
+          private
+
+          def section_hash(file)
+            content = JSON.parse(file.read)
+            return [] if content.is_a?(Array)
+
+            sections = content["sections"]
+            return [] if sections.nil?
+
+            sections
+          rescue JSON::JSONError
+            []
+          end
+
+          def files
+            @theme.json_files
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
@@ -31,7 +31,7 @@ module ShopifyCLI
 
           def section_hash(file)
             content = JSON.parse(file.read)
-            return [] if content.is_a?(Array)
+            return [] unless content.is_a?(Hash)
 
             sections = content["sections"]
             return [] if sections.nil?

--- a/test/shopify-cli/theme/dev_server/hot_reload/sections_index_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload/sections_index_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/dev_server/hot_reload/sections_index"
+require "shopify_cli/theme/theme"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class HotReload
+        class SectionsIndexTest < Minitest::Test
+          def setup
+            super
+            root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+            @theme = Theme.new(nil, root: root)
+          end
+
+          def test_section_names_by_type
+            expected_index = { "main-blog" => ["main"] }
+            actual_index = SectionsIndex.new(@theme).section_names_by_type
+
+            assert_equal(expected_index, actual_index)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -30,7 +30,7 @@ module ShopifyCLI
 
           params_js = <<~JS
             (() => {
-              window.__SHOPIFY_CLI_ENV__ = {"mode":"off"};
+              window.__SHOPIFY_CLI_ENV__ = {"mode":"off","section_names_by_type":{"main-blog":["main"]}};
             })();
           JS
 


### PR DESCRIPTION
### WHY are these changes introduced?

When sections have a name different from the type, the live reload mechanism refreshes the entire page instead of hot reloading the sections.

### WHAT is this pull request doing?

This PR changes the `hot_reload.rb` to inject an index of section names by type, and it also changes the `hot-reload.js` to consume that index and update all appropriate sections.

### How to test your changes?

- Create a simple section file called `sections/it-works-section.liquid` with this content:
  ```html
  <div style="border-bottom: 20px solid #ffdb58">
    <h1>It works!</h1>
  </div>
  ```
- Change the `templates/index.json` of your theme to look like this:
  ```json
  {
    "sections": {
      "it-works-section": {
        "type": "it-works-section"
      },
      "it_works_1": {
        "type": "it-works-section"
      },
      "it_works_2": {
        "type": "it-works-section"
      },
      "it_works_3": {
        "type": "it-works-section"
      },
      "it_works_4": {
        "type": "it-works-section"
      }
    },
    "order": [
      "it-works-section",
      "it_works_1",
      "it_works_2",
      "it_works_3",
      "it_works_4"
    ]
  }
  ```
- Run `shopify theme serve`
- Change the `sections/it-works-section.liquid` section
- Notice in the Google Chrome console that all sections are hot-reloaded

Before:
![before](https://user-images.githubusercontent.com/1079279/156789338-70bf72fa-730d-4aef-a5dc-9adc31db777c.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/156789372-473b4eaf-7cc1-4826-82b7-e03771833cb3.gif)


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).