### PR TITLE
Packaging for release v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.14.0
+
 ### Changed
 * [#2126](https://github.com/Shopify/shopify-cli/pull/2126): Use javy version 0.2.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.13.0)
+    shopify-cli (2.14.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.1)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.13.0"
+  VERSION = "2.14.0"
 end


### PR DESCRIPTION
PR for release 2.14.0 with changelog:

```
### Changed
* [#2126](https://github.com/Shopify/shopify-cli/pull/2126): Use javy version 0.2.1

### Added
* [#2103](https://github.com/Shopify/shopify-cli/pull/2103): Improve `shopify theme package` to include the `release-notes.md` file

### Fixed
* [#2112](https://github.com/Shopify/shopify-cli/pull/2112): Fix intermittent error ("can't add a new key into hash during iteration") in the `theme push` command
* [#2088](https://github.com/Shopify/shopify-cli/pull/2088): Update theme-check to 1.10.1
* [#2130](https://github.com/Shopify/shopify-cli/pull/2130): Fix Homebrew installation.
* [#2133](https://github.com/Shopify/shopify-cli/pull/2133): Fix ignore file handling in DevServer::Watcher.
```