### PR TITLE
Prevent duplicate locales for Checkout extension localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2086](https://github.com/Shopify/shopify-cli/pull/2086): Improve check of dependency versions
 * [#2149](https://github.com/Shopify/shopify-cli/pull/2149): Fix `ThemeAdminAPI` not to handle asset errors
+* [#2146](https://github.com/Shopify/shopify-cli/pull/2146): Prevent duplicate locales for Checkout extension localization
 
 ## Version 2.14.0
 

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -43,6 +43,7 @@ module Extension
             # Localization is optional
             return {} if locale_filenames.empty?
 
+            validate_no_duplicate_locale(locale_filenames)
             validate_total_size(locale_filenames)
             default_locale = single_default_locale(locale_filenames)
 
@@ -59,6 +60,18 @@ module Extension
               }
             end
           end
+        end
+
+        def validate_no_duplicate_locale(locale_filenames)
+          duplicate_locale = locale_filenames
+            .map { |filename| basename_for_locale_filename(filename.downcase) }
+            .group_by { |locale| locale }
+            .detect { |_k, v| v.size > 1 }
+            &.first
+          raise(
+            ShopifyCLI::Abort,
+            ShopifyCLI::Context.message("#{L10N_ERROR_PREFIX}.duplicate_locale_code", duplicate_locale)
+          ) unless duplicate_locale.nil?
         end
 
         def validate_total_size(locale_filenames)

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -281,6 +281,8 @@ module ShopifyCLI
               localization: {
                 error: {
                   bundle_too_large: "Total size of all locale files must be less than %s.",
+                  duplicate_locale_code: "Duplicate locale found: `%s`; locale codes"\
+                    " should be unique and are case insensitive.",
                   file_empty: "Locale file `%s` is empty.",
                   file_too_large: "Locale file `%s` too large; size must be less than %s.",
                   invalid_file_extension: "Invalid locale filename: `%s`; only .json files are allowed.",

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -162,6 +162,22 @@ module Extension
           end
         end
 
+        def test_l10n_duplicate_locales_with_different_casing
+          write("locales/EN.json", "{}")
+          write("locales/en.default.json", "{}")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.duplicate_locale_code" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
+        def test_l10n_duplicate_locales_with_same_casing
+          write("locales/fr-ca.json", "{}")
+          write("locales/fr-ca.default.json", "{}")
+          assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.duplicate_locale_code" do
+            @checkout_ui_extension.config(@context)
+          end
+        end
+
         def test_l10n_no_defaults
           write("locales/fr.json", "{}")
           assert_raises ShopifyCLI::Abort, "#{L10N_ERROR_PREFIX}.single_default_locale" do


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes internal issue https://github.com/Shopify/checkout-web/issues/9044

With the current implementation of localization for Checkout extensions, there is a possibility of the user providing the same locale code twice as part of their localization data.

This is possible by having the default locale file and another locale file contain the same locale code, for instance:
- `en.default.json`
- `en.json`

If we do nothing, eventually during processing only one translation dictionary out of the duplicates would be preserved and sent over to the backend as part of the `extension push` command. This would happen silently and might lead to unwanted bad surprises for the developer.

We prefer detecting such a situation early, before sending the data, and returning an error to the CLI console so that the developer might rectify the situation.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Detects the situation mentioned above for Checkout extensions and shows an error if it does happen.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
- In a checkout extension project, create a `locales` folder, and within that folder create the following files:
  - `en.default.json`
  - `en.json`
- Add some content to the files so that you do not get an empty file error.
- Try to `extension push` the contents of your extension
- You should be presented with the expected error message

<img width="642" alt="Screen Shot 2022-03-15 at 3 55 48 PM" src="https://user-images.githubusercontent.com/3000613/158460614-81eef707-b739-4ef3-b301-6fe9448b16d4.png">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
None

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).