### PR TITLE
Fix link to bugs label in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ When contributing to the Shopify CLI, there are a set of [design guidelines](htt
 
 ### Where to find known issues
 
-We track all of our issues in GitHub and [bugs](https://github.com/Shopify/shopify-cli/labels/Bug) are labeled accordingly. If you are planning to work on an issue, avoid ones which already have an assignee, where someone has commented within the last two weeks they are working on it, or the issue is labeled with [fix in progress](https://github.com/Shopify/shopify-cli/labels/fix%20in%20progress). We will do our best to communicate when an issue is being worked on internally.
+We track all of our issues in GitHub and [bugs](https://github.com/Shopify/shopify-cli/labels/type:bug) are labeled accordingly. If you are planning to work on an issue, avoid ones which already have an assignee, where someone has commented within the last two weeks they are working on it, or the issue is labeled with [fix in progress](https://github.com/Shopify/shopify-cli/labels/fix%20in%20progress). We will do our best to communicate when an issue is being worked on internally.
 
 ### Running against a local environment
 


### PR DESCRIPTION
### WHY are these changes introduced?

The GitHub label used for bugs in this repo seems to be `type:bug`, not `Bug` – this means that the supposed link to "bugs" in `CONTRIBUTING.md` currently points to an empty list.

### WHAT is this pull request doing?

Fixes a link to the list of open bugs.

### How to test your changes?

Verify that the updated link in the Markdown doc now points to the correct list of filtered issues about bugs.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).