### PR TITLE
Improve encoding error handling for Checkout Extension localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
+
 ## Version 2.15.2
 
 ### Fixed

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -294,6 +294,7 @@ module ShopifyCLI
                   invalid_file_extension: "Invalid locale filename: `%s`; only .json files are allowed.",
                   invalid_locale_code: "Invalid locale filename: `%s`; locale code should be 2 or 3 letters,"\
                     " optionally followed by a two-letter region code, e.g. `fr-CA`.",
+                  invalid_file_encoding: "Invalid file encoding for `%s`; file encoding should be UTF-8.",
                   single_default_locale: "There must be one and only one locale identified as the default locale,"\
                     " e.g. `en.default.json`",
                 },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [internal issue 1](https://github.com/Shopify/checkout-web/issues/8687), [internal issue 2](https://github.com/Shopify/checkout-web/issues/8688)

<!--
  Context about the problem that’s being addressed.
-->

Localization files not properly encoded in UTF-8 (without `bom`) could cause unexpected errors in the CLI when using the `extension push` command.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

- Raise an explicit error on non-UTF-8 encodings
- Silently strip the UTF-8 `bom` from localization data if present

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

- Have a local setup ready for Checkout Extension development
- In a checkout extension project, create a `locales` folder, and within that folder create the following files:
  - `en.default.json`
- Add some content to the files so that you do not get an empty file error.
- First Scenario: To see the encoding error, encode the locale file with an encoding other than UTF-8, such as `macThai` and containing Thai characters (`ก ไก่`)
- Second Scenario: Use UTF-8 with `bom` to verify that this does not cause an error
- When ready, try to `extension push` the contents of your extension

#### Before 
<img width="1358" alt="Screen Shot 2022-03-21 at 3 27 21 PM" src="https://user-images.githubusercontent.com/3000613/159349300-ad4de7af-d762-40ad-91fe-4e439a10591a.png">

#### After
<img width="618" alt="Screen Shot 2022-03-23 at 11 45 58 AM" src="https://user-images.githubusercontent.com/3000613/159739497-f8c2344f-c54e-4942-8b79-310e58b48594.png">

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
n/a

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).