### PR TITLE
Fix ignore file handling in `DevServer::Watcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2112](https://github.com/Shopify/shopify-cli/pull/2112): Fix intermittent error ("can't add a new key into hash during iteration") in the `theme push` command
 * [#2088](https://github.com/Shopify/shopify-cli/pull/2088): Update theme-check to 1.10.1
 * [#2130](https://github.com/Shopify/shopify-cli/pull/2130): Fix Homebrew installation.
+* [#2133](https://github.com/Shopify/shopify-cli/pull/2133): Fix ignore file handling in DevServer::Watcher.
 
 ## Version 2.13.0
 

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -59,7 +59,7 @@ module ShopifyCLI
         private
 
         def ignore_file?(file)
-          @ignore_filter&.ignore?(file.relative_path)
+          @ignore_filter&.ignore?(file.relative_path.to_s)
         end
       end
     end

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -45,13 +45,21 @@ module ShopifyCLI
         def filter_theme_files(files)
           files
             .select { |file| @theme.theme_file?(file) }
-            .reject { |file| @ignore_filter&.ignore?(file) }
+            .map { |file| @theme[file] }
+            .reject { |file| ignore_file?(file) }
         end
 
         def filter_remote_files(files)
           files
             .select { |file| @syncer.remote_file?(file) }
-            .reject { |file| @ignore_filter&.ignore?(file) }
+            .map { |file| @theme[file] }
+            .reject { |file| ignore_file?(file) }
+        end
+
+        private
+
+        def ignore_file?(file)
+          @ignore_filter&.ignore?(file.relative_path)
         end
       end
     end

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -276,7 +276,7 @@ module ShopifyCLI
       end
 
       def ignored_by_include_filter?(path)
-        include_filter && !include_filter.match?(path)
+        !!include_filter && !include_filter.match?(path)
       end
 
       def get(file)

--- a/test/shopify-cli/theme/dev_server/watcher_test.rb
+++ b/test/shopify-cli/theme/dev_server/watcher_test.rb
@@ -42,7 +42,6 @@ module ShopifyCLI
 
           @watcher.filter_theme_files([absolute_path])
         end
-
       end
     end
   end

--- a/test/shopify-cli/theme/dev_server/watcher_test.rb
+++ b/test/shopify-cli/theme/dev_server/watcher_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+require "shopify_cli/theme/dev_server/watcher"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class WatcherTest < Minitest::Test
+        def setup
+          super
+          @root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+          @ctx = TestHelpers::FakeContext.new(root: @root)
+          @theme = Theme.new(@ctx, root: @root)
+          @syncer = stub("Syncer", enqueue_uploads: true, enqueue_updates: true)
+          @ignore_filter = IgnoreFilter.new(@root, patterns: ["foo/*"])
+          @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer, ignore_filter: @ignore_filter)
+        end
+
+        def test_upload_files_when_changed
+          included_path = "layout/theme.liquid"
+          included_file = @theme[included_path]
+          ignored_path = "foo/bar.liquid"
+          ignored_file = @theme[ignored_path]
+
+          @theme.expects(:theme_file?).with(included_path).returns(true)
+          @theme.expects(:theme_file?).with(ignored_path).returns(true)
+          @theme.expects(:[]).with(included_path).returns(included_file)
+          @theme.expects(:[]).with(ignored_path).returns(ignored_file)
+
+          @syncer.expects(:enqueue_updates).with([included_file])
+
+          @watcher.upload_files_when_changed([included_path, ignored_path], [], [])
+        end
+
+        def test_filters_theme_files_correctly_by_relative_path
+          relative_path = "layout/theme.liquid"
+          absolute_path = ::File.join(@root, relative_path)
+
+          @theme.expects(:theme_file?).with(absolute_path).returns(true)
+          @ignore_filter.expects(:ignore?).with(relative_path)
+
+          @watcher.filter_theme_files([absolute_path])
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed that when I ran `theme serve` with root argument (`theme serve dist`, with `.shopifyignore` inside my `dist` folder) that all my files were being ignored because I had inadvertently had `dist/*` as a pattern in `.shopifyignore` from when it was inside my project root instead of my theme root.

### WHAT is this pull request doing?
This PR updates `DevServer::Watcher` to use file relative paths for comparison in the ignore filter so that any patterns in `.shopifyignore` or supplied on the command line will be considered relative the root. This behavior is the same as how it is already handled in Syncer. 

This PR also updates the Syncer `ignored_by_include_filter?` to make sure it always returns a boolean value rather than nil.

### How to test your changes?
- Have a valid theme inside a subfolder `dist`, along with a .shopifyignore file (with `dist/*` in the file) inside this folder.
- Run `theme serve dist` from outside the dist folder
- make a change `layout/theme.liquid` and see the change uploaded

### Post-release steps
N/A

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).