### PR TITLE
Add optional 2-way sync between the CLI (`theme serve`) and the Theme Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#1934](https://github.com/Shopify/shopify-cli/pull/1934): Block directories in theme assets
 * [#1880](https://github.com/Shopify/shopify-cli/pull/1880): Recognize attempts to pass a store name and suggest correction
+* [#2174](https://github.com/Shopify/shopify-cli/pull/2174): Add optional 2-way sync between the CLI (`theme serve`) and the Theme Editor
 
 ### Fixed
 * [#1874](https://github.com/Shopify/shopify-cli/pull/1874): Make ngrok errors more robust and helpful

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -16,7 +16,7 @@ module Theme
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
-        parser.on("--theme-editor-sync=SECONDS") { |seconds| flags[:pull_interval] = seconds.to_i }
+        parser.on("--theme-editor-sync") { flags[:editor_sync] = true }
       end
 
       def call(_args, name)

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -16,6 +16,7 @@ module Theme
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
+        parser.on("--theme-editor-sync=SECONDS") { |seconds| flags[:pull_interval] = seconds.to_i }
       end
 
       def call(_args, name)

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -101,14 +101,14 @@ module Theme
             Usage: {{command:%s theme serve [ ROOT ]}}
 
             Options:
-              {{command:--port=PORT}}                 Local port to serve theme preview from.
-              {{command:--poll}}                      Force polling to detect file changes.
-              {{command:--host=HOST}}                 Set which network interface the web server listens on. The default value is 127.0.0.1.
-              {{command:--theme-editor-sync=SECONDS}} Pulling interval (in seconds) to download Theme Editor changes and in your local theme files (default: off).
-              {{command:--live-reload=MODE}}          The live reload mode switches the server behavior when a file is modified:
-                                          - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
-                                          - {{command:full-page}}  Always refreshes the entire page
-                                          - {{command:off}}        Deactivate live reload
+              {{command:--port=PORT}}         Local port to serve theme preview from.
+              {{command:--poll}}              Force polling to detect file changes.
+              {{command:--host=HOST}}         Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--theme-editor-sync}} Pulling interval (in seconds) to download Theme Editor changes and in your local theme files (default: off).
+              {{command:--live-reload=MODE}}  The live reload mode switches the server behavior when a file is modified:
+                                  - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
+                                  - {{command:full-page}}  Always refreshes the entire page
+                                  - {{command:off}}        Deactivate live reload
           HELP
           reload_mode_is_not_valid: "The live reload mode `%s` is not valid.",
           try_a_valid_reload_mode: "Try a valid live reload mode: %s.",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -104,7 +104,7 @@ module Theme
               {{command:--port=PORT}}         Local port to serve theme preview from.
               {{command:--poll}}              Force polling to detect file changes.
               {{command:--host=HOST}}         Set which network interface the web server listens on. The default value is 127.0.0.1.
-              {{command:--theme-editor-sync}} Pulling interval (in seconds) to download Theme Editor changes and in your local theme files (default: off).
+              {{command:--theme-editor-sync}} Synchronize Theme Editor updates in the local theme files.
               {{command:--live-reload=MODE}}  The live reload mode switches the server behavior when a file is modified:
                                   - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
                                   - {{command:full-page}}  Always refreshes the entire page

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -101,13 +101,14 @@ module Theme
             Usage: {{command:%s theme serve [ ROOT ]}}
 
             Options:
-              {{command:--port=PORT}}        Local port to serve theme preview from.
-              {{command:--poll}}             Force polling to detect file changes.
-              {{command:--host=HOST}}        Set which network interface the web server listens on. The default value is 127.0.0.1.
-              {{command:--live-reload=MODE}} The live reload mode switches the server behavior when a file is modified:
-                                 - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
-                                 - {{command:full-page}}  Always refreshes the entire page
-                                 - {{command:off}}        Deactivate live reload
+              {{command:--port=PORT}}                 Local port to serve theme preview from.
+              {{command:--poll}}                      Force polling to detect file changes.
+              {{command:--host=HOST}}                 Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--theme-editor-sync=SECONDS}} Pulling interval (in seconds) to download Theme Editor changes and in your local theme files (default: off).
+              {{command:--live-reload=MODE}}          The live reload mode switches the server behavior when a file is modified:
+                                          - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
+                                          - {{command:full-page}}  Always refreshes the entire page
+                                          - {{command:off}}        Deactivate live reload
           HELP
           reload_mode_is_not_valid: "The live reload mode `%s` is not valid.",
           try_a_valid_reload_mode: "Try a valid live reload mode: %s.",
@@ -119,6 +120,36 @@ module Theme
               error: "ERROR",
               synced: "Synced",
               fixed: "Fixed",
+            },
+          },
+          syncer: {
+            forms: {
+              apply_to_all: {
+                title: "Would like apply this to all the other %s files?",
+                yes: "Yes",
+                no: "No",
+              },
+              update_strategy: {
+                title_context: <<~TITLE,
+
+                  The local file {{command:%s}} is different from the remote version in the development theme."
+                TITLE
+                title_question: "What would you like to do?",
+                keep_remote: "Keep the remote version",
+                keep_local: "Keep the local version",
+                union_merge: "Merge files (it may break the local file)",
+                exit: "Exit",
+              },
+              delete_strategy: {
+                title_context: <<~TITLE,
+
+                  The local file {{command:%s}} has been recently removed, but it's present on your remote development theme.",
+                TITLE
+                title_question: "What would you like to do?",
+                delete: "Delete permanently",
+                restore: "Restore with the remote version",
+                exit: "Exit",
+              },
             },
           },
           error: {
@@ -137,9 +168,10 @@ module Theme
             Serving %s
 
           SERVING
+          download_changes: ", and use 'theme pull' to get the changes",
           customize_or_preview: <<~CUSTOMIZE_OR_PREVIEW,
 
-            Customize this theme in the Theme Editor:
+            Customize this theme in the Theme Editor%s:
             {{green:%s}}
 
             Share this theme preview:

--- a/lib/shopify_cli/git.rb
+++ b/lib/shopify_cli/git.rb
@@ -103,6 +103,42 @@ module ShopifyCLI
       end
 
       ##
+      # Run git three-way file merge (it doesn't require an initialized git repository)
+      #
+      # #### Parameters
+      #
+      # * `current_file  - string path of the current file
+      # * `base_file`    - string path of the base file
+      # * `other_file`   - string path of the other file
+      # * `opts`         - list of "git merge-file" options. Valid values:
+      #                    - "-q"       - do not warn about conflicts
+      #                    - "--diff3"  - show conflicts
+      #                    - "--ours"   - resolve conflicts favoring lines from `current_file`
+      #                    - "--theirs" - resolve conflicts favoring lines from `other_file`
+      #                    - "--union"  - resolve conflicts favoring lines from both files
+      #                    - "-p"       - send results to standard output instead of
+      #                                 overwriting the `current_file`
+      # * `ctx`          - the current running context of your command, defaults to a new context
+      #
+      # #### Returns
+      #
+      # * standard output from git
+      #
+      # #### Example
+      #
+      #   output = ShopifyCLI::Git.merge_file(current_file, base_file, other_file, opts, ctx: ctx)
+      #
+      def merge_file(current_file, base_file, other_file, opts = [], ctx: Context.new)
+        output, status = ctx.capture2e("git", "merge-file", current_file, base_file, other_file, *opts)
+
+        unless status.success?
+          ctx.abort(ctx.message("core.git.error.merge_failed"))
+        end
+
+        output
+      end
+
+      ##
       # will initialize a new repo in the current directory. This will output
       # if it was successful or not.
       #

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -388,6 +388,7 @@ module ShopifyCLI
             sparse_checkout_not_set: "Sparse checkout set command failed.",
             pull_failed: "Pull failed.",
             pull_failed_bad_branch: "Pull failed. Branch %s cannot be found. Check the branch name and try again.",
+            merge_failed: "The file %s merge failed.",
           },
 
           cloning: "Cloning %s into %s…",

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -11,6 +11,7 @@ require_relative "dev_server/local_assets"
 require_relative "dev_server/proxy"
 require_relative "dev_server/sse"
 require_relative "dev_server/watcher"
+require_relative "dev_server/remote_watcher"
 require_relative "dev_server/web_server"
 require_relative "dev_server/certificate_manager"
 
@@ -26,12 +27,13 @@ module ShopifyCLI
       class << self
         attr_accessor :ctx
 
-        def start(ctx, root, host: "127.0.0.1", port: 9292, poll: false, mode: ReloadMode.default)
+        def start(ctx, root, host: "127.0.0.1", port: 9292, poll: false, pull_interval: 0, mode: ReloadMode.default)
           @ctx = ctx
           theme = DevelopmentTheme.find_or_create!(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
-          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter)
+          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: pull_interval.zero?)
           watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, ignore_filter: ignore_filter, poll: poll)
+          remote_watcher = RemoteWatcher.to(theme: theme, syncer: @syncer, interval: pull_interval)
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
           @app = Proxy.new(ctx, theme: theme, syncer: @syncer)
@@ -57,9 +59,17 @@ module ShopifyCLI
 
             return if stopped
 
+            preview_suffix = pull_interval.zero? ? ctx.message("theme.serve.download_changes") : ""
+            preview_message = ctx.message(
+              "theme.serve.customize_or_preview",
+              preview_suffix,
+              theme.editor_url,
+              theme.preview_url
+            )
+
             ctx.puts(ctx.message("theme.serve.serving", theme.root))
             ctx.open_url!(address)
-            ctx.puts(ctx.message("theme.serve.customize_or_preview", theme.editor_url, theme.preview_url))
+            ctx.puts(preview_message)
           end
 
           logger = if ctx.debug?
@@ -69,6 +79,7 @@ module ShopifyCLI
           end
 
           watcher.start
+          remote_watcher.start
           WebServer.run(
             @app,
             BindAddress: host,
@@ -76,6 +87,7 @@ module ShopifyCLI
             Logger: logger,
             AccessLog: [],
           )
+          remote_watcher.stop
           watcher.stop
 
         rescue ShopifyCLI::API::APIRequestForbiddenError,

--- a/lib/shopify_cli/theme/dev_server/hot_reload/remote_file_reloader.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/remote_file_reloader.rb
@@ -51,7 +51,7 @@ module ShopifyCLI
           def fetch_asset(file)
             api_client.get(
               path: "themes/#{@theme.id}/assets.json",
-              query: URI.encode_www_form("asset[key]" => file.relative_path.to_s),
+              query: URI.encode_www_form("asset[key]" => file.relative_path),
             )
           rescue ShopifyCLI::API::APIRequestNotFoundError
             [404, {}]

