### PR TITLE
Fix `ThemeAdminAPI` not to handle asset errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 ### Fixed
 * [#2086](https://github.com/Shopify/shopify-cli/pull/2086): Improve check of dependency versions
+* [#2149](https://github.com/Shopify/shopify-cli/pull/2149): Fix `ThemeAdminAPI` not to handle asset errors
 
 ## Version 2.14.0
 

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -42,11 +42,12 @@ module ShopifyCLI
       rescue ShopifyCLI::API::APIRequestForbiddenError,
              ShopifyCLI::API::APIRequestUnauthorizedError => error
         # The Admin API returns 403 Forbidden responses on different
-        # scenarios.
+        # scenarios:
         #
         # * when a user doesn't have permissions for a request:
         #   <APIRequestForbiddenError: 403 {}>
-        # * when an asset cannot be removed:
+        #
+        # * when an asset operation cannot be performed:
         #   <APIRequestForbiddenError: 403 {"message":"templates/gift_card.liquid could not be deleted"}>
         if empty_response_error?(error)
           return handle_permissions_error

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -11,35 +11,19 @@ module ShopifyCLI
       end
 
       def get(path:, **args)
-        rest_request(
-          method: "GET",
-          path: path,
-          **args
-        )
+        rest_request(method: "GET", path: path, **args)
       end
 
       def put(path:, **args)
-        rest_request(
-          method: "PUT",
-          path: path,
-          **args
-        )
+        rest_request(method: "PUT", path: path, **args)
       end
 
       def post(path:, **args)
-        rest_request(
-          method: "POST",
-          path: path,
-          **args
-        )
+        rest_request(method: "POST", path: path, **args)
       end
 
       def delete(path:, **args)
-        rest_request(
-          method: "DELETE",
-          path: path,
-          **args
-        )
+        rest_request(method: "DELETE", path: path, **args)
       end
 
       def get_shop_or_abort # rubocop:disable Naming/AccessorMethodName
@@ -56,15 +40,21 @@ module ShopifyCLI
           **args.compact
         )
       rescue ShopifyCLI::API::APIRequestForbiddenError,
-             ShopifyCLI::API::APIRequestUnauthorizedError
-        handle_permissions_error
+             ShopifyCLI::API::APIRequestUnauthorizedError => error
+        return handle_permissions_error if permissions_error?(error)
+        raise error
       end
 
       def handle_permissions_error
-        ensure_user_error = @ctx.message("theme.ensure_user_error", get_shop_or_abort)
+        ensure_user_error = @ctx.message("theme.ensure_user_error", shop)
         ensure_user_try_this = @ctx.message("theme.ensure_user_try_this")
 
         @ctx.abort(ensure_user_error, ensure_user_try_this)
+      end
+
+      def permissions_error?(error)
+        error_message = error&.response&.body.to_s
+        error_message.empty?
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

We've introduced the `ThemeAdminAPI` on #2114 to handle scenarios with where users doesn't have permissions and show a friendly message instead of an error.

### WHAT is this pull request doing?

This PR restricts the scope of the error by handling only permissions errors and defering other errors to upper levels.

### How to test your changes?

- Login with an user with permissions in a store (with `shopify login -s <shop>`)
- Remove the `templates/gift_card.liquid`
- Notice the error appear as expected

Before this PR:
<img width="1592" alt="Screenshot 2022-03-16 at 13 00 10" src="https://user-images.githubusercontent.com/1079279/158595524-3d84bfad-4ce9-4692-8164-f9ce04a7775f.png">


After this PR:
<img width="1592" alt="Screenshot 2022-03-16 at 12 58 25" src="https://user-images.githubusercontent.com/1079279/158595442-562b53c3-0f10-4ac0-9475-c7c3a910ca18.png">

### FAQ

**Is the `theme serve` still working?**
Yes. The unexpected error message appears, but the features continue working as expected:
<img width="1592" alt="Screenshot 2022-03-16 at 13 00 31" src="https://user-images.githubusercontent.com/1079279/158595403-b4cd9a98-2d88-48e0-855e-a077fffae469.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).