### PR TITLE
Remove `TODO` as now CI features are supported by custom apps

### DIFF
--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -20,9 +20,12 @@ module Theme
       end
 
       def call(_args, name)
+        valid_authentication_method!
+
         root = root_value(options, name)
         flags = options.flags.dup
         host = flags[:host] || DEFAULT_HTTP_HOST
+
         ShopifyCLI::Theme::DevServer.start(@ctx, root, host: host, **flags) do |syncer|
           UI::SyncProgressBar.new(syncer).progress(:upload_theme!, delay_low_priority_files: true)
         end
@@ -37,6 +40,30 @@ module Theme
 
       def self.help
         ShopifyCLI::Context.message("theme.serve.help", ShopifyCLI::TOOL_NAME)
+      end
+
+      private
+
+      def valid_authentication_method!
+        if exchange_token && !storefront_renderer_token
+          ShopifyCLI::Context.abort(error_message, help_message)
+        end
+      end
+
+      def error_message
+        ShopifyCLI::Context.message("theme.serve.auth.error_message", ShopifyCLI::TOOL_NAME)
+      end
+
+      def help_message
+        ShopifyCLI::Context.message("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME)
+      end
+
+      def exchange_token
+        ShopifyCLI::DB.get(:shopify_exchange_token)
+      end
+
+      def storefront_renderer_token
+        ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token)
       end
     end
   end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -55,7 +55,7 @@ module Theme
       end
 
       def help_message