--- a/lib/shopify_cli/theme/dev_server/local_assets.rb
+++ b/lib/shopify_cli/theme/dev_server/local_assets.rb
@@ -71,7 +71,7 @@ module ShopifyCLI
 
         def replace_asset_urls(body)
           replaced_body = body.join.gsub(ASSET_REGEX) do |match|
-            path = Pathname.new(Regexp.last_match[1])
+            path = Regexp.last_match[1]
             if @theme.static_asset_paths.include?(path)
               "/#{path}"
             else

--- a/lib/shopify_cli/theme/dev_server/remote_watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/remote_watcher.rb
@@ -8,40 +8,35 @@ module ShopifyCLI
   module Theme
     module DevServer
       class RemoteWatcher
+        SYNC_INTERVAL = 3 # seconds
+
         class << self
-          def to(theme:, syncer:, interval:)
-            new(theme, syncer, interval)
+          def to(theme:, syncer:)
+            new(theme, syncer)
           end
         end
 
         def start
-          return unless activated?
           thread_pool.schedule(recurring_job)
         end
 
         def stop
-          return unless activated?
           thread_pool.shutdown
         end
 
         private
 
-        def initialize(theme, syncer, interval)
+        def initialize(theme, syncer)
           @theme = theme
           @syncer = syncer
-          @interval = interval
         end
 
         def thread_pool
           @thread_pool ||= ShopifyCLI::ThreadPool.new(pool_size: 1)
         end
 
-        def activated?
-          @interval > 0
-        end
-
         def recurring_job
-          JsonFilesUpdateJob.new(@theme, @syncer, @interval)
+          JsonFilesUpdateJob.new(@theme, @syncer, SYNC_INTERVAL)
         end
       end
     end

--- a/lib/shopify_cli/theme/dev_server/remote_watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/remote_watcher.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "shopify_cli/thread_pool"
+
+require_relative "remote_watcher/json_files_update_job"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class RemoteWatcher
+        class << self
+          def to(theme:, syncer:, interval:)
+            new(theme, syncer, interval)
+          end
+        end
+
+        def start
+          return unless activated?
+          thread_pool.schedule(recurring_job)
+        end
+
+        def stop
+          return unless activated?
+          thread_pool.shutdown
+        end
+
+        private
+
+        def initialize(theme, syncer, interval)
+          @theme = theme
+          @syncer = syncer
+          @interval = interval
+        end
+
+        def thread_pool
+          @thread_pool ||= ShopifyCLI::ThreadPool.new(pool_size: 1)
+        end
+
+        def activated?
+          @interval > 0
+        end
+
+        def recurring_job
+          JsonFilesUpdateJob.new(@theme, @syncer, @interval)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
+++ b/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
@@ -25,6 +25,7 @@ module ShopifyCLI
             @theme
               .json_files
               .reject { |file| @syncer.pending_updates.include?(file) }
+              .reject { |file| @syncer.broken_file?(file) }
           end
         end
       end

