### PR TITLE
Rails force generate to include overwritten CSP file

### DIFF
--- a/lib/shopify_cli/services/app/create/rails_service.rb
+++ b/lib/shopify_cli/services/app/create/rails_service.rb
@@ -189,7 +189,7 @@ module ShopifyCLI
             end
 
             CLI::UI::Frame.open(context.message("core.app.create.rails.running_generator")) do
-              syscall(%w(rails generate shopify_app --new-shopify-cli-app))
+              syscall(%w(rails generate shopify_app --new-shopify-cli-app -f))
             end
 
             CLI::UI::Frame.open(context.message("core.app.create.rails.running_migrations")) do


### PR DESCRIPTION
### WHY are these changes introduced?

For context: 
- issue: https://github.com/Shopify/shopify_app/issues/1377
- related PR: https://github.com/Shopify/shopify_app/pull/1389

Rails apps published in the App Store require the proper Content Security Policy to be set, specifically the frame_ancestors directive. The change in shopify_app accomplishes this by creating a new CSP configuration template with frame_ancestors included. This requires that when running `rails generate ...`, the `-f` flag must be passed in so that we can overwrite the default CSP configuration template (content_security_policy.rb).

### WHAT is this pull request doing?

Adds the `-f` flag to forcibly overwrite the content_security_policy.rb file when generating rails apps.


### How to test your changes?

Run `shopify app create rails` and verify that the app is generated correctly (ideally with the new csp file).

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).