### PR TITLE
Reduce GraphQL query complexity for calls against the Partners CLI API.

### DIFF
--- a/lib/graphql/all_organizations.graphql
+++ b/lib/graphql/all_organizations.graphql
@@ -1,10 +1,10 @@
 query AllOrgs{
-  organizations {
+  organizations(first: 3) {
     nodes {
       id
       businessName
       website
-      stores(first: 500) {
+      stores(first: 50) {
         nodes {
           shopId
           link

--- a/lib/graphql/all_orgs_with_apps.graphql
+++ b/lib/graphql/all_orgs_with_apps.graphql
@@ -1,10 +1,10 @@
 query AllOrgs{
-  organizations {
+  organizations(first: 3) {
     nodes {
       id
       businessName
       website
-      stores(first: 500) {
+      stores(first: 25) {
         nodes {
           shopId
           link
@@ -14,7 +14,7 @@ query AllOrgs{
           convertableToPartnerTest
         }
       }
-      apps(first: 500) {
+      apps(first: 25) {
         nodes {
           id
           title

--- a/lib/graphql/find_organization.graphql
+++ b/lib/graphql/find_organization.graphql
@@ -1,10 +1,10 @@
 query FindOrg($id: ID!) {
-  organizations(id: $id) {
+  organizations(id: $id, first: 1) {
     nodes {
       id
       businessName
       website
-      stores(first: 500) {
+      stores(first: 190) {
         nodes {
           link
           shopDomain


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

To make the Shopify CLI compatible with [stricter limits in the Partners CLI API](https://github.com/Shopify/partners/issues/38963).

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR prevents the CLI client from running GraphQL queries with a complexity greater than 1000 against the Partners CLI API.

This is only an example. Some other solution is likely needed.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).