### PR TITLE
[Feature] Handle invalid input query error

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -180,6 +180,23 @@ module Script
             @max_size = max_size
           end
         end
+
+        class InvalidInputQueryErrors < ScriptProjectError
+          attr_reader :messages
+
+          def initialize(messages)
+            @messages = messages
+            super()
+          end
+
+          def input_query_path
+            ScriptProjectRepository::INPUT_QUERY_PATH
+          end
+
+          def message
+            messages.join("\n")
+          end
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -83,6 +83,8 @@ module Script
               valid_types: e["message"],
               filename: script_config.filename,
             )
+          elsif (errors = user_errors.filter { |err| err["tag"] == "input_query_validation_error" }).any?
+            raise Errors::InvalidInputQueryErrors, errors.map { |err| err["message"] }
           elsif user_errors.find { |err| %w(not_use_msgpack_error schema_version_argument_error).include?(err["tag"]) }
             raise Domain::Errors::MetadataValidationError
           else

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -86,6 +86,9 @@ module Script
                                                      "type(s): %{valid_types}.",
           configuration_schema_field_invalid_value_error_help: "Change the value of the type.",
 
+          input_query_error_cause: "Input query is invalid:\n%{messages}\n\n",
+          input_query_error_help: "Fix the query in the `%{input_query_path}` file.",
+
           script_not_found_cause: "Can't find script %s for Script API %s",
 
           system_call_failure_cause: "Something went wrong while running: {{command:%{cmd}}}.",

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -216,6 +216,17 @@ module Script
               "script.error.configuration_schema_field_invalid_value_error_help"
             ),
           }
+        when Layers::Infrastructure::Errors::InvalidInputQueryErrors
+          {
+            cause_of_error: ShopifyCLI::Context.message(
+              "script.error.input_query_error_cause",
+              messages: e.messages.map { |message| "  {{x}} #{message}." }.join("\n"),
+            ),
+            help_suggestion: ShopifyCLI::Context.message(
+              "script.error.input_query_error_help",
+              input_query_path: e.input_query_path,
+            ),
+          }
         when Layers::Infrastructure::Errors::DependencyInstallError
           {
             cause_of_error: ShopifyCLI::Context.message("script.error.dependency_install_cause"),

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -292,6 +292,23 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
       end
 
+      describe "when input query is invalid" do
+        let(:response) do
+          {
+            "data" => {
+              "appScriptSet" => {
+                "userErrors" => [{ "message" => "error", "tag" => "input_query_validation_error" }],
+              },
+            },
+          }
+        end
+
+        it "raises InvalidInputQueryError" do
+          error = assert_raises(Script::Layers::Infrastructure::Errors::InvalidInputQueryErrors) { subject }
+          assert_equal(["error"], error.messages)
+        end
+      end
+
       describe "when response is empty" do
         let(:response) { nil }
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -323,6 +323,15 @@ describe Script::UI::ErrorHandler do
         end
       end
 
+      describe "when InvalidInputQueryError" do
+        let(:err) do
+          Script::Layers::Infrastructure::Errors::InvalidInputQueryErrors.new(["some msg"])
+        end
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
+
       describe "when DependencyInstallError" do
         let(:err) { Script::Layers::Infrastructure::Errors::DependencyInstallError.new }
         it "should call display_and_raise" do


### PR DESCRIPTION
### WHY are these changes introduced?

We now validate the input query in script-service. When the query is
invalid, a user error tagged `input_query_validation_error` is
returned. With this commit, we'll display this error as such:

```
Couldn't push script to app. Input query is invalid:
  ✗ Field 'doesntexit' doesn't exist on type 'PurchaseProposal' at 'query.purchaseProposal.doesntexit'.

Fix the query in the `input.graphql` file.
```

### How to test your changes?

See instructions in Shopify/script-service#4532

### Update checklist

-  ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
   This feature is still in stealth mode, so no changelog.

------

#gsd:23093