### PR TITLE
Fix minitest RuntimeErrors in RubyMine

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,4 +20,4 @@ Mocha.configure do |c|
   c.stubbing_method_on_nil = :prevent
 end
 
-Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(color: true)])
+Minitest::Reporters.use!([Minitest::Reporters::DefaultReporter.new(color: true)]) unless ENV["RM_INFO"]


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes this runtime error when running Minitests in RubyMine:
```
$HOME/Library/Application Support/JetBrains/Toolbox/apps/RubyMine
/ch-0/213.6777.43/RubyMine.app/Contents/plugins/ruby/rb/testing/patch
/testunit/minitest/rm_reporter_plugin.rb:37:in 
`assert_no_minitest_reporters': (RuntimeError)

Current implementation of IntelliJ Minitest support conflicts with 
Minitest::Reporters. Please remove Minitest::Reporters.use! from your
test code or suppress the invocation if ENV['RM_INFO'] is defined, then
re-run your tests.
```

https://user-images.githubusercontent.com/4490738/157957963-ccd25080-1b84-4ddb-aea1-74a74d60dda4.mp4

See this issue: https://blog.jetbrains.com/ruby/2021/04/improved-minitest-support-action-required/

### How to test your changes?

Run Minitests in Rubymine

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).