### PR TITLE
Detect outdated extensions

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -63,6 +63,7 @@ module Extension
       autoload :Build, Project.project_filepath("tasks/execute_commands/build")
       autoload :Create, Project.project_filepath("tasks/execute_commands/create")
       autoload :Serve, Project.project_filepath("tasks/execute_commands/serve")
+      autoload :OutdatedExtensionDetection, Project.project_filepath("tasks/execute_commands/outdated_extension_detection")
 
       class << self
         def build(*args)

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -63,7 +63,8 @@ module Extension
       autoload :Build, Project.project_filepath("tasks/execute_commands/build")
       autoload :Create, Project.project_filepath("tasks/execute_commands/create")
       autoload :Serve, Project.project_filepath("tasks/execute_commands/serve")
-      autoload :OutdatedExtensionDetection, Project.project_filepath("tasks/execute_commands/outdated_extension_detection")
+      autoload :OutdatedExtensionDetection,
+        Project.project_filepath("tasks/execute_commands/outdated_extension_detection")
 
       class << self
         def build(*args)

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -59,6 +59,7 @@ module Extension
           root_dir: form.directory_name,
           template: form.template,
           type: form.type.identifier.downcase,
+          context: @ctx,
         )
         @ctx.chdir(form.directory_name)
         write_env_file(form)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -210,7 +210,7 @@ module Extension
             * Add a develop script: shopify-cli-extensions develop
             * Change then build script to: shopify-cli-extensions build
           TEXT
-        }
+        },
       },
       warnings: {
         resource_url_auto_generation_failed: "{{*}} {{yellow:Warning:}} Unable to auto generate " \

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -194,6 +194,23 @@ module Extension
         "{{command:%1$s extension connect}} " \
         "or run {{command:%1$s extension register}} to register a new extension.",
         module_not_found: "Unable to find module %s. Ensure your dependencies are up-to-date and try again.",
+        development_server_binary_not_found: <<~ERROR,
+          Development server binary not found! If you're running a development version of the CLI, please run `rake extensions:install` to install it. Otherwise, please file a bug report via https://github.com/Shopify/shopify-cli/issues/new.
+        ERROR
+        outdated_extensions: {
+          unknown: <<~TEXT.strip,
+            Please refer to the documentation for more information on how to upgrade your extension:
+            https://shopify.dev/apps/app-extensions
+          TEXT
+          checkout_ui_extension: <<~TEXT.strip,
+            Please update your package.json as follows:
+            * Replace the development dependency @shopify/checkout-ui-extensions-run
+              with @shopify/shopify-cli-extensions
+            * Remove the start and server script
+            * Add a develop script: shopify-cli-extensions develop
+            * Change then build script to: shopify-cli-extensions build
+          TEXT
+        }
       },
       warnings: {
         resource_url_auto_generation_failed: "{{*}} {{yellow:Warning:}} Unable to auto generate " \

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -208,7 +208,7 @@ module Extension
               with @shopify/shopify-cli-extensions
             * Remove the start and server script
             * Add a develop script: shopify-cli-extensions develop
-            * Change then build script to: shopify-cli-extensions build
+            * Change the build script to: shopify-cli-extensions build
           TEXT
         },
       },

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -25,8 +25,9 @@ module Extension
           SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
         end
 
-        def type_supported?(type)
-          SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
+        # Some types are enabled unconditionally; others require beta_enabled
+        def type_enabled?(type)
+          beta_enabled? || "checkout_ui_extension" == type.downcase
         end
 
         private
@@ -35,9 +36,8 @@ module Extension
           Models::DevelopmentServer.new.executable_installed?
         end
 
-        # Some types are enabled unconditionally; others require beta_enabled
-        def type_enabled?(type)
-          beta_enabled? || "checkout_ui_extension" == type.downcase
+        def context
+          @context ||= ShopifyCLI::Context.new
         end
       end
     end

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -25,6 +25,10 @@ module Extension
           SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
         end
 
+        def type_supported?(type)
+          SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
+        end
+
         private
 
         def binary_installed?

--- a/lib/project_types/extension/models/npm_package.rb
+++ b/lib/project_types/extension/models/npm_package.rb
@@ -8,9 +8,9 @@ module Extension
 
       property :name
       property :version