--- a/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
+++ b/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "shopify_cli/thread_pool/job"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class RemoteWatcher
+        class JsonFilesUpdateJob < ShopifyCLI::ThreadPool::Job
+          def initialize(theme, syncer, interval)
+            super(interval)
+
+            @theme = theme
+            @syncer = syncer
+          end
+
+          def perform!
+            @syncer.fetch_checksums!
+            @syncer.enqueue_get(json_files)
+          end
+
+          private
+
+          def json_files
+            @theme
+              .json_files
+              .reject { |file| @syncer.pending_updates.include?(file) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -59,7 +59,7 @@ module ShopifyCLI
         private
 
         def ignore_file?(file)
-          @ignore_filter&.ignore?(file.relative_path.to_s)
+          @ignore_filter&.ignore?(file.relative_path)
         end
       end
     end

--- a/lib/shopify_cli/theme/file.rb
+++ b/lib/shopify_cli/theme/file.rb
@@ -4,7 +4,6 @@ require_relative "mime_type"
 module ShopifyCLI
   module Theme
     class File < Struct.new(:path)
-      attr_reader :relative_path
       attr_accessor :remote_checksum
 
       def initialize(path, root)
@@ -42,7 +41,7 @@ module ShopifyCLI
       end
 
       def mime_type
-        @mime_type ||= MimeType.by_filename(relative_path)
+        @mime_type ||= MimeType.by_filename(@relative_path)
       end
 
       def text?
@@ -54,7 +53,7 @@ module ShopifyCLI
       end
 
       def liquid_css?
-        relative_path.to_s.end_with?(".css.liquid")
+        relative_path.end_with?(".css.liquid")
       end
 
       def json?
@@ -62,7 +61,7 @@ module ShopifyCLI
       end
 
       def template?
-        relative_path.to_s.start_with?("templates/")
+        relative_path.start_with?("templates/")
       end
 
       def checksum
@@ -82,6 +81,18 @@ module ShopifyCLI
       # some of which may be relative paths while others are absolute paths.
       def ==(other)
         relative_path == other.relative_path
+      end
+
+      def name(*args)
+        ::File.basename(path, *args)
+      end
+
+      def absolute_path
+        path.realpath.to_s
+      end
+
+      def relative_path
+        @relative_path.to_s
       end
 
       private

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
+
 require "thread"
 require "json"
 require "base64"
 require "forwardable"
 
+require_relative "syncer/checksums"
 require_relative "syncer/error_reporter"
-require_relative "syncer/standard_reporter"
+require_relative "syncer/ignore_helper"
+require_relative "syncer/json_delete_handler"
+require_relative "syncer/json_update_handler"
+require_relative "syncer/merger"
 require_relative "syncer/operation"
+require_relative "syncer/standard_reporter"
 require_relative "theme_admin_api"
 
 module ShopifyCLI
@@ -14,36 +20,46 @@ module ShopifyCLI
     class Syncer
       extend Forwardable
 
-      attr_reader :checksums
-      attr_reader :checksums_mutex
-      attr_accessor :include_filter
-      attr_accessor :ignore_filter
+      include IgnoreHelper
+      include JsonDeleteHandler
+      include JsonUpdateHandler
+
+      QUEUEABLE_METHODS = [
+        :get,         # - Updates the local file with the remote file content
+        :update,      # - Updates the remote file with the local file content
+        :delete,      # - Deletes the remote file
+        :union_merge, # - Union merges the local file content with the remote file content
+      ]
+
+      attr_reader :theme, :checksums
+      attr_accessor :include_filter, :ignore_filter
 
       def_delegators :@error_reporter, :has_any_error?
 
-      def initialize(ctx, theme:, include_filter: nil, ignore_filter: nil)
+      def initialize(ctx, theme:, include_filter: nil, ignore_filter: nil, overwrite_json: true)
         @ctx = ctx
         @theme = theme
         @include_filter = include_filter
         @ignore_filter = ignore_filter
+        @overwrite_json = overwrite_json
         @error_reporter = ErrorReporter.new(ctx)
         @standard_reporter = StandardReporter.new(ctx)
         @reporters = [@error_reporter, @standard_reporter]
 
         # Queue of `Operation`s waiting to be picked up from a thread for processing.
         @queue = Queue.new
+
         # `Operation`s will be removed from this Array completed.
         @pending = []
+
         # Thread making the API requests.
         @threads = []
+
         # Mutex used to pause all threads when backing-off when hitting API rate limits
         @backoff_mutex = Mutex.new
 
-        # Mutex used to coordinate changes in the checksums (shared accross all threads)
-        @checksums_mutex = Mutex.new
-
         # Latest theme assets checksums. Updated on each upload.
-        @checksums = {}
+        @checksums = Checksums.new(theme)
 
         # Checksums of assets with errors.
         @error_checksums = []
@@ -73,6 +89,10 @@ module ShopifyCLI
         files.each { |file| enqueue(:delete, file) }
       end
 
+      def enqueue_union_merges(files)
+        files.each { |file| enqueue(:union_merge, file) }
+      end
+
       def size
         @pending.size
       end
@@ -86,7 +106,7 @@ module ShopifyCLI
       end
 
       def remote_file?(file)
-        checksums.key?(@theme[file].relative_path.to_s)
+        checksums.has?(file)
       end
 
       def wait!
@@ -133,22 +153,22 @@ module ShopifyCLI
 
       def upload_theme!(delay_low_priority_files: false, delete: true, &block)
         fetch_checksums!
+        removed_json_files = []
+        removed_files = []
 
         if delete
-          # Delete remote files not present locally
-          removed_files = checksums.keys - @theme.theme_files.map { |file| file.relative_path.to_s }
+          removed_json_files, removed_files = checksums
+            .keys
+            .-(@theme.theme_files.map(&:relative_path))
+            .map { |file| @theme[file] }
+            .partition(&:json?)
+
           enqueue_deletes(removed_files)
+          enqueue_json_deletes(removed_json_files)
         end
 
-        # Some files must be uploaded after the other ones
-        delayed_config_files = [
-          @theme["config/settings_schema.json"],
-          @theme["config/settings_data.json"],
-        ]
-
-        enqueue_updates(@theme.liquid_files)
-        enqueue_updates(@theme.json_files - delayed_config_files)
-        enqueue_updates(delayed_config_files)
+        enqueue_updates(@theme.liquid_files - removed_files)
+        enqueue_json_updates(@theme.json_files - removed_json_files)
 
         if delay_low_priority_files
           # Wait for liquid & JSON files to upload, because those are rendered remotely
@@ -158,7 +178,7 @@ module ShopifyCLI
         # Process lower-priority files in the background
 
         # Assets are served locally, so can be uploaded in the background
-        enqueue_updates(@theme.static_asset_files)
+        enqueue_updates(@theme.static_asset_files - removed_files)
 
         unless delay_low_priority_files
           wait!(&block)
@@ -171,7 +191,7 @@ module ShopifyCLI
         if delete
           # Delete local files not present remotely
           missing_files = @theme.theme_files
-            .reject { |file| checksums.key?(file.relative_path.to_s) }.uniq
+            .reject { |file| checksums.has?(file) }.uniq
             .reject { |file| ignore_file?(file) }
           missing_files.each do |file|
             @ctx.debug("rm #{file.relative_path}")
@@ -187,12 +207,13 @@ module ShopifyCLI
       private
 
       def report_error(operation, error_suffix = "")
-        @error_checksums << @checksums[operation.file_path]
+        @error_checksums << checksums[operation.file_path]
         @error_reporter.report("#{operation.as_error_message}#{error_suffix}")
       end
 
       def enqueue(method, file)
         raise ArgumentError, "file required" unless file
+        raise ArgumentError, "method '#{method}' cannot be queued" unless QUEUEABLE_METHODS.include?(method)
 
         operation = Operation.new(@ctx, method, @theme[file])
 
@@ -204,7 +225,7 @@ module ShopifyCLI
           return
         end
 
-        if [:update, :get].include?(method) && operation.file.exist? && !file_has_changed?(operation.file)
+        if [:update, :get].include?(method) && operation.file.exist? && !checksums.file_has_changed?(operation.file)
           is_fixed = !!@error_checksums.delete(operation.file.checksum)
           @standard_reporter.report(operation.as_fix_message) if is_fixed
           return
@@ -236,7 +257,7 @@ module ShopifyCLI
       end
 
       def update(file)
-        asset = { key: file.relative_path.to_s }
+        asset = { key: file.relative_path }
         if file.text?
           asset[:value] = file.read
         else
@@ -253,32 +274,10 @@ module ShopifyCLI
         response
       end
 
-      def ignore_operation?(operation)
-        path = operation.file_path
-        ignore_path?(path)
-      end
-
-      def ignore_file?(file)
-        path = file.path
-        ignore_path?(path)
-      end
-
-      def ignore_path?(path)
-        ignored_by_ignore_filter?(path) || ignored_by_include_filter?(path)
-      end
-
-      def ignored_by_ignore_filter?(path)
-        ignore_filter&.ignore?(path)
-      end
-
-      def ignored_by_include_filter?(path)
-        !!include_filter && !include_filter.match?(path)
-      end
-
       def get(file)
         _status, body, response = api_client.get(
           path: "themes/#{@theme.id}/assets.json",
-          query: URI.encode_www_form("asset[key]" => file.relative_path.to_s),
+          query: URI.encode_www_form("asset[key]" => file.relative_path),
         )
 
         update_checksums(body)
@@ -297,37 +296,45 @@ module ShopifyCLI
         _status, _body, response = api_client.delete(
           path: "themes/#{@theme.id}/assets.json",
           body: JSON.generate(asset: {
-            key: file.relative_path.to_s,
+            key: file.relative_path,
           })
         )
 
         response
       end
 
+      def union_merge(file)
+        _status, body, response = api_client.get(
+          path: "themes/#{@theme.id}/assets.json",
+          query: URI.encode_www_form("asset[key]" => file.relative_path),
+        )
+
+        return response unless file.text?
+
+        remote_content = body.dig("asset", "value")
+
+        return response if remote_content.nil?
+
+        content = Merger.union_merge(file, remote_content)
+
+        file.write(content)
+        response
+      end
+
       def update_checksums(api_response)
         api_response.values.flatten.each do |asset|
           next unless asset["key"]
-          checksums_mutex.synchronize do
-            @checksums[asset["key"]] = asset["checksum"]
-          end
+          checksums[asset["key"]] = asset["checksum"]
         end
-        # Generate .liquid asset files are reported twice in checksum:
-        # once of generated, once for .liquid. We only keep the .liquid, that's the one we have
-        # on disk.
-        checksums_mutex.synchronize do
-          @checksums.reject! { |key, _| @checksums.key?("#{key}.liquid") }
-        end
-      end
 
-      def file_has_changed?(file)
-        file.checksum != @checksums[file.relative_path.to_s]
+        checksums.reject_duplicated_checksums!
       end
 
       def parse_api_errors(exception)
         parsed_body = JSON.parse(exception&.response&.body)
         message = parsed_body.dig("errors", "asset") || parsed_body["message"] || exception.message
         # Truncate to first lines
-        [message].flatten.map { |mess| mess.split("\n", 2).first }
+        [message].flatten.map { |m| m.split("\n", 2).first }
       rescue JSON::ParserError
         [exception.message]
       end
@@ -337,6 +344,10 @@ module ShopifyCLI
           @ctx.debug("Near API call limit, waiting 2 sec…")
           @backoff_mutex.synchronize { sleep(2) }
         end
+      end
+
+      def overwrite_json?
+        @overwrite_json
       end
 
       def backingoff?

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -110,7 +110,7 @@ module ShopifyCLI
       end
 
       def broken_file?(file)
-        error_checksums.key?(file.relative_path)
+        error_checksums.include?(checksums[file.relative_path])
       end
 
       def wait!
@@ -157,8 +157,6 @@ module ShopifyCLI
 
       def upload_theme!(delay_low_priority_files: false, delete: true, &block)
         fetch_checksums!
-        removed_json_files = []
-        removed_files = []
 
         if delete
           removed_json_files, removed_files = checksums
@@ -171,8 +169,8 @@ module ShopifyCLI
           enqueue_json_deletes(removed_json_files)
         end
 
-        enqueue_updates(@theme.liquid_files - removed_files)
-        enqueue_json_updates(@theme.json_files - removed_json_files)
+        enqueue_updates(@theme.liquid_files)
+        enqueue_json_updates(@theme.json_files)
 
         if delay_low_priority_files
           # Wait for liquid & JSON files to upload, because those are rendered remotely
@@ -182,7 +180,7 @@ module ShopifyCLI
         # Process lower-priority files in the background
 
         # Assets are served locally, so can be uploaded in the background
-        enqueue_updates(@theme.static_asset_files - removed_files)
+        enqueue_updates(@theme.static_asset_files)
 
         unless delay_low_priority_files
           wait!(&block)

--- a/lib/shopify_cli/theme/syncer/checksums.rb
+++ b/lib/shopify_cli/theme/syncer/checksums.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class Checksums
+        def initialize(theme)
+          @theme = theme
+          @checksum_by_key = {}
+
+          # Mutex used to coordinate changes in the checksums (shared accross `Syncer` threads)
+          @checksums_mutex = Mutex.new
+        end
+
+        def has?(file)
+          checksum_by_key.key?(to_key(file))
+        end
+
+        def file_has_changed?(file)
+          file.checksum != checksum_by_key[file.relative_path]
+        end
+
+        def keys
+          checksum_by_key.keys
+        end
+
+        def [](key)
+          checksum_by_key[key]
+        end
+
+        def []=(key, value)
+          checksums_mutex.synchronize do
+            checksum_by_key[key] = value
+          end
+        end
+
+        # Generate .liquid asset files are reported twice in checksum:
+        # once of generated, once for .liquid. We only keep the .liquid, that's the one we have
+        # on disk.
+        def reject_duplicated_checksums!
+          checksums_mutex.synchronize do
+            checksum_by_key.reject! { |key, _| checksum_by_key.key?("#{key}.liquid") }
+          end
+        end
+
+        private
+
+        def to_key(file)
+          theme[file].relative_path
+        end
+
+        # Private getters only used in unit tests
+
+        attr_reader :checksum_by_key
+        attr_reader :theme
+        attr_reader :checksums_mutex
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/forms/apply_to_all.rb
+++ b/lib/shopify_cli/theme/syncer/forms/apply_to_all.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "apply_to_all_form"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class ApplyToAll
+          attr_reader :value
+
+          def initialize(ctx, number_of_files)
+            @ctx = ctx
+            @number_of_files = number_of_files
+            @value = nil
+            @apply = nil
+          end
+
+          def apply?(value)
+            return unless @number_of_files > 1
+
+            if @apply.nil?
+              @apply = ask.apply?
+              @value = value if @apply
+            end
+
+            @apply
+          end
+
+          private
+
+          def ask
+            ApplyToAllForm.ask(@ctx, [], number_of_files: @number_of_files)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/forms/apply_to_all_form.rb
+++ b/lib/shopify_cli/theme/syncer/forms/apply_to_all_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class ApplyToAllForm < ShopifyCLI::Form
+          attr_accessor :apply
+          flag_arguments :number_of_files
+
+          def ask
+            title = message("title", number_of_files - 1)
+
+            self.apply = CLI::UI::Prompt.ask(title, allow_empty: false) do |handler|
+              handler.option(message("yes")) { true }
+              handler.option(message("no")) { false }
+            end
+
+            self
+          end
+
+          def apply?
+            apply
+          end
+
+          private
+
+          def message(key, *params)
+            ctx.message("theme.serve.syncer.forms.apply_to_all.#{key}", *params)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/forms/base_strategy_form.rb
+++ b/lib/shopify_cli/theme/syncer/forms/base_strategy_form.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class BaseStrategyForm < ShopifyCLI::Form
+          attr_accessor :strategy
+
+          def ask
+            ctx.puts(title_context(file))
+
+            self.strategy = CLI::UI::Prompt.ask(title_question, allow_empty: false) do |handler|
+              strategies.each do |strategy|
+                handler.option(as_text(strategy)) { strategy }
+              end
+            end
+
+            exit_cli if self.strategy == :exit
+
+            self
+          end
+
+          protected
+
+          ##
+          # List of strategies that populate the form options
+          #
+          def strategies
+            raise "`#{self.class.name}#strategies' must be defined"
+          end
+
+          ##
+          # Message prefix for the form title and options (strategies).
+          # See the methods `title` and `as_text`
+          #
+          def prefix
+            raise "`#{self.class.name}#prefix' must be defined"
+          end
+
+          private
+
+          def exit_cli
+            exit(0)
+          end
+
+          def title_context(file)
+            ctx.message("#{prefix}.title_context", file.relative_path)
+          end
+
+          def title_question
+            ctx.message("#{prefix}.title_question")
+          end
+
+          def as_text(strategy)
+            ctx.message("#{prefix}.#{strategy}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/forms/select_delete_strategy.rb
+++ b/lib/shopify_cli/theme/syncer/forms/select_delete_strategy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "base_strategy_form"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class SelectDeleteStrategy < BaseStrategyForm
+          flag_arguments :file
+
+          def strategies
+            %i[
+              delete
+              restore
+              exit
+            ]
+          end
+
+          def prefix
+            "theme.serve.syncer.forms.delete_strategy"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/forms/select_update_strategy.rb
+++ b/lib/shopify_cli/theme/syncer/forms/select_update_strategy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "base_strategy_form"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class SelectUpdateStrategy < BaseStrategyForm
+          flag_arguments :file
+
+          def strategies
+            %i[
+              keep_remote
+              keep_local
+              union_merge
+              exit
+            ]
+          end
+
+          def prefix
+            "theme.serve.syncer.forms.update_strategy"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/ignore_helper.rb
+++ b/lib/shopify_cli/theme/syncer/ignore_helper.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module IgnoreHelper
+        def ignore_operation?(operation)
+          path = operation.file_path
+          ignore_path?(path)
+        end
+
+        def ignore_file?(file)
+          path = file.path
+          ignore_path?(path)
+        end
+
+        def ignore_path?(path)
+          ignored_by_ignore_filter?(path) || ignored_by_include_filter?(path)
+        end
+
+        private
+
+        def ignored_by_ignore_filter?(path)
+          ignore_filter&.ignore?(path)
+        end
+
+        def ignored_by_include_filter?(path)
+          !!include_filter && !include_filter.match?(path)
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/json_delete_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_delete_handler.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "forms/apply_to_all"
+require_relative "forms/select_delete_strategy"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module JsonDeleteHandler
+        def enqueue_json_deletes(files)
+          files = files.select { |file| !ignore_file?(file) }
+
+          if overwrite_json?
+            enqueue_deletes(files)
+          else
+            # Handle conflicts when JSON files cannot be overwritten
+            handle_delete_conflicts(files)
+          end
+        end
+
+        private
+
+        def handle_delete_conflicts(files)
+          to_delete = []
+          to_get = []
+
+          apply_to_all = Forms::ApplyToAll.new(@ctx, files.size)
+
+          files.each do |file|
+            delete_strategy = apply_to_all.value || ask_delete_strategy(file)
+            apply_to_all.apply?(delete_strategy)
+
+            case delete_strategy
+            when :delete
+              to_delete << file
+            when :restore
+              to_get << file
+            end
+          end
+
+          enqueue_deletes(to_delete)
+          enqueue_get(to_get)
+        end
+
+        def ask_delete_strategy(file)
+          Forms::SelectDeleteStrategy.ask(@ctx, [], file: file).strategy
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "forms/apply_to_all"
+require_relative "forms/select_update_strategy"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module JsonUpdateHandler
+        def enqueue_json_updates(files)
+          # Some files must be uploaded after the other ones
+          delayed_files = [
+            theme["config/settings_schema.json"],
+            theme["config/settings_data.json"],
+          ]
+
+          # Update remote JSON files and delays `delayed_files` update
+          files = files
+            .select { |file| !ignore_file?(file) && file.exist? && checksums.file_has_changed?(file) }
+            .sort_by { |file| delayed_files.include?(file) ? 1 : 0 }
+
+          if overwrite_json?
+            enqueue_updates(files)
+          else
+            # Handle conflicts when JSON files cannot be overwritten
+            handle_update_conflicts(files)
+          end
+        end
+
+        private
+
+        def handle_update_conflicts(files)
+          to_get = []
+          to_delete = []
+          to_update = []
+          to_union_merge = []
+
+          apply_to_all = Forms::ApplyToAll.new(@ctx, files.size)
+
+          files.each do |file|
+            update_strategy = apply_to_all.value || ask_update_strategy(file)
+            apply_to_all.apply?(update_strategy)
+
+            case update_strategy
+            when :keep_remote
+              if file_exist_remotely?(file)
+                to_get << file
+              else
+                delete_locally(file)
+              end
+            when :keep_local
+              to_update << file
+            when :union_merge
+              if file_exist_remotely?(file)
+                to_union_merge << file
+              else
+                to_update << file
+              end
+            end
+          end
+
+          enqueue_get(to_get)
+          enqueue_deletes(to_delete)
+          enqueue_updates(to_update)
+          enqueue_union_merges(to_union_merge)
+        end
+
+        def file_exist_remotely?(file)
+          !checksums[file.relative_path].nil?
+        end
+
+        def delete_locally(file)
+          ::File.delete(file.absolute_path)
+        end
+
+        def ask_update_strategy(file)
+          Forms::SelectUpdateStrategy.ask(@ctx, [], file: file).strategy
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/merger.rb
+++ b/lib/shopify_cli/theme/syncer/merger.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class Merger
+        class << self
+          ##
+          # Merge `theme_file` with the `new_content` by relying on the union merge
+          #
+          def union_merge(theme_file, new_content)
+            git_merge(theme_file, new_content, ["--union", "-p"])
+          end
+
+          private
+
+          ##
+          # Merge theme file (`ShopifyCLI::Theme::File`) with a new content (String),
+          # by creating a temporary file based on the `new_content`.
+          #
+          def git_merge(theme_file, new_content, opts)
+            remote_file = create_tmp_file(tmp_file_name(theme_file), new_content)
+            empty_file = create_tmp_file("empty")
+
+            ShopifyCLI::Git.merge_file(
+              theme_file.absolute_path,
+              empty_file.path,
+              remote_file.path,
+              opts
+            )
+          ensure
+            # Remove temporary files on Windows as well
+            remote_file.close!
+            empty_file.close!
+          end
+
+          def create_tmp_file(basename, content = "")
+            tmp_file = Tempfile.new(basename)
+            tmp_file.write(content)
+            tmp_file.close # Make it ready to merge
+            tmp_file
+          end
+
+          def tmp_file_name(ref_file)
+            "shopify-cli-merge-#{ref_file.name(".*")}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/syncer/operation.rb
+++ b/lib/shopify_cli/theme/syncer/operation.rb
@@ -35,7 +35,7 @@ module ShopifyCLI
         end
 
         def file_path
-          file&.relative_path.to_s
+          file&.relative_path
         end
 
         private

--- a/lib/shopify_cli/thread_pool.rb
+++ b/lib/shopify_cli/thread_pool.rb
@@ -27,11 +27,23 @@ module ShopifyCLI
     def spawn_thread
       Thread.new do
         catch(:stop_thread) do
-          loop do
-            @jobs.pop.call
-          end
+          loop { perform(@jobs.pop) }
         end
       end
+    end
+
+    def perform(job)
+      job.call
+      reschedule(job) if job.recurring?
+    end
+
+    def reschedule(job)
+      wait(job.interval)
+      schedule(job)
+    end
+
+    def wait(seconds)
+      sleep(seconds)
     end
   end
 end

--- a/lib/shopify_cli/thread_pool/job.rb
+++ b/lib/shopify_cli/thread_pool/job.rb
@@ -3,10 +3,14 @@
 module ShopifyCLI
   class ThreadPool
     class Job
-      attr_reader :error
+      attr_reader :error, :interval
+
+      def initialize(interval = 0)
+        @interval = interval
+      end
 
       def perform!
-        raise "`#{self.class.name}#perform!` must be defined"
+        raise "`#{self.class.name}#perform!' must be defined"
       end
 
       def call
@@ -21,6 +25,10 @@ module ShopifyCLI
 
       def error?
         !!@error
+      end
+
+      def recurring?
+        !interval.zero?
       end
     end
   end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -57,6 +57,15 @@ module Theme
         end
       end
 
+      def test_can_specify_pull_interval
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, pull_interval: 42)
+
+        run_serve_command do |command|
+          command.options.flags[:pull_interval] = 42
+        end
+      end
+
       def test_can_specify_root
         ShopifyCLI::Theme::DevServer.expects(:start)
           .with(@ctx, "dist", host: Theme::Command::Serve::DEFAULT_HTTP_HOST)

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -57,12 +57,12 @@ module Theme
         end
       end
 
-      def test_can_specify_pull_interval
+      def test_can_specify_editor_sync
         ShopifyCLI::Theme::DevServer.expects(:start)
-          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, pull_interval: 42)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, editor_sync: true)
 
         run_serve_command do |command|
