### PR TITLE
Fix `BaseGlob` coverter to support multiple flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2086](https://github.com/Shopify/shopify-cli/pull/2086): Improve check of dependency versions
 * [#2149](https://github.com/Shopify/shopify-cli/pull/2149): Fix `ThemeAdminAPI` not to handle asset errors
+* [#2122](https://github.com/Shopify/shopify-cli/pull/2122): Fix `--only`/`--ignore` flags parser to support multiple occurrences without quotes
 
 ## Version 2.14.0
 

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -26,11 +26,11 @@ module Theme
         parser.on("-d", "--development") { flags[:development] = true }
         parser.on("-o", "--only=PATTERN", Conversions::IncludeGlob) do |pattern|
           flags[:includes] ||= []
-          flags[:includes] += pattern
+          flags[:includes] |= pattern
         end
         parser.on("-x", "--ignore=PATTERN", Conversions::IgnoreGlob) do |pattern|
           flags[:ignores] ||= []
-          flags[:ignores] += pattern
+          flags[:ignores] |= pattern
         end
       end
 

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -30,11 +30,11 @@ module Theme
         parser.on("-p", "--publish") { flags[:publish] = true }
         parser.on("-o", "--only=PATTERN", Conversions::IncludeGlob) do |pattern|
           flags[:includes] ||= []
-          flags[:includes] += pattern
+          flags[:includes] |= pattern
         end
         parser.on("-x", "--ignore=PATTERN", Conversions::IgnoreGlob) do |pattern|
           flags[:ignores] ||= []
-          flags[:ignores] += pattern
+          flags[:ignores] |= pattern
         end
       end
 

--- a/lib/project_types/theme/conversions/base_glob.rb
+++ b/lib/project_types/theme/conversions/base_glob.rb
@@ -10,8 +10,22 @@ module Theme
 
         def convert(parser)
           argv = parser.default_argv
-          option_index = argv.index { |v| options.include?(v) }
+          values = []
 
+          option_indexes(argv).each do |option_index|
+            values += option_values(argv, parser, option_index)
+          end
+
+          values
+        end
+
+        def options
+          raise "`#{self.class.name}#options` must be defined"
+        end
+
+        private
+
+        def option_values(argv, parser, option_index)
           return [] if option_index.nil?
 
           start_index = option_index + 1
@@ -26,11 +40,12 @@ module Theme
           values
         end
 
-        def options
-          raise "`#{self.class.name}#options` must be defined"
+        def option_indexes(argv)
+          argv
+            .each_with_index
+            .select { |item, _index| options.include?(item) }
+            .map(&:last)
         end
-
-        private
 
         def options_map(parser)
           map = {}

--- a/test/project_types/theme/conversions/base_glob_test.rb
+++ b/test/project_types/theme/conversions/base_glob_test.rb
@@ -18,8 +18,9 @@ module Theme
 
         actual_params = Conversions::BaseGlob.convert(parser)
         expected_params = [
-          "layout/password.liquid",
+          "layout/password1.liquid",
           "layout/theme.liquid",
+          "layout/password2.liquid",
         ]
 
         assert_equal(expected_params, actual_params)
@@ -54,11 +55,13 @@ module Theme
           "push",
           "-d",
           "--only",
-          "layout/password.liquid",
+          "layout/password1.liquid",
           "layout/theme.liquid",
           "--ignore",
           "sections/announcement-bar.liquid",
           "sections/contact-form.liquid",
+          "--only",
+          "layout/password2.liquid",
         ]
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `BaseGlob` converter, introduced to support patterns without quotes, doesn't support many occurrences of the same flag.

### WHAT is this pull request doing?

This PR changes the `BaseGlob` converter to support multiple occurrences of the same flag.

### How to test your changes?

- Open a theme directory
- Run `DEBUG=1 shopify-dev theme pull -d -x config/settings_schema.json -x config/settings_data.json`
- Notice that both files are ignored

**Before this PR:**
<img width="60%" alt="before" src="https://user-images.githubusercontent.com/1079279/158987379-4111580d-5e29-4b54-aee8-eb4d7ba19366.png">

**After this PR:**
<img width="60%" alt="after" src="https://user-images.githubusercontent.com/1079279/158987391-b552527a-f47d-4681-9404-6bad63f3b070.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).