-      property :scripts, accepts: Hash
-      property :dependencies, accepts: Hash
-      property :dev_dependencies, accepts: Hash
+      property :scripts, accepts: Hash, default: -> { {} }
+      property :dependencies, accepts: Hash, default: -> { {} }
+      property :dev_dependencies, accepts: Hash, default: -> { {} }
 
       def initialize(**config)
         super(**config.select { |property_name, _| self.class.properties.key?(property_name) })
@@ -26,6 +26,18 @@ module Extension
       def <=>(other)
         return nil unless name == other.name
         Semantic::Version.new(version) <=> Semantic::Version.new(other.version)
+      end
+
+      def script?(name)
+        scripts.key?(name)
+      end
+
+      def dependency?(name)
+        dependencies.key?(name)
+      end
+
+      def dev_dependency?(name)
+        dev_dependencies.key?(name)
       end
     end
   end

--- a/lib/project_types/extension/tasks/execute_commands/base.rb
+++ b/lib/project_types/extension/tasks/execute_commands/base.rb
@@ -6,7 +6,12 @@ module Extension
     module ExecuteCommands
       class Base
         include SmartProperties
+
         property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
+
+        def self.inherited(subclass)
+          subclass.prepend(OutdatedExtensionDetection)
+        end
       end
     end
   end

--- a/lib/project_types/extension/tasks/execute_commands/base.rb
+++ b/lib/project_types/extension/tasks/execute_commands/base.rb
@@ -8,6 +8,7 @@ module Extension
         include SmartProperties
 
         property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
+        property! :context, accepts: ShopifyCLI::Context
 
         def self.inherited(subclass)
           subclass.prepend(OutdatedExtensionDetection)

--- a/lib/project_types/extension/tasks/execute_commands/base.rb
+++ b/lib/project_types/extension/tasks/execute_commands/base.rb
@@ -11,6 +11,7 @@ module Extension
         property! :context, accepts: ShopifyCLI::Context
 
         def self.inherited(subclass)
+          super
           subclass.prepend(OutdatedExtensionDetection)
         end
       end

--- a/lib/project_types/extension/tasks/execute_commands/base.rb
+++ b/lib/project_types/extension/tasks/execute_commands/base.rb
@@ -9,11 +9,6 @@ module Extension
 
         property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
         property! :context, accepts: ShopifyCLI::Context
-
-        def self.inherited(subclass)
-          super
-          subclass.prepend(OutdatedExtensionDetection)
-        end
       end
     end
   end

--- a/lib/project_types/extension/tasks/execute_commands/build.rb
+++ b/lib/project_types/extension/tasks/execute_commands/build.rb
@@ -5,6 +5,8 @@ module Extension
   module Tasks
     module ExecuteCommands
       class Build < Base
+        prepend OutdatedExtensionDetection
+
         property! :config_file_path, accepts: String
 
         def call

--- a/lib/project_types/extension/tasks/execute_commands/build.rb
+++ b/lib/project_types/extension/tasks/execute_commands/build.rb
@@ -5,7 +5,6 @@ module Extension
   module Tasks
     module ExecuteCommands
       class Build < Base
-        property! :context, accepts: ShopifyCLI::Context
         property! :config_file_path, accepts: String
 
         def call

--- a/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
+++ b/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
@@ -11,7 +11,7 @@ module Extension
 
           def call
             return false if valid?(parse_package)
-            raise upgrade_instructions
+            context.abort(upgrade_instructions)
           end
 
           private