-          command.options.flags[:pull_interval] = 42
+          command.options.flags[:editor_sync] = true
         end
       end
 

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -65,6 +65,41 @@ module ShopifyCLI
       end
     end
 
+    def test_merge_file_successfully
+      current_file = "/tmp/current_file"
+      base_file = "/tmp/base_file"
+      other_file = "/tmp/other_file"
+      opts = ["--ours", "-p"]
+      expected_output = "<output>"
+      ctx = mock
+
+      ctx.expects(:abort).never
+      ctx.expects(:capture2e)
+        .with("git", "merge-file", current_file, base_file, other_file, "--ours", "-p")
+        .returns([expected_output, stub(success?: true)])
+
+      actual_output = ShopifyCLI::Git.merge_file(current_file, base_file, other_file, opts, ctx: ctx)
+
+      assert_equal(expected_output, actual_output)
+    end
+
+    def test_merge_file_fails
+      current_file = "/tmp/current_file"
+      base_file = "/tmp/base_file"
+      other_file = "/tmp/other_file"
+      opts = ["--ours", "-p"]
+      expected_output = "<output>"
+      ctx = mock
+
+      ctx.expects(:message).with("core.git.error.merge_failed").returns("merge_failed")
+      ctx.expects(:abort).with("merge_failed")
+      ctx.expects(:capture2e)
+        .with("git", "merge-file", current_file, base_file, other_file, "--ours", "-p")
+        .returns([expected_output, stub(success?: false)])
+
+      ShopifyCLI::Git.merge_file(current_file, base_file, other_file, opts, ctx: ctx)
+    end
+
     def test_init_initializes_successfully
       stub_git_init(status: true, commits: true)
       assert_nil(ShopifyCLI::Git.init(@context))

--- a/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
+++ b/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/dev_server/remote_watcher/json_files_update_job"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class RemoteWatcher
+        class JsonFilesUpdateJobTest < Minitest::Test
+          def setup
+            super
+
+            interval = 2
+            @job = JsonFilesUpdateJob.new(theme, syncer, interval)
+          end
+
+          def test_perform
+            file1 = mock
+            file2 = mock
+            file3 = mock
+            syncer.stubs(pending_updates: [file2])
+            theme.stubs(json_files: [file1, file2, file3])
+
+            syncer.expects(:fetch_checksums!)
+            syncer.expects(:enqueue_get).with([file1, file3])
+
+            @job.perform!
+          end
+
+          def test_recurring
+            assert(@job.recurring?)
+            assert_equal(2, @job.interval)
+          end
+
+          private
+
+          def theme
+            @theme ||= mock
+          end
+
+          def syncer
+            @syncer ||= mock
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
+++ b/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
@@ -19,11 +19,14 @@ module ShopifyCLI
             file1 = mock
             file2 = mock
             file3 = mock
+            file4 = mock
             syncer.stubs(pending_updates: [file2])
-            theme.stubs(json_files: [file1, file2, file3])
+            syncer.stubs(:broken_file?).returns(false)
+            syncer.stubs(:broken_file?).with(file3).returns(true)
+            theme.stubs(json_files: [file1, file2, file3, file4])
 
             syncer.expects(:fetch_checksums!)
-            syncer.expects(:enqueue_get).with([file1, file3])
+            syncer.expects(:enqueue_get).with([file1, file4])
 
             @job.perform!
           end

--- a/test/shopify-cli/theme/dev_server/remote_watcher_test.rb
+++ b/test/shopify-cli/theme/dev_server/remote_watcher_test.rb
@@ -7,11 +7,11 @@ module ShopifyCLI
   module Theme
     module DevServer
       class RemoteWatcherTest < Minitest::Test
-        def test_start_when_it_is_activated
+        def test_start
           thread_pool = mock
           job = mock
 
-          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 1)
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer)
           watcher.stubs(:thread_pool).returns(thread_pool)
           watcher.stubs(:recurring_job).returns(job)
 
@@ -20,35 +20,13 @@ module ShopifyCLI
           watcher.start
         end
 
-        def test_start_when_it_is_not_activated
+        def test_stop
           thread_pool = mock
 
