### PR TITLE
ShopifyCLI::Result#unwrap!

### DIFF
--- a/lib/shopify_cli/result.rb
+++ b/lib/shopify_cli/result.rb
@@ -182,6 +182,13 @@ module ShopifyCLI
       end
 
       ##
+      # returns the value this success represents
+      #
+      def unwrap!
+        value
+      end
+
+      ##
       # returns the success value and ignores the fallback value that was either
       # provided as a method argument or by passing a block. However, the caller
       # is still required to specify a fallback value to ensure that in the
@@ -338,6 +345,13 @@ module ShopifyCLI
       def unwrap(*args, &block)
         raise ArgumentError, "expected either a fallback value or a block" unless (args.length == 1) ^ block
         block ? block.call(@error) : args.pop
+      end
+
+      ##
+      # raises the error this failure represents
+      #
+      def unwrap!
+        raise error
       end
     end
 

--- a/test/shopify-cli/result_test.rb
+++ b/test/shopify-cli/result_test.rb
@@ -144,6 +144,11 @@ module ShopifyCLI
         assert_same(success, success.rescue { called = true })
         refute called
       end
+
+      def test_force_unwrapping_returns_the_value
+        success = Success.new(:success)
+        assert_equal :success, success.unwrap!
+      end
     end
 
     class FailureTest < Minitest::Test
@@ -219,6 +224,14 @@ module ShopifyCLI
 
       def test_rescue_captures_exceptions_and_wraps_them_in_an_error
         assert Failure.new(1).then { raise "Failure" }.failure?
+      end
+
+      def test_force_unwrapping_raises_the_error
+        failure = Failure.new(RuntimeError.new("Some error"))
+        error = assert_raises(RuntimeError) do
+          failure.unwrap!
+        end
+        assert_equal "Some error", error.message
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

To make it easier to unwrap `Shopify::Result` objects. The pattern of either unwrapping the value or raising an exception is pretty common. It shouldn't require

```ruby
Shopify::Result.wrap("Some value").unwrap { |error| raise error }
```

when

```ruby
Shopify::Result.wrap("Some value").unwrap!
```

would suffice.

### WHAT is this pull request doing?

Adds a convenience method to `Shopify::Result::Sucess` and `Shopify::Result::Failure` to allow forceful unwrapping. `#unwrap!` simply returns the value in the success case. In the error case, it will throw the exception the failure represents.

### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~~I've included any post-release steps in the section above (if needed).~~