-        ShopifyCLI::Context.message("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME)
+        ShopifyCLI::Context.message("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
       end
 
       def exchange_token

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -121,6 +121,14 @@ module Theme
           viewing_theme: "Viewing theme…",
           syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
+          auth: {
+            error_message: "You're not authenticated for using the {{command:%s theme serve}}.",
+            help_message: <<~HELP_MESSAGE,
+              Please try to logout and login with the {{command:%s login --store STORE}} command.
+
+              Tip: Unset the {{command:SHOPIFY_SHOP}} and {{command:SHOPIFY_PASSWORD}} environment variables before trying to re-login.
+            HELP_MESSAGE
+          },
           operation: {
             status: {
               error: "ERROR",

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -122,9 +122,11 @@ module Theme
           syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
           auth: {
-            error_message: "You're not authenticated for using {{command:%s theme serve}}.",
+            error_message: <<~ERROR_MESSAGE,
+              It looks like you are using credentials that do not work with {{command:%s theme serve}}.
+            ERROR_MESSAGE
             help_message: <<~HELP_MESSAGE,
-              Please try to logout and login with the {{command:%s login --password "" --store STORE}} command.
+              Run {{command:%s logout}} and {{command:%s login --password "" --store STORE}} to force the authentication thought your browser.
             HELP_MESSAGE
           },
           operation: {

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -124,9 +124,7 @@ module Theme
           auth: {
             error_message: "You're not authenticated for using {{command:%s theme serve}}.",
             help_message: <<~HELP_MESSAGE,
-              Please try to logout and login with the {{command:%s login --store STORE}} command.
-
-              Tip: Unset the {{command:SHOPIFY_SHOP}} and {{command:SHOPIFY_PASSWORD}} environment variables before trying to re-login.
+              Please try to logout and login with the {{command:%s login --password "" --store STORE}} command.
             HELP_MESSAGE
           },
           operation: {

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -122,7 +122,7 @@ module Theme
           syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
           auth: {
-            error_message: "You're not authenticated for using the {{command:%s theme serve}}.",
+            error_message: "You're not authenticated for using {{command:%s theme serve}}.",
             help_message: <<~HELP_MESSAGE,
               Please try to logout and login with the {{command:%s login --store STORE}} command.
 

--- a/lib/shopify_cli/admin_api.rb
+++ b/lib/shopify_cli/admin_api.rb
@@ -156,7 +156,7 @@ module ShopifyCLI
     def auth_headers(token)
       {
         Authorization: "Bearer #{token}",
-        "X-Shopify-Access-Token" => token, # TODO: Remove when we no longer need private apps
+        "X-Shopify-Access-Token" => token,
       }
     end
   end

--- a/lib/shopify_cli/commands/login.rb
+++ b/lib/shopify_cli/commands/login.rb
@@ -26,8 +26,7 @@ module ShopifyCLI
           end
         end
 
-        # As password auth will soon be deprecated, we enable only in CI
-        if @ctx.ci? && (password = options.flags[:password] || @ctx.getenv("SHOPIFY_PASSWORD"))
+        if (password = options.flags[:password] || @ctx.getenv("SHOPIFY_PASSWORD"))
           ShopifyCLI::DB.set(shopify_exchange_token: password)
         else
           IdentityAuth.new(ctx: @ctx).authenticate(spinner: true)

--- a/lib/shopify_cli/commands/login.rb
+++ b/lib/shopify_cli/commands/login.rb
@@ -26,7 +26,8 @@ module ShopifyCLI
           end
         end
 
-        if (password = options.flags[:password] || @ctx.getenv("SHOPIFY_PASSWORD"))
+        password = options.flags[:password] || @ctx.getenv("SHOPIFY_PASSWORD")
+        if !password.nil? && !password.empty?
           ShopifyCLI::DB.set(shopify_exchange_token: password)
         else
           IdentityAuth.new(ctx: @ctx).authenticate(spinner: true)

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -73,11 +73,62 @@ module Theme
         run_serve_command(["dist"])
       end
 
+      def test_valid_authentication_method_when_storefront_renderer_token_and_password_are_present
+        ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
+        ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("SFR token")
+
+        ShopifyCLI::Context.expects(:abort).never
+
+        command = Theme::Command::Serve.new(@ctx)
+        command.send(:valid_authentication_method!)
+      end
+
+      def test_valid_authentication_method_when_storefront_renderer_token_is_present_and_password_is_not_present
+        ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns(nil)
+        ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("SFR token")
+
+        ShopifyCLI::Context.expects(:abort).never
+
+        command = Theme::Command::Serve.new(@ctx)
+        command.send(:valid_authentication_method!)
+      end
+
+      def test_valid_authentication_method_when_storefront_renderer_token_is_not_present_and_password_is_present
+        error_message = "error message"
+        help_message = "help message"
+
+        ShopifyCLI::Context.stubs(:message)
+          .with("theme.serve.auth.error_message", ShopifyCLI::TOOL_NAME)
+          .returns(error_message)
+        ShopifyCLI::Context.stubs(:message)
+          .with("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME)
+          .returns(help_message)
+
+        ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
+        ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)
+
+        ShopifyCLI::Context.expects(:abort).with(error_message, help_message)
+
+        command = Theme::Command::Serve.new(@ctx)
+        command.send(:valid_authentication_method!)
+      end
+
+      def test_valid_authentication_method_when_storefront_renderer_token_and_password_are_not_present
+        ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns(nil)
+        ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)
+
+        ShopifyCLI::Context.expects(:abort).never
+
+        command = Theme::Command::Serve.new(@ctx)
+        command.send(:valid_authentication_method!)
+      end
+
       private
 
       def run_serve_command(argv = [])
         command = Theme::Command::Serve.new(@ctx)
 
+        stubs_auth(command)
         stubs_parser(command, argv)
         yield(command) if block_given?
 
@@ -88,6 +139,10 @@ module Theme
         argv = ["shopify", "theme", "serve"] + argv
         parser = command.options.parser
         parser.stubs(:default_argv).returns(argv)
+      end
+
+      def stubs_auth(command)
+        command.stubs(:valid_authentication_method!)
       end
     end
   end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -101,7 +101,7 @@ module Theme
           .with("theme.serve.auth.error_message", ShopifyCLI::TOOL_NAME)
           .returns(error_message)
         ShopifyCLI::Context.stubs(:message)
-          .with("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME)
+          .with("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
           .returns(help_message)
 
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")

--- a/test/shopify-cli/commands/login_test.rb
+++ b/test/shopify-cli/commands/login_test.rb
@@ -85,6 +85,21 @@ module ShopifyCLI
         run_cmd("login --store=testshop.myshopify.io")
       end
 
+      def test_call_login_with_empty_password
+        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
+        ShopifyCLI::Shopifolk.stubs(:check).returns(true)
+        CLI::UI::Prompt.expects(:confirm).never
+        ShopifyCLI::DB.expects(:set).with(acting_as_shopify_organization: true).never
+
+        auth = mock
+        auth.expects(:authenticate)
+        IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
+        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
+        Whoami.expects(:call).with([], "whoami")
+
+        run_cmd("login --store=testshop.myshopify.io --password=")
+      end
+
       def test_call_login_with_shop_flag_doesnt_ask_acting_as_shopify
         ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io").once.returns("testshop.myshopify.io")
         ShopifyCLI::Shopifolk.stubs(:check).returns(true)

--- a/test/shopify-cli/commands/login_test.rb
+++ b/test/shopify-cli/commands/login_test.rb
@@ -107,8 +107,6 @@ module ShopifyCLI
         ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
 
-        @context.expects(:ci?).returns(true)
-
         run_cmd("login --store=testshop.myshopify.io --password=muffin")
       end
 
@@ -119,26 +117,7 @@ module ShopifyCLI
         ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
 
-        @context.expects(:ci?).returns(true)
-
         run_cmd("login --shop=testshop.myshopify.io --password=muffin")
-      end
-
-      def test_cant_call_login_with_password_flag_not_on_ci
-        CLI::UI::Prompt.expects(:confirm).never
-        ShopifyCLI::DB.expects(:get).with(:acting_as_shopify_organization).never
-        ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
-        ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin").never
-
-        auth = mock
-        auth.expects(:authenticate)
-        IdentityAuth.expects(:new).with(ctx: @context).returns(auth)
-        ShopifyCLI::DB.expects(:set).with(organization_id: @stub_org["id"].to_i).once
-        Whoami.expects(:call).with([], "whoami")
-
-        @context.expects(:ci?).returns(false)
-
-        run_cmd("login --store=testshop.myshopify.io --password=muffin")
       end
 
       def test_call_login_with_shop_and_password_env_vars
@@ -147,8 +126,6 @@ module ShopifyCLI
         ShopifyCLI::DB.expects(:set).with(shop: "testshop.myshopify.io")
         ShopifyCLI::DB.expects(:set).with(shopify_exchange_token: "muffin")
         IdentityAuth.expects(:new).never
-
-        @context.expects(:ci?).returns(true)
 
         @context.expects(:getenv).with("SHOPIFY_SHOP").returns("testshop.myshopify.io")
         @context.expects(:getenv).with("SHOPIFY_PASSWORD").returns("muffin")


### PR DESCRIPTION
### WHY are these changes introduced?

We no longer need to remove this line, as the developers may rely on custom apps **Admin API access token** as the `SHOPIFY_PASSWORD`.

### WHAT is this pull request doing?

This PR removes the `TODO` comment related to private apps and changes the password-based authentication to no longer require the `CI` flag.

### How to test your changes?

- Create a custom app at your store
- Add proper permissions
- Create an **Admin API access token** at the API credentials section
- Copy the **Admin API access token** value
- Open a terminal window
- Run `shopify-dev logout`
- Run `export CI=1`
- Run `export SHOPIFY_SHOP=<your store>`
- Run `export SHOPIFY_PASSWORD=<Admin API access token value>`
- Run `shopify-dev login`
- Run `shopify-dev theme pull -t <existing Theme ID or name>` 
- Notice the Theme will be downloaded

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).