-          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 0)
-          watcher.stubs(:thread_pool).returns(thread_pool)
-
-          thread_pool.expects(:schedule).never
-
-          watcher.start
-        end
-
-        def test_stop_when_it_is_activated
-          thread_pool = mock
-
-          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 1)
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer)
           watcher.stubs(:thread_pool).returns(thread_pool)
 
           thread_pool.expects(:shutdown)
-
-          watcher.stop
-        end
-
-        def test_stop_when_it_is_not_activated
-          thread_pool = mock
-
-          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 0)
-          watcher.stubs(:thread_pool).returns(thread_pool)
-
-          thread_pool.expects(:shutdown).never
 
           watcher.stop
         end

--- a/test/shopify-cli/theme/dev_server/remote_watcher_test.rb
+++ b/test/shopify-cli/theme/dev_server/remote_watcher_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+
+module ShopifyCLI
+  module Theme
+    module DevServer
+      class RemoteWatcherTest < Minitest::Test
+        def test_start_when_it_is_activated
+          thread_pool = mock
+          job = mock
+
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 1)
+          watcher.stubs(:thread_pool).returns(thread_pool)
+          watcher.stubs(:recurring_job).returns(job)
+
+          thread_pool.expects(:schedule).with(job)
+
+          watcher.start
+        end
+
+        def test_start_when_it_is_not_activated
+          thread_pool = mock
+
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 0)
+          watcher.stubs(:thread_pool).returns(thread_pool)
+
+          thread_pool.expects(:schedule).never
+
+          watcher.start
+        end
+
+        def test_stop_when_it_is_activated
+          thread_pool = mock
+
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 1)
+          watcher.stubs(:thread_pool).returns(thread_pool)
+
+          thread_pool.expects(:shutdown)
+
+          watcher.stop
+        end
+
+        def test_stop_when_it_is_not_activated
+          thread_pool = mock
+
+          watcher = RemoteWatcher.to(theme: theme, syncer: syncer, interval: 0)
+          watcher.stubs(:thread_pool).returns(thread_pool)
+
+          thread_pool.expects(:shutdown).never
+
+          watcher.stop
+        end
+
+        private
+
+        def theme
+          @theme ||= mock
+        end
+
+        def syncer
+          @syncer ||= mock
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/file_test.rb
+++ b/test/shopify-cli/theme/file_test.rb
@@ -67,7 +67,48 @@ module ShopifyCLI
         @file.write("content")
       end
 
+      def test_name
+        file = fixture_file("layout/theme.liquid")
+
+        expected_name = "theme.liquid"
+        actual_name = file.name
+
+        assert_equal(expected_name, actual_name)
+      end
+
+      def test_name_with_args
+        file = fixture_file("layout/theme.liquid")
+
+        expected_name = "theme"
+        actual_name = file.name(".*")
+
+        assert_equal(expected_name, actual_name)
+      end
+
+      def test_absolute_path
+        absolute_path = "#{ShopifyCLI::ROOT}/layout/theme.liquid"
+
+        realpath = stub(to_s: absolute_path)
+        path = stub(realpath: realpath)
+        @file.stubs(path: path)
+
+        assert_equal(absolute_path, @file.absolute_path)
+      end
+
+      def test_relative_path
+        file = fixture_file("layout/theme.liquid")
+
+        expected_relative_path = "layout/theme.liquid"
+        actual_relative_path = file.relative_path
+
+        assert_equal(expected_relative_path, actual_relative_path)
+      end
+
       private
+
+      def fixture_file(file_path)
+        File.new("#{ShopifyCLI::ROOT}/#{file_path}", root)
+      end
 
       def path
         @path = mock