--- a/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
+++ b/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
@@ -1,0 +1,62 @@
+module Extension
+  module Tasks
+    module ExecuteCommands
+      module OutdatedExtensionDetection
+        class OutdatedCheck
+          include ShopifyCLI::MethodObject
+
+          property! :type, accepts: Models::DevelopmentServerRequirements.method(:type_supported?)
+          property! :project, accepts: ShopifyCLI::Project, default: -> { ShopifyCLI::Project.current }
+
+          def call
+            return if valid?(parse_package)
+            raise upgrade_instructions
+          end
+
+          private
+
+          def upgrade_instructions
+            case type
+            when "checkout_ui_extension"
+              <<~TEXT.strip
+                Please update your package.json as follows:
+                * Replace the development dependency @shopify/checkout-ui-extensions-run
+                  with @shopify/shopify-cli-extensions
+                * Remove the start and server script
+                * Add a develop script: shopify-cli-extensions develop
+                * Change then build script to: shopify-cli-extensions build
+              TEXT
+            else
+              <<~TEXT.strip
+              Please refer to the documentation for more information on how to upgrade your extension:
+              https://shopify.dev/apps/app-extensions
+              TEXT
+            end
+          end
+
+          def parse_package
+            File.open(Pathname(project.directory).join("package.json")) do |file|
+              Models::NpmPackage.parse(file)
+            end
+          end
+
+          def valid?(package)
+            case type
+            when "checkout_ui_extension"
+              package.dependency?("@shopify/checkout-ui-extensions") &&
+                package.script?("build") &&
+                package.script?("develop")
+            else
+              true
+            end
+          end
+        end
+
+        def call(*)
+          return super unless Models::DevelopmentServerRequirements.supported?(type)
+          OutdatedCheck.call(type: type).then { super }
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
+++ b/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
@@ -10,7 +10,7 @@ module Extension
           property! :project, accepts: ShopifyCLI::Project, default: -> { ShopifyCLI::Project.current }
 
           def call
-            return if valid?(parse_package)
+            return false if valid?(parse_package)
             raise upgrade_instructions
           end
 
@@ -19,19 +19,9 @@ module Extension
           def upgrade_instructions
             case type
             when "checkout_ui_extension"
-              <<~TEXT.strip
-                Please update your package.json as follows:
-                * Replace the development dependency @shopify/checkout-ui-extensions-run
-                  with @shopify/shopify-cli-extensions
-                * Remove the start and server script
-                * Add a develop script: shopify-cli-extensions develop
-                * Change then build script to: shopify-cli-extensions build
-              TEXT
+              context.message("errors.outdated_extensions.checkout_ui_extension")
             else
-              <<~TEXT.strip
-              Please refer to the documentation for more information on how to upgrade your extension:
-              https://shopify.dev/apps/app-extensions
-              TEXT
+              context.message("errors.outdated_extensions.unknown")
             end
           end
 
@@ -44,7 +34,7 @@ module Extension
           def valid?(package)
             case type
             when "checkout_ui_extension"
-              package.dependency?("@shopify/checkout-ui-extensions") &&
+              package.dev_dependency?("@shopify/shopify-cli-extensions") &&
                 package.script?("build") &&
                 package.script?("develop")
             else

--- a/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
+++ b/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
@@ -6,6 +6,7 @@ module Extension
           include ShopifyCLI::MethodObject
 
           property! :type, accepts: Models::DevelopmentServerRequirements.method(:type_supported?)
+          property! :context, accepts: ShopifyCLI::Context
           property! :project, accepts: ShopifyCLI::Project, default: -> { ShopifyCLI::Project.current }
 
           def call
@@ -54,7 +55,7 @@ module Extension
 
         def call(*)
           return super unless Models::DevelopmentServerRequirements.supported?(type)
-          OutdatedCheck.call(type: type).then { super }
+          OutdatedCheck.call(type: type, context: context).then { super }
         end
       end
     end

--- a/lib/project_types/extension/tasks/execute_commands/serve.rb
+++ b/lib/project_types/extension/tasks/execute_commands/serve.rb
@@ -5,6 +5,8 @@ module Extension
   module Tasks
     module ExecuteCommands
       class Serve < Base
+        prepend OutdatedExtensionDetection
+
         property! :config_file_path, accepts: String
         property  :port, accepts: Integer, default: ShopifyCLI::Constants::Extension::DEFAULT_PORT
         property  :resource_url, accepts: String

--- a/lib/project_types/extension/tasks/execute_commands/serve.rb
+++ b/lib/project_types/extension/tasks/execute_commands/serve.rb
@@ -5,7 +5,6 @@ module Extension
   module Tasks
     module ExecuteCommands
       class Serve < Base
-        property! :context, accepts: ShopifyCLI::Context
         property! :config_file_path, accepts: String
         property  :port, accepts: Integer, default: ShopifyCLI::Constants::Extension::DEFAULT_PORT
         property  :resource_url, accepts: String

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -48,7 +48,9 @@ module Extension
         stub_project(type)
 
         Models::DevelopmentServerRequirements.stubs(:supported?).returns(true)
