### PR TITLE
Fix Homebrew template

### DIFF
--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -24,7 +24,8 @@ class ShopifyCli < Formula
       ohai("Fetching shopify-cli from gem source")
       cache.cd do
         ENV["GEM_SPEC_CACHE"] = "#{cache}/gem_spec_cache"
-        _, err, status = Open3.capture3("#{ruby_bin}/gem", "fetch", "shopify-cli", "--version", gem_version)
+
+        _, err, status = Open3.capture3("gem", "fetch", "shopify-cli", "--version", gem_version)
         unless status.success?
           odie err
         end
@@ -72,7 +73,7 @@ class ShopifyCli < Formula
     end
 
     system(
-      "#{ruby_bin}/gem",
+      "gem",
       "install",
       cached_download,
       "--no-document",


### PR DESCRIPTION
### WHY are these changes introduced?
Users reported issues trying to install the [CLI](https://github.com/Shopify/shopify-cli/issues/2057) through Homebrew.

### WHAT is this pull request doing?
The logic for obtaining the Ruby path when installing the CLI returns a path to a non-existing executable. It turns out that when the formula dependencies are installed as part of the same process, Homebrew keeps the dependencies in a temporary directory until all the installations complete and then everything is moved over to the final directory. I'm assuming they do that to ensure the installation is atomic (either everything is installed or none of it). Because of that, we can't assume from `ruby_path` that Ruby lives in its final directory. However, Homebrew exposes the dependencies in the environment, so we can simply do `ruby` or `gem`, and they'll be read from the temporary directory.

### How to test your changes?

You can follow the steps [here](https://github.com/Shopify/shopify-cli/issues/2057#issuecomment-1060640948)

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).