--- a/test/shopify-cli/theme/syncer/checksums_test.rb
+++ b/test/shopify-cli/theme/syncer/checksums_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/checksums"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class ChecksumsTest < Minitest::Test
+        def setup
+          super
+          @checksums = Checksums.new(@context)
+          @checksums.stubs(theme: theme)
+          @checksums.stubs(:checksum_by_key).returns({ file.relative_path => "checksum" })
+        end
+
+        def test_has_when_file_is_not_on_checksums
+          @checksums.stubs(:checksum_by_key).returns({})
+
+          refute(@checksums.has?(file))
+        end
+
+        def test_has_when_file_is_on_checksums
+          assert(@checksums.has?(file))
+        end
+
+        def test_file_has_changed_when_its_changed
+          @checksums.stubs(:checksum_by_key).returns({ file.relative_path => "changed" })
+
+          assert(@checksums.file_has_changed?(file))
+        end
+
+        def test_file_has_changed_when_its_not_changed
+          refute(@checksums.file_has_changed?(file))
+        end
+
+        def test_keys
+          @checksums.stubs(:checksum_by_key).returns({ "path1" => "1", "path2" => "2", "path3" => "3" })
+
+          assert_equal(["path1", "path2", "path3"], @checksums.keys.sort)
+        end
+
+        def test_setter_with_mutex
+          @checksums[file.relative_path] = "changed"
+
+          assert_equal("changed", @checksums[file.relative_path])
+        end
+
+        def test_setter_without_mutex
+          @checksums.stubs(:checksums_mutex).returns(stub(synchronize: nil))
+          @checksums[file.relative_path] = "changed"
+
+          assert_equal("checksum", @checksums[file.relative_path])
+        end
+
+        def test_reject_duplicated_checksums
+          @checksums.stubs(:checksum_by_key).returns({
+            "file1.liquid" => "",
+            "file2.liquid" => "",
+            "file1" => "",
+            "file2" => "",
+          })
+
+          @checksums.reject_duplicated_checksums!
+
+          assert_equal(["file1.liquid", "file2.liquid"], @checksums.keys.sort)
+        end
+
+        private
+
+        def file
+          @file ||= stub(
+            relative_path: "layout/theme.liquid",
+            checksum: "checksum"
+          )
+        end
+
+        def theme
+          @theme ||= stub(
+            :[] => file
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/forms/apply_to_all_form_test.rb
+++ b/test/shopify-cli/theme/syncer/forms/apply_to_all_form_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/forms/apply_to_all_form"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class ApplyToAllFormTest < Minitest::Test
+          def test_ask
+            @context
+              .expects(:message)
+              .with("theme.serve.syncer.forms.apply_to_all.title", 4)
+              .returns("title")
+
+            CLI::UI::Prompt
+              .expects(:ask)
+              .with("title", allow_empty: false)
+              .returns(true)
+
+            assert ApplyToAllForm.ask(@context, [], number_of_files: 5)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/forms/apply_to_all_test.rb
+++ b/test/shopify-cli/theme/syncer/forms/apply_to_all_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/forms/apply_to_all"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class ApplyToAllTest < Minitest::Test
+          def test_apply_when_applies
+            number_of_files = 5
+            apply_to_all = ApplyToAll.new(@context, number_of_files)
+
+            ApplyToAllForm.expects(:ask)
+              .with(@context, [], number_of_files: number_of_files)
+              .returns(stub(apply?: true))
+
+            assert(apply_to_all.apply?("value"))
+            assert_equal("value", apply_to_all.value)
+          end
+
+          def test_apply_when_it_does_not_apply
+            number_of_files = 5
+            apply_to_all = ApplyToAll.new(@context, number_of_files)
+
+            ApplyToAllForm.expects(:ask)
+              .with(@context, [], number_of_files: number_of_files)
+              .returns(stub(apply?: false))
+
+            refute(apply_to_all.apply?("value"))
+            assert_nil(apply_to_all.value)
+          end
+
+          def test_apply_when_number_of_files_is_not_greater_than_one
+            number_of_files = 1
+            apply_to_all = ApplyToAll.new(@context, number_of_files)
+
+            ApplyToAllForm.expects(:ask).never
+
+            assert_nil(apply_to_all.apply?("value"))
+            assert_nil(apply_to_all.value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/forms/base_strategy_form_test.rb
+++ b/test/shopify-cli/theme/syncer/forms/base_strategy_form_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/forms/base_strategy_form"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class BaseStrategyFormTest < Minitest::Test
+          def setup
+            super
+            @form = FakeForm.new(@context, [], {})
+          end
+
+          def test_ask
+            file = mock
+
+            @form.expects(:file).returns(file)
+            @form.expects(:title_context).with(file).returns("title_context")
+            @form.expects(:title_question).returns("title_question")
+            @form.expects(:exit_cli).never
+
+            @context.expects(:puts).with("title_context")
+
+            CLI::UI::Prompt
+              .expects(:ask)
+              .with("title_question", allow_empty: false)
+              .returns(:strategy1)
+
+            assert_equal(:strategy1, @form.ask.strategy)
+          end
+
+          def test_ask_when_strategy_is_exit
+            file = mock
+
+            @form.expects(:file).returns(file)
+            @form.expects(:title_context).with(file).returns("title_context")
+            @form.expects(:title_question).returns("title_question")
+            @form.expects(:exit_cli)
+
+            @context.expects(:puts).with("title_context")
+
+            CLI::UI::Prompt
+              .expects(:ask)
+              .with("title_question", allow_empty: false)
+              .returns(:exit)
+
+            @form.ask
+          end
+
+          def test_title_question
+            expected_title = "title"
+
+            @context.expects(:message).with("prefix.title_question").returns(expected_title)
+            actual_title = @form.send(:title_question)
+
+            assert_equal(expected_title, actual_title)
+          end
+
+          def test_title_context
+            file = stub(relative_path: "layout/theme.liquid")
+            expected_title = "title"
+
+            @context.expects(:message).with("prefix.title_context", "layout/theme.liquid").returns(expected_title)
+            actual_title = @form.send(:title_context, file)
+
+            assert_equal(expected_title, actual_title)
+          end
+
+          def test_as_text
+            expected_text = "text"
+
+            @context.expects(:message).with("prefix.strategy1").returns(expected_text)
+            actual_text = @form.send(:as_text, :strategy1)
+
+            assert_equal(expected_text, actual_text)
+          end
+        end
+
+        class FakeForm < BaseStrategyForm
+          attr_reader :file
+
+          def strategies
+            %i[
+              strategy1
+              strategy2
+              strategy3
+            ]
+          end
+
+          def prefix
+            "prefix"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/forms/select_delete_strategy_test.rb
+++ b/test/shopify-cli/theme/syncer/forms/select_delete_strategy_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/forms/select_delete_strategy"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class SelectDeleteStrategyTest < Minitest::Test
+          def setup
+            super
+            @form = SelectDeleteStrategy.new(@context, [], {})
+          end
+
+          def test_strategies
+            refute_empty(@form.strategies)
+          end
+
+          def test_prefix
+            refute_empty(@form.prefix)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/forms/select_update_strategy_test.rb
+++ b/test/shopify-cli/theme/syncer/forms/select_update_strategy_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/forms/select_update_strategy"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      module Forms
+        class SelectUpdateStrategyTest < Minitest::Test
+          def setup
+            super
+            @form = SelectUpdateStrategy.new(@context, [], {})
+          end
+
+          def test_strategies
+            refute_empty(@form.strategies)
+          end
+
+          def test_prefix
+            refute_empty(@form.prefix)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/ignore_helper_test.rb
+++ b/test/shopify-cli/theme/syncer/ignore_helper_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/ignore_helper"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class IgnoreHelperTest < Minitest::Test
+        include IgnoreHelper
+
+        attr_reader :ignore_filter, :include_filter
+
+        def test_ignore_operation_when_it_returns_true
+          path = mock
+          operation = stub(file_path: path)
+
+          expects(:ignore_path?).with(path).returns(true)
+
+          assert(ignore_operation?(operation))
+        end
+
+        def test_ignore_operation_when_it_returns_false
+          path = mock
+          operation = stub(file_path: path)
+
+          expects(:ignore_path?).with(path).returns(false)
+
+          refute(ignore_operation?(operation))
+        end
+
+        def test_ignore_file_when_it_returns_true
+          path = mock
+          file = stub(path: path)
+
+          expects(:ignore_path?).with(path).returns(true)
+
+          assert(ignore_file?(file))
+        end
+
+        def test_ignore_file_when_it_returns_false
+          path = mock
+          file = stub(path: path)
+
+          expects(:ignore_path?).with(path).returns(false)
+
+          refute(ignore_file?(file))
+        end
+
+        def test_ignore_path_when_ignored_by_ignore_filter
+          path = mock
+          @ignore_filter = stub(ignore?: true)
+          @include_filter = stub(match?: true)
+
+          assert(ignore_path?(path))
+        end
+
+        def test_ignore_path_when_ignored_by_ignore_and_include_filter
+          path = mock
+          @ignore_filter = stub(ignore?: true)
+          @include_filter = stub(match?: false)
+
+          assert(ignore_path?(path))
+        end
+
+        def test_ignore_path_when_ignored_by_include_filter
+          path = mock
+          @ignore_filter = stub(ignore?: false)
+          @include_filter = stub(match?: false)
+
+          assert(ignore_path?(path))
+        end
+
+        def test_ignore_path_when_path_is_not_ignored
+          path = mock
+          @ignore_filter = stub(ignore?: false)
+          @include_filter = stub(match?: true)
+
+          refute(ignore_path?(path))
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/json_delete_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_delete_handler_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/json_delete_handler"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class JsonDeleteHandlerTest < Minitest::Test
+        include JsonDeleteHandler
+
+        def setup
+          super
+
+          mock_files
+
+          @ctx = @context
+          @files = [@file1, @file2, @file3]
+          @to_delete = [@file1, @file3]
+        end
+
+        def test_enqueue_json_deletes_when_it_should_overwrite_json_files
+          @overwrite_json = true
+
+          expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_when_it_should_not_overwrite_json_files_and_strategy_is_delete
+          @overwrite_json = false
+          @to_delete.each do |file|
+            Forms::SelectDeleteStrategy
+              .expects(:ask)
+              .with(@ctx, [], file: file)
+              .returns(stub(strategy: :delete))
+          end
+
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_delete.size)
+            .returns(stub(apply?: false, value: nil))
+
+          expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_when_it_should_not_overwrite_json_files_and_strategy_is_restore
+          @overwrite_json = false
+          @to_delete.each do |file|
+            Forms::SelectDeleteStrategy
+              .expects(:ask)
+              .with(@ctx, [], file: file)
+              .returns(stub(strategy: :restore))
+          end
+
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_delete.size)
+            .returns(stub(apply?: false, value: nil))
+
+          expects(:enqueue_get).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_when_it_should_not_overwrite_json_files_and_apply_to_all_is_enabled
+          @overwrite_json = false
+
+          Forms::SelectDeleteStrategy.expects(:ask).never
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_delete.size)
+            .returns(stub(apply?: true, value: :delete))
+
+          expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        private
+
+        def mock_files
+          @file1 = mock
+          @file2 = mock
+          @file3 = mock
+          stubs(:ignore_file?).with(@file1).returns(false)
+          stubs(:ignore_file?).with(@file2).returns(true)
+          stubs(:ignore_file?).with(@file3).returns(false)
+        end
+
+        # Methods required in the host class/module to support the `JsonDeleteHandler`
+
+        def overwrite_json?
+          @overwrite_json
+        end
+
+        def enqueue_deletes(files); end
+        def enqueue_get(files); end
+        def ignore_file?(file); end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/json_update_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_update_handler_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/json_update_handler"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class JsonUpdateHandlerTest < Minitest::Test
+        include JsonUpdateHandler
+
+        def setup
+          super
+
+          mock_files
+
+          @ctx = @context
+          @files = [@file1, @delayed_file1, @file2, @delayed_file2, @file3, @file4, @file5]
+          @to_update = [@file1, @file3, @file5, @delayed_file1, @delayed_file2]
+        end
+
+        def test_enqueue_json_updates_when_it_should_overwrite_json_files
+          @overwrite_json = true
+
+          expects(:enqueue_updates).with(@to_update)
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_it_should_not_overwrite_json_files_and_strategy_is_keep_remote
+          @overwrite_json = false
+          @to_update.each do |file|
+            Forms::SelectUpdateStrategy
+              .expects(:ask)
+              .with(@ctx, [], file: file)
+              .returns(stub(strategy: :keep_remote))
+          end
+
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_update.size)
+            .returns(stub(apply?: false, value: nil))
+
+          expects(:enqueue_get).with([@file3, @file5, @delayed_file1, @delayed_file2])
+          expects(:delete_locally).with(@file1)
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_it_should_not_overwrite_json_files_and_strategy_is_keep_local
+          @overwrite_json = false
+          @to_update.each do |file|
+            Forms::SelectUpdateStrategy
+              .expects(:ask)
+              .with(@ctx, [], file: file)
+              .returns(stub(strategy: :keep_local))
+          end
+
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_update.size)
+            .returns(stub(apply?: false, value: nil))
+
+          expects(:enqueue_updates).with(@to_update)
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_it_should_not_overwrite_json_files_and_strategy_is_union_merge
+          @overwrite_json = false
+          @to_update.each do |file|
+            Forms::SelectUpdateStrategy
+              .expects(:ask)
+              .with(@ctx, [], file: file)
+              .returns(stub(strategy: :union_merge))
+          end
+
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_update.size)
+            .returns(stub(apply?: false, value: nil))
+
+          expects(:enqueue_union_merges).with([@file3, @file5, @delayed_file1, @delayed_file2])
+          expects(:enqueue_updates).with([@file1])
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_it_should_not_overwrite_json_files_and_apply_to_all_is_enabled
+          @overwrite_json = false
+
+          Forms::SelectUpdateStrategy.expects(:ask).never
+          Forms::ApplyToAll
+            .expects(:new)
+            .with(@ctx, @to_update.size)
+            .returns(stub(apply?: true, value: :keep_remote))
+
+          expects(:enqueue_get).with([@file3, @file5, @delayed_file1, @delayed_file2])
+          expects(:delete_locally).with(@file1)
+
+          enqueue_json_updates(@files)
+        end
+
+        private
+
+        def mock_files
+          @file1 = stub(exist?: true, relative_path: "file1")
+          @file2 = stub(exist?: true, relative_path: "file2")
+          @file3 = stub(exist?: true, relative_path: "file3")
+          @file4 = stub(exist?: true, relative_path: "file4")
+          @file5 = stub(exist?: true, relative_path: "file5")
+          @delayed_file1 = stub(exist?: true, relative_path: "delayed_file1")
+          @delayed_file2 = stub(exist?: true, relative_path: "delayed_file2")
+
+          @checksums = mock
+          @theme = {
+            "config/settings_schema.json" => @delayed_file1,
+            "config/settings_data.json" => @delayed_file2,
+          }
+
+          stubs(:ignore_file?).with(@file1).returns(false)
+          stubs(:ignore_file?).with(@file2).returns(true)
+          stubs(:ignore_file?).with(@file3).returns(false)
+          stubs(:ignore_file?).with(@file4).returns(false)
+          stubs(:ignore_file?).with(@file5).returns(false)
+          stubs(:ignore_file?).with(@delayed_file1).returns(false)
+          stubs(:ignore_file?).with(@delayed_file2).returns(false)
+
+          @checksums.stubs(:file_has_changed?).with(@file1).returns(true)
+          @checksums.stubs(:file_has_changed?).with(@file2).returns(true)
+          @checksums.stubs(:file_has_changed?).with(@file3).returns(true)
+          @checksums.stubs(:file_has_changed?).with(@file4).returns(false)
+          @checksums.stubs(:file_has_changed?).with(@file5).returns(true)
+          @checksums.stubs(:file_has_changed?).with(@delayed_file1).returns(true)
+          @checksums.stubs(:file_has_changed?).with(@delayed_file2).returns(true)
+
+          @checksums.stubs(:[]).with("file1").returns(nil)
+          @checksums.stubs(:[]).with("file2").returns("")
+          @checksums.stubs(:[]).with("file3").returns("")
+          @checksums.stubs(:[]).with("file4").returns("")
+          @checksums.stubs(:[]).with("file5").returns("")
+          @checksums.stubs(:[]).with("delayed_file1").returns("")
+          @checksums.stubs(:[]).with("delayed_file2").returns("")
+        end
+
+        # Methods required in the host class/module to support the `JsonUpdateHandler`
+
+        attr_reader :checksums, :theme
+
+        def overwrite_json?
+          @overwrite_json
+        end
+
+        def enqueue_get(files); end
+        def enqueue_updates(files); end
+        def enqueue_deletes(files); end
+        def enqueue_union_merges(files); end
+        def delete_locally(file); end
+        def ignore_file?(file); end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/merger_test.rb
+++ b/test/shopify-cli/theme/syncer/merger_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/syncer/merger"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class MergerTest < Minitest::Test
+        def test_union_merge
+          file = theme_file(<<-CONTENT)
+            {
+              "name":"SHOPIFY CLI",
+              "version":"2",
+              "type":"tool"
+            }
+          CONTENT
+          new_content = <<-CONTENT
+            {
+              "name":"SHOPIFY CLI",
+              "version":"3",
+              "uuid":"0000-1111-2222-3333",
+              "type":"tool"
+            }
+          CONTENT
+          expected_content = <<-CONTENT
+            {
+              "name":"SHOPIFY CLI",
+              "version":"2",
+              "version":"3",
+              "uuid":"0000-1111-2222-3333",
+              "type":"tool"
+            }
+          CONTENT
+          actual_content = Merger.union_merge(file, new_content)
+
+          assert_equal(expected_content, actual_content)
+        ensure
+          file.fs_file.close!
+        end
+
+        private
+
+        def theme_file(content)
+          file = Tempfile.new("theme_file")
+          file.write(content)
+          file.close
+
+          stub(
+            name: "theme_file",
+            absolute_path: file.path,
+            fs_file: file
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -115,6 +115,57 @@ module ShopifyCLI
         @syncer.wait!
       end
 
+      def test_union_merge_file
+        file = @theme["assets/theme.css"]
+
+        ShopifyCLI::AdminAPI
+          .expects(:rest_request)
+          .with(
+            @ctx,
+            api_version: "unstable",
+            method: "GET",
+            shop: @theme.shop,
+            path: "themes/#{@theme.id}/assets.json",
+            query: "asset%5Bkey%5D=assets%2Ftheme.css"
+          )
+          .returns([200, { "asset" => { "value" => "new content" } }, {}])
+
+        Syncer::Merger
+          .expects(:union_merge)
+          .with(file, "new content")
+          .returns("merged content")
+
+        file.expects(:write).with("merged content")
+
+        @syncer.start_threads
+        @syncer.enqueue_union_merges([file])
+        @syncer.wait!
+      end
+
+      def test_union_merge_file_when_file_is_not_a_text
+        file = @theme["assets/logo.png"]
+
+        ShopifyCLI::AdminAPI
+          .expects(:rest_request)
+          .with(
+            @ctx,
+            api_version: "unstable",
+            method: "GET",
+            shop: @theme.shop,
+            path: "themes/#{@theme.id}/assets.json",
+            query: "asset%5Bkey%5D=assets%2Flogo.png"
+          )
+          .returns([200, {}, {}])
+
+        Syncer::Merger.expects(:union_merge).never
+
+        file.expects(:write).never
+
+        @syncer.start_threads
+        @syncer.enqueue_union_merges([file])
+        @syncer.wait!
+      end
+
       def test_upload_when_unmodified
         @syncer.start_threads
         @syncer.checksums["assets/theme.css"] = @theme["assets/theme.css"].checksum
@@ -241,8 +292,9 @@ module ShopifyCLI
 
       def test_download_theme
         @syncer.start_threads
-        @syncer.checksums.replace(@theme.theme_files.map { |file| [file.relative_path.to_s, "OUTDATED"] }.to_h)
-        @syncer.checksums.delete("assets/generated.css.liquid")
+        @theme.theme_files
+          .reject { |file| file.relative_path == "assets/generated.css.liquid" }
+          .each { |file| @syncer.checksums[file.relative_path] = "OUTDATED" }
 
         expected_size = @theme.theme_files.size - 1 # 1 deleted file
 
@@ -273,7 +325,8 @@ module ShopifyCLI
         @syncer.include_filter.expects(:match?).with("layout/theme.liquid").returns(true)
 
         @syncer.start_threads
-        @syncer.checksums.replace(@theme.theme_files.map { |file| [file.relative_path.to_s, "OUTDATED"] }.to_h)
+
+        @theme.theme_files.each { |file| @syncer.checksums[file.relative_path] = "OUTDATED" }
 
         File.any_instance.expects(:write)
           .with("new content")
@@ -301,8 +354,10 @@ module ShopifyCLI
         @syncer.ignore_filter.expects(:ignore?).with(@theme["assets/generated.css.liquid"].path).returns(true)
 
         @syncer.start_threads
-        @syncer.checksums.replace(@theme.theme_files.map { |file| [file.relative_path.to_s, file.checksum] }.to_h)
-        @syncer.checksums.delete("assets/generated.css.liquid")
+
+        @theme.theme_files
+          .reject { |file| file.relative_path == "assets/generated.css.liquid" }
+          .each { |file| @syncer.checksums[file.relative_path] = file.checksum }
 
         File.any_instance.expects(:delete).never
         File.any_instance.expects(:write).never
@@ -317,7 +372,7 @@ module ShopifyCLI
 
       def test_download_theme_without_checksum
         @syncer.start_threads
-        @syncer.checksums.replace(@theme.theme_files.map { |file| [file.relative_path.to_s, nil] }.to_h)
+        @theme.theme_files.each { |file| @syncer.checksums[file.relative_path] = nil }
 
         expected_size = @theme.theme_files.size
 
@@ -363,7 +418,7 @@ module ShopifyCLI
 
         response_assets = expected_files.map do |file|
           {
-            "key" => file.relative_path.to_s,
+            "key" => file.relative_path,
             "checksum" => file.checksum,
           }
         end
@@ -404,6 +459,38 @@ module ShopifyCLI
           .returns([200, {}, {}])
 
         @syncer.upload_theme!
+      end
+
+      def test_upload_theme_deletes_missing_files_when_delete_is_true
+        @syncer.stubs(:overwrite_json?).returns(false)
+        @syncer.stubs(:fetch_checksums!)
+        @syncer.checksums[removed_css_file.relative_path] = "removed non-JSON file"
+        @syncer.checksums[removed_json_file.relative_path] = "removed JSON file"
+
+        @syncer.expects(:enqueue_deletes).with([removed_css_file])
+        @syncer.expects(:enqueue_json_deletes).with([removed_json_file])
+        @syncer.expects(:enqueue_updates).with(@theme.liquid_files)
+        @syncer.expects(:enqueue_updates).with(@theme.static_asset_files)
+        @syncer.expects(:enqueue_json_updates).with(@theme.json_files)
+
+        @syncer.start_threads
+        @syncer.upload_theme!(delete: true)
+      end
+
+      def test_upload_theme_deletes_missing_files_when_delete_is_false
+        @syncer.stubs(:overwrite_json?).returns(false)
+        @syncer.stubs(:fetch_checksums!)
+        @syncer.checksums[removed_css_file.relative_path] = "removed non-JSON file"
+        @syncer.checksums[removed_json_file.relative_path] = "removed JSON file"
+
+        @syncer.expects(:enqueue_deletes).never
+        @syncer.expects(:enqueue_json_deletes).never
+        @syncer.expects(:enqueue_updates).with(@theme.liquid_files)
+        @syncer.expects(:enqueue_updates).with(@theme.static_asset_files)
+        @syncer.expects(:enqueue_json_updates).with(@theme.json_files)
+
+        @syncer.start_threads
+        @syncer.upload_theme!(delete: false)
       end
 
       def test_backoff_near_api_limit
@@ -569,27 +656,14 @@ module ShopifyCLI
         @syncer.unlock_io!
       end
 
-      def test_update_checksums_without_checksums_mutex
-        api_value = { "key" => "key", "checksum" => "checksum" }
-        api_response = stub(values: [api_value])
-        checksums_mutex = stub(synchronize: nil)
+      def test_enqueue_invalid_method
+        file = mock
+        error = assert_raises(ArgumentError) { @syncer.send(:enqueue, :shutdown, file) }
 
-        @syncer.stubs(:checksums_mutex).returns(checksums_mutex)
+        expected_error = "method 'shutdown' cannot be queued"
+        actual_error = error.message
 
-        @syncer.checksums.expects(:[]=).never
-        @syncer.checksums.expects(:reject!).never
-
-        @syncer.send(:update_checksums, api_response)
-      end
-
-      def test_update_checksums_with_checksums_mutex
-        api_value = { "key" => "key", "checksum" => "checksum" }
-        api_response = stub(values: [api_value])
-
-        @syncer.checksums.expects(:[]=).once
-        @syncer.checksums.expects(:reject!).once
-
-        @syncer.send(:update_checksums, api_response)
+        assert_equal(expected_error, actual_error)
       end
 
       private
@@ -617,6 +691,18 @@ module ShopifyCLI
 
       def default_response_body
         JSON.generate(errors: {})
+      end
+
+      def removed_json_file
+        @removed_json_file ||= File.new("templates/removed.json", root)
+      end
+
+      def removed_css_file
+        @removed_css_file ||= File.new("assets/removed.css", root)
+      end
+
+      def root
+        @root ||= Pathname.new(ShopifyCLI::ROOT)
       end
     end
   end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -675,15 +675,17 @@ module ShopifyCLI
       end
 
       def test_broken_file_when_file_is_broken
-        file = stub(relative_path: "templates/index.json")
-        @syncer.stubs(:error_checksums).returns({ "templates/index.json" => nil })
+        file = stub(relative_path: "templates/index.json", checksum: "AAAABBBCCC")
+        @syncer.stubs(:checksums).returns({ "templates/index.json" => "AAAABBBCCC" })
+        @syncer.stubs(:error_checksums).returns(["AAAABBBCCC"])
 
         assert(@syncer.broken_file?(file))
       end
 
       def test_broken_file_when_file_is_not_broken
-        file = stub(relative_path: "templates/index.json")
-        @syncer.stubs(:error_checksums).returns({})
+        file = stub(relative_path: "templates/index.json", checksum: "AAAABBBCCC")
+        @syncer.stubs(:checksums).returns({ "templates/index.json" => "AAAABBBCCC" })
+        @syncer.stubs(:error_checksums).returns([])
 
         refute(@syncer.broken_file?(file))
       end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -137,6 +137,14 @@ module ShopifyCLI
 
         file.expects(:write).with("merged content")
 
+        @syncer.expects(:enqueue).with(:update, file)
+        @syncer.send(:union_merge, file)
+      end
+
+      def test_enqueue_union_merges
+        file = @theme["assets/theme.css"]
+
+        @syncer.expects(:enqueue).with(:union_merge, file)
         @syncer.start_threads
         @syncer.enqueue_union_merges([file])
         @syncer.wait!
@@ -664,6 +672,20 @@ module ShopifyCLI
         actual_error = error.message
 
         assert_equal(expected_error, actual_error)
+      end
+
+      def test_broken_file_when_file_is_broken
+        file = stub(relative_path: "templates/index.json")
+        @syncer.stubs(:error_checksums).returns({ "templates/index.json" => nil })
+
+        assert(@syncer.broken_file?(file))
+      end
+
+      def test_broken_file_when_file_is_not_broken
+        file = stub(relative_path: "templates/index.json")
+        @syncer.stubs(:error_checksums).returns({})
+
+        refute(@syncer.broken_file?(file))
       end
 
       private

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -26,20 +26,20 @@ module ShopifyCLI
       end
 
       def test_static_assets
-        assert_includes(@theme.static_asset_paths, Pathname.new("assets/theme.css"))
+        assert_includes(@theme.static_asset_paths, "assets/theme.css")
       end
 
       def test_theme_files
-        assert_includes(@theme.theme_files.map(&:relative_path), Pathname.new("layout/theme.liquid"))
-        assert_includes(@theme.theme_files.map(&:relative_path), Pathname.new("templates/blog.json"))
-        assert_includes(@theme.theme_files.map(&:relative_path), Pathname.new("locales/en.default.json"))
-        assert_includes(@theme.theme_files.map(&:relative_path), Pathname.new("assets/theme.css"))
-        assert_includes(@theme.theme_files.map(&:relative_path), Pathname.new("assets/theme.js"))
+        assert_includes(@theme.theme_files.map(&:relative_path), "layout/theme.liquid")
+        assert_includes(@theme.theme_files.map(&:relative_path), "templates/blog.json")
+        assert_includes(@theme.theme_files.map(&:relative_path), "locales/en.default.json")
+        assert_includes(@theme.theme_files.map(&:relative_path), "assets/theme.css")
+        assert_includes(@theme.theme_files.map(&:relative_path), "assets/theme.js")
       end
 
       def test_get_file
-        assert_equal(Pathname.new("layout/theme.liquid"), @theme["layout/theme.liquid"].relative_path)
-        assert_equal(Pathname.new("layout/theme.liquid"),
+        assert_equal("layout/theme.liquid", @theme["layout/theme.liquid"].relative_path)
+        assert_equal("layout/theme.liquid",
           @theme[Pathname.new("#{ShopifyCLI::ROOT}/test/fixtures//theme/layout/theme.liquid")].relative_path)
         assert_equal(@theme.theme_files.first, @theme[@theme.theme_files.first])
       end

--- a/test/shopify-cli/thread_pool/job_test.rb
+++ b/test/shopify-cli/thread_pool/job_test.rb
@@ -16,7 +16,7 @@ module ShopifyCLI
       def test_perform_with_an_invalid_job
         job = InvalidJob.new
 
-        expected_error = "`ShopifyCLI::ThreadPool::InvalidJob#perform!` must be defined"
+        expected_error = "`ShopifyCLI::ThreadPool::JobTest::InvalidJob#perform!' must be defined"
         actual_error = assert_raises(RuntimeError) { job.perform! }.message
 
         assert_equal(expected_error, actual_error)
@@ -50,21 +50,35 @@ module ShopifyCLI
         refute error_job.success?
         assert success_job.success?
       end
-    end
 
-    class ValidJob < ShopifyCLI::ThreadPool::Job
-      def perform!
-        true
+      def test_recurring_when_it_returns_true
+        job = ValidJob.new(1)
+
+        assert(job.recurring?)
+        assert_equal(1, job.interval)
       end
-    end
 
-    class InvalidJob < ShopifyCLI::ThreadPool::Job
-      # Without `#perform!` definition
-    end
+      def test_recurring_when_it_returns_false
+        job = ValidJob.new
 
-    class ErrorJob < ShopifyCLI::ThreadPool::Job
-      def perform!
-        raise "error message"
+        refute(job.recurring?)
+        assert_equal(0, job.interval)
+      end
+
+      class ValidJob < ShopifyCLI::ThreadPool::Job
+        def perform!
+          true
+        end
+      end
+
+      class InvalidJob < ShopifyCLI::ThreadPool::Job
+        # Without `#perform!` definition
+      end
+
+      class ErrorJob < ShopifyCLI::ThreadPool::Job
+        def perform!
+          raise "error message"
+        end
       end
     end
   end

--- a/test/shopify-cli/thread_pool_test.rb
+++ b/test/shopify-cli/thread_pool_test.rb
@@ -2,6 +2,7 @@
 
 require "test_helper"
 require "shopify_cli/thread_pool"
+require "shopify_cli/thread_pool/job"
 
 module ShopifyCLI
   class ThreadPoolTest < MiniTest::Test
@@ -16,14 +17,67 @@ module ShopifyCLI
       thread_pool = ShopifyCLI::ThreadPool.new
 
       number_of_executions.times do |i|
-        thread_pool.schedule(-> do
+        job = RegularJob.new do
           mutex.synchronize { actual[i] = i }
-        end)
+        end
+
+        thread_pool.schedule(job)
       end
 
       thread_pool.shutdown
 
       assert_equal(expected, actual)
+    end
+
+    def test_schedule_with_a_recurring_job
+      mutex = Mutex.new
+      actual_executions = 0
+      expected_executions = 3
+      thread_pool = ShopifyCLI::ThreadPool.new
+      thread_pool.stubs(:wait).returns(nil)
+
+      job = RecurringJob.new do
+        mutex.synchronize { actual_executions += 1 }
+      end
+
+      job.stubs(:recurring?).returns(true, true, false)
+
+      thread_pool.schedule(job)
+
+      with_retries(Minitest::Assertion) { assert_equal(expected_executions, actual_executions) }
+    ensure
+      thread_pool.shutdown
+    end
+
+    private
+
+    def with_retries(*exceptions, retries: 5)
+      yield
+    rescue *exceptions
+      retries -= 1
+      if retries > 0
+        sleep(0.1)
+        retry
+      else
+        raise
+      end
+    end
+
+    class RegularJob < ShopifyCLI::ThreadPool::Job
+      def initialize(interval = 0, &block)
+        super(interval)
+        @perform = block
+      end
+
+      def perform!
+        @perform.call
+      end
+    end
+
+    class RecurringJob < RegularJob
+      def initialize(&block)
+        super(0.1, &block)
+      end
     end
   end
 end


### PR DESCRIPTION
⚠️ I've [split this PR into meaningful commits](https://user-images.githubusercontent.com/1079279/159683112-e01c679d-649d-402f-b9c3-aa1039e24696.png) to make the review process a bit easier (check it with `git log -12`). They do not reflect the order of implementation but a more logical path to follow.

### WHY are these changes introduced?

Currently, when developers run `theme serve`, the CLI replaces the remote development theme with the local version.

Many developers expect that (1-way sync) behavior and already have tooling/workflows relying on that.

However, other developers prefer to rely on a 2-way sync logic. In other words: when something changes in the Theme Editor, the CLI (`theme serve`) should auto get the remote updated version; and when something changes in the local files, the CLI should auto pushes the updated version.

Thus, this PR adds an optional 2-way sync capabilities between the CLI (`theme serve`) and the Theme Editor with the new `--theme-editor-sync` flag.

<img width="1503" alt="image" src="https://user-images.githubusercontent.com/1079279/159980150-2c6d9e60-8bbb-49b8-a7df-85b888738c41.png">


### WHAT is this pull request doing?

This PR approaches the 2-way sync with 3 pillars:

- **1. The `theme serve` startup**
 
  When developers run  `theme serve` with the `--theme-editor-sync` flag, the CLI checks (before pushing the local files to the development theme) if there are changes on remote `.json` files.

  If so, the CLI prompts users to check which version they prefer to keep, or even if they want a merged version of files (ref: `JsonUpdateHandler` and `JsonDeleteHandler`).

- **2. The `theme serve` pulling mechanism**
 
  When developers run  `theme serve` with the `--theme-editor-sync` flag, the CLI adopts will an approach similar to [--pull-json-interval](https://github.com/Shopify/shopify-cli/pull/1708) to pull `.json` files (ref: `RemoteWatcher`).
 
- **3. the Theme Editor conflicts mechanism**

  The CLI already automatically uploads the updated `.json` file when partners locally change them, and the Theme Editor already has a mechanism to avoid conflicts. Thus, no changes will be performed on this side.

#### Goals and non-goals

This PR introduces the `--theme-editor-sync` flag to help developers (that expect 2-way sync features) on avoiding scenarios where they lose their data/work (e.g., when re-run `theme serve` after working in the Theme Editor).

It focuses on performing checks/helpful-actions during the start-up and auto-pulling files when the theme serve  is running.

This PR doesn't aim to introduce consensus ordering between the CLI and the Theme Editor, mutation history, and ensure conflict-free features in the `Syncer`.

### How to test your changes?

**Sync test case**
- Run `shopify theme serve --theme-editor-sync`
- Open the Theme Editor
- Change something
- Notice the change is synced 
 
![with_sync_no_message_and_sync_demo](https://user-images.githubusercontent.com/1079279/159701770-3a18ff9d-7be1-4616-b16a-ccb1709c9377.gif)

**Startup case**
- Open the Theme Editor
- Change something
- Run `shopify theme serve --theme-editor-sync`
- Notice the CLI asks which version it should keep
 
![modified_version_remotely](https://user-images.githubusercontent.com/1079279/159702024-f64608d0-4551-424e-833e-4ef0fd6b9636.gif)


#### Other test cases:


<details>
<summary>
<b>
Many updated files localy test case
</b>
</summary>

- With local theme with many modified files
- Run  `shopify theme serve --theme-editor-sync`
- Notice the CLI asks about how to proceed
- Select "Keep the local version" 
- Notice the CLI uploads the JSON files
![apply_all](https://user-images.githubusercontent.com/1079279/159699617-d52a0be7-66f4-444a-bcdc-b09476329af6.gif)
- Also, try the "Keep the remote version"  (notice the CLI will download the JSON files)
- Finally, try the "Merge files"  (notice the CLI will union merge the local and remote the JSON files)

</details>


<!-- ===================================================== -->

<details>
<summary>
<b>
Files removed locally (restore test case)
</b>
</summary>

- Remove a JSON file from your local theme
- Run `shopify theme serve --theme-editor-sync`
- Notice the CLI asks before removing the file from your remote development theme
- Recover your JSON file
- Notice the is recovered
![startup_recover_local_delete](https://user-images.githubusercontent.com/1079279/159703832-968a2ea0-d0c5-4e23-94bc-bb39b610903b.gif)

</details>

<!-- ===================================================== -->


<details>
<summary>
<b>
Files removed locally (delete test case)
</b>
</summary>

- Run `shopify theme serve --theme-editor-sync`
- Change `templates/index.json` locally
- Change `templates/index.json` in the Theme Editor
- Notice that users may solve the conflict at the editor
- Delete your JSON file
- Notice the is removed remotely
![remove_forever](https://user-images.githubusercontent.com/1079279/159703862-ee4c6374-710d-430b-aa83-3c490d4ee428.gif)

 
</details>

<!-- ===================================================== -->

<details>
<summary>
<b>
<code>theme serve</code> without the <code>--theme-editor-sync</code> flag test case
</b>
</summary>

- Run `shopify theme serve` with modified files locally
- Notice the CLI doesn't ask about conflicts
- Notice that now the Theme Editor message is
  `Customize this theme in the Theme Editor, and use 'theme pull' to get the changes`
- Notice the pulling mechanism is not activated
  ![regular_diff_message](https://user-images.githubusercontent.com/1079279/159700207-169c8f54-14a0-45fe-987c-7ab948f0bc45.gif)
  ![dontask_apply_to_all](https://user-images.githubusercontent.com/1079279/159700084-304d8afd-e0d3-4d72-a3c4-6dd9fa33708a.gif)
</details>


### Post-release steps

Include the `--theme-editor-sync` in the [`theme serve`documentation](https://shopify.dev/themes/tools/cli/theme-commands#serve).

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).