-        Tasks::ExecuteCommands::OutdatedExtensionDetection::OutdatedCheck.expects(:call).returns(ShopifyCLI::Result.success(true))
+        Tasks::ExecuteCommands::OutdatedExtensionDetection::OutdatedCheck
+          .expects(:call)
+          .returns(ShopifyCLI::Result.success(true))
 
         command = Tasks::ExecuteCommands::Build.new(context: @context, config_file_path: config_file,
           type: type.downcase)

--- a/test/project_types/extension/commands/build_test.rb
+++ b/test/project_types/extension/commands/build_test.rb
@@ -47,7 +47,8 @@ module Extension
         type = "CHECKOUT_UI_EXTENSION"
         stub_project(type)
 
-        Models::DevelopmentServerRequirements.expects(:supported?).with(type).returns(true)
+        Models::DevelopmentServerRequirements.stubs(:supported?).returns(true)
+        Tasks::ExecuteCommands::OutdatedExtensionDetection::OutdatedCheck.expects(:call).returns(ShopifyCLI::Result.success(true))
 
         command = Tasks::ExecuteCommands::Build.new(context: @context, config_file_path: config_file,
           type: type.downcase)

--- a/test/project_types/extension/tasks/execute_commands/build_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/build_test.rb
@@ -54,15 +54,15 @@ module Extension
           {
             "name": "test-extension",
             "dependencies": {
-              "@shopify/checkout-ui-extensions": "^1.0.0"
+              "@shopify/checkout-ui-extensions": "^1.0.0",
             },
             "devDependencies": {
-              "@shopify/shopify-cli-extensions": "latest"
+              "@shopify/shopify-cli-extensions": "latest",
             },
             "scripts": {
               "build": "some command",
-              "develop": "some command"
-            }
+              "develop": "some command",
+            },
           }
         end
       end

--- a/test/project_types/extension/tasks/execute_commands/build_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/build_test.rb
@@ -13,22 +13,20 @@ module Extension
           CLI::Kit::System.expects(:capture3).returns(["some output", nil, mock(success?: true)])
         end
 
-        def teardown
-          FileUtils.rm_rf("tmp")
-        end
-
         def test_success_object_is_returned_on_successful_call
-          Dir.mkdir("tmp") unless Dir.exist?("tmp")
-          FileUtils.touch("tmp/test.txt")
-
-          test_file_path = File.join(Dir.pwd, "tmp")
+          FileUtils.touch("extension.config.yml")
+          File.write("package.json", JSON.dump(up_to_date_package_json))
 
           result = ExecuteCommands::Build.new(
             type: "checkout_ui_extension",
-            config_file_path: File.join(test_file_path, "test.txt"),
+            config_file_path: "extension.config.yml",
             context: TestHelpers::FakeContext.new
           ).call
+
           assert_kind_of(ShopifyCLI::Result::Success, result)
+        ensure
+          FileUtils.rm("package.json")
+          FileUtils.rm("extension.config.yml")
         end
 
         private
@@ -50,6 +48,22 @@ module Extension
             user: Models::ServerConfig::User.new,
             development: development
           )
+        end
+
+        def up_to_date_package_json
+          {
+            "name": "test-extension",
+            "dependencies": {
+              "@shopify/checkout-ui-extensions": "^1.0.0"
+            },
+            "devDependencies": {
+              "@shopify/shopify-cli-extensions": "latest"
+            },
+            "scripts": {
+              "build": "some command",
+              "develop": "some command"
+            }
+          }
         end
       end
     end

--- a/test/project_types/extension/tasks/execute_commands/create_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/create_test.rb
@@ -12,7 +12,7 @@ module Extension
 
         def test_error_is_raised_if_error_occurs
           development_server = Models::DevelopmentServer.new(executable: "fake")
-          Models::DevelopmentServer.expects(:new).returns(development_server) do |server|
+          Models::DevelopmentServer.expects(:new).at_least_once.returns(development_server) do |server|
             server.expects(:create).returns(StandardError)
           end
 

--- a/test/project_types/extension/tasks/execute_commands/create_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/create_test.rb
@@ -20,7 +20,8 @@ module Extension
             ExecuteCommands::Create.new(
               type: "checkout_ui_extension",
               template: "javascript",
-              root_dir: "test"
+              root_dir: "test",
+              context: TestHelpers::FakeContext.new
             ).call
           end
         end

--- a/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+module Extension
+  module Tasks
+    module ExecuteCommands
+      class OutdatedExtensionDetectionTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCLI::ProjectType.load_type(:extension)
+        end
+
+        def dummy_command
+          Class.new(Base) do
+            include ShopifyCLI::MethodObject
+
+            property :type
+            property! :executed, default: false
+
+            def call
+              self.executed = true
+              :success
+            end
+          end
+        end
+
+        def test_bypasses_outdated_check_for_extensions_that_do_not_support_the_new_development_server
+          Models::DevelopmentServerRequirements.expects(:supported?).returns(false)
+          OutdatedExtensionDetection::OutdatedCheck.expects(:call).never
+          assert_equal :success, dummy_command.call(type: "checkout_ui_extension").unwrap!
+        end
+
+        def test_performs_outdated_check_for_extensions_supporting_the_new_development_server
+          Models::DevelopmentServerRequirements.expects(:supported?).returns(true)
+          OutdatedExtensionDetection::OutdatedCheck
+            .expects(:call).with(type: "checkout_ui_extension").once
+            .returns(ShopifyCLI::Result.wrap(true))
+          assert_equal :success, dummy_command.call(type: "checkout_ui_extension").unwrap!
+        end
+
+        def test_aborts_command_execution_if_outdated_check_fails
+          Models::DevelopmentServerRequirements.expects(:supported?).returns(true)
+          OutdatedExtensionDetection::OutdatedCheck
+            .expects(:call).with(type: "checkout_ui_extension").once
+            .returns(ShopifyCLI::Result.wrap(RuntimeError.new))
+
+          dummy_command_instance = dummy_command.new(type: "checkout_ui_extension")
+          assert_raises(RuntimeError) { dummy_command_instance.call.unwrap! }
+          refute dummy_command_instance.executed
+        end
+      end
+
+      class OutdatedCheckTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCLI::ProjectType.load_type(:extension)
+        end
+
+        def test_raises_with_upgrade_instructions_if_package_json_is_outdated
+          package_json = StringIO.new(<<~JSON)
+          {
+            "name": "my-extension",
+            "scripts": {
+              "start": "some command",
+              "build": "some other command"
+            }
+          }
+          JSON
+
+          File
+            .expects(:open)
+            .with(Pathname(ShopifyCLI::Project.current.directory).join("package.json"))
+            .returns(Models::NpmPackage.parse(package_json))
+
+          message = <<~TEXT.strip
+            Please update your package.json as follows:
+            * Replace the development dependency @shopify/checkout-ui-extensions-run
+              with @shopify/shopify-cli-extensions
+            * Remove the start and server script
+            * Add a develop script: shopify-cli-extensions develop
+            * Change then build script to: shopify-cli-extensions build
+          TEXT
+
+          result = OutdatedExtensionDetection::OutdatedCheck.call(type: "checkout_ui_extension")
+          assert_predicate(result, :failure?)
+          assert_equal message, result.error.message
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
@@ -90,6 +90,32 @@ module Extension
           assert_predicate(result, :failure?)
           assert_equal message, result.error.message
         end
+
+        def test_does_not_raise_with_upgrade_instructions_if_package_json_is_up_to_date
+          $debug = true
+          package_json = StringIO.new(<<~JSON)
+          {
+            "name": "my-extension",
+            "devDependencies": {
+              "@shopify/shopify-cli-extensions": "^0.2.0"
+            },
+            "scripts": {
+              "build": "some command",
+              "develop": "some other command"
+            }
+          }
+          JSON
+
+          File
+            .expects(:open)
+            .with(Pathname(ShopifyCLI::Project.current.directory).join("package.json"))
+            .returns(Models::NpmPackage.parse(package_json))
+
+          result = OutdatedExtensionDetection::OutdatedCheck.call(type: "checkout_ui_extension", context: TestHelpers::FakeContext.new)
+          assert_predicate(result, :success?)
+        ensure
+          $debug = false
+        end
       end
     end
   end

--- a/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
@@ -79,7 +79,7 @@ module Extension
               with @shopify/shopify-cli-extensions
             * Remove the start and server script
             * Add a develop script: shopify-cli-extensions develop
-            * Change then build script to: shopify-cli-extensions build
+            * Change the build script to: shopify-cli-extensions build
           TEXT
 
           result = OutdatedExtensionDetection::OutdatedCheck.call(type: "checkout_ui_extension",

--- a/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
@@ -38,6 +38,7 @@ module Extension
 
         def dummy_command
           Class.new(Base) do
+            prepend OutdatedExtensionDetection
             include ShopifyCLI::MethodObject
 
             property :type

--- a/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/outdated_extension_detection_test.rb
@@ -62,7 +62,7 @@ module Extension
         end
 
         def test_raises_with_upgrade_instructions_if_package_json_is_outdated
-          package_json = StringIO.new(<<~JSON)
+          File.write("package.json", <<~JSON)
             {
               "name": "my-extension",
               "scripts": {
@@ -72,13 +72,8 @@ module Extension
             }
           JSON
 
-          File
-            .expects(:open)
-            .with(Pathname(ShopifyCLI::Project.current.directory).join("package.json"))
-            .returns(Models::NpmPackage.parse(package_json))
-
           message = <<~TEXT.strip
-            Please update your package.json as follows:
+            {{x}} Please update your package.json as follows:
             * Replace the development dependency @shopify/checkout-ui-extensions-run
               with @shopify/shopify-cli-extensions
             * Remove the start and server script
@@ -90,10 +85,11 @@ module Extension
             context: TestHelpers::FakeContext.new)
           assert_predicate(result, :failure?)
           assert_equal message, result.error.message
+        ensure
+          FileUtils.rm("package.json")
         end
 
         def test_does_not_raise_with_upgrade_instructions_if_package_json_is_up_to_date
-          $debug = true
           package_json = StringIO.new(<<~JSON)
             {
               "name": "my-extension",

--- a/test/project_types/extension/tasks/execute_commands/serve_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/serve_test.rb
@@ -54,15 +54,15 @@ module Extension
           {
             "name": "test-extension",
             "dependencies": {
-              "@shopify/checkout-ui-extensions": "^1.0.0"
+              "@shopify/checkout-ui-extensions": "^1.0.0",
             },
             "devDependencies": {
-              "@shopify/shopify-cli-extensions": "latest"
+              "@shopify/shopify-cli-extensions": "latest",
             },
             "scripts": {
               "build": "some command",
-              "develop": "some command"
-            }
+              "develop": "some command",
+            },
           }
         end
       end

--- a/test/project_types/extension/tasks/execute_commands/serve_test.rb
+++ b/test/project_types/extension/tasks/execute_commands/serve_test.rb
@@ -13,23 +13,20 @@ module Extension
           CLI::Kit::System.stubs(:popen3).returns("fake output")
         end
 
-        def teardown
-          FileUtils.rm_rf("tmp")
-        end
-
         def test_success_object_is_returned_on_successful_call
-          Dir.mkdir("tmp") unless Dir.exist?("tmp")
-          FileUtils.touch("tmp/test.txt")
-
-          test_file_path = File.join(Dir.pwd, "tmp")
+          FileUtils.touch("extension.config.yml")
+          File.write("package.json", JSON.dump(up_to_date_package_json))
 
           result = ExecuteCommands::Serve.new(
             type: "checkout_ui_extension",
-            config_file_path: File.join(test_file_path, "test.txt"),
+            config_file_path: "extension.config.yml",
             context: TestHelpers::FakeContext.new,
             tunnel_url: "http://example.ngrok.io"
           ).call
+
           assert_kind_of(ShopifyCLI::Result::Success, result)
+        ensure
+          FileUtils.rm("extension.config.yml")
         end
 
         private
@@ -51,6 +48,22 @@ module Extension
             user: Models::ServerConfig::User.new,
             development: development
           )
+        end
+
+        def up_to_date_package_json
+          {
+            "name": "test-extension",
+            "dependencies": {
+              "@shopify/checkout-ui-extensions": "^1.0.0"
+            },
+            "devDependencies": {
+              "@shopify/shopify-cli-extensions": "latest"
+            },
+            "scripts": {
+              "build": "some command",
+              "develop": "some command"
+            }
+          }
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent the CLI from crashing when running `shopify extensions build|serve` with the new extensions server without migrating the extension. Instead of crashing, the CLI will now emit an error message with detailed instructions.

<img width="860" alt="Screen Shot 2022-03-11 at 4 28 24 PM" src="https://user-images.githubusercontent.com/77060/157975843-dec5beae-e2c5-4e9d-8d08-e3892d2d0af7.png">

### WHAT is this pull request doing?

- ShopifyCLI::Result#unwrap!
- OutdatedExtensionCheck

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).
