### PR TITLE
Improve error message when suspended users run `theme serve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2121](https://github.com/Shopify/shopify-cli/pull/2121): Fix the hot-reload to work when the section name is not equal to the type
+* [#2183](https://github.com/Shopify/shopify-cli/pull/2183): Improve error message when suspended users run `theme serve`
 
 ## Version 2.15.1
 

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -8,8 +8,9 @@ module Theme
             Usage: {{command:%1$s theme [ %2$s ]}}
         HELP
         ensure_user_error: "You are not authorized to edit themes on %s.",
-        ensure_user_try_this: "Make sure you are a user of that store, and allowed to edit themes.",
-
+        ensure_user_try_this: <<~ENSURE_USER,
+          Check if your user is activated, has permission to edit themes at the store, and try to re-login.
+        ENSURE_USER
         init: {
           help: <<~HELP,
             {{command:%s theme init}}: Clones a Git repository to use as a starting point for building a new theme.
@@ -181,7 +182,7 @@ module Theme
           CUSTOMIZE_OR_PREVIEW
           ensure_user: <<~ENSURE_USER,
             You are not authorized to edit themes on %s.
-            Make sure you are a user of that store, and allowed to edit themes.
+            Check if your user is activated, has permission to edit themes at the store, and try to re-login.
           ENSURE_USER
           address_already_in_use: "The address \"%s\" is already in use.",
           try_port_option: "Use the --port=PORT option to serve the theme in a different port.",

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -92,7 +92,8 @@ module ShopifyCLI
 
         rescue ShopifyCLI::API::APIRequestForbiddenError,
                ShopifyCLI::API::APIRequestUnauthorizedError
-          raise ShopifyCLI::Abort, @ctx.message("theme.serve.ensure_user", theme.shop)
+          shop = ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
+          raise ShopifyCLI::Abort, @ctx.message("theme.serve.ensure_user", shop)
         rescue Errno::EADDRINUSE
           error_message = @ctx.message("theme.serve.address_already_in_use", address)
           help_message = @ctx.message("theme.serve.try_port_option")

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -41,31 +41,46 @@ module ShopifyCLI
         )
       rescue ShopifyCLI::API::APIRequestForbiddenError,
              ShopifyCLI::API::APIRequestUnauthorizedError => error
+
+        ##
         # The Admin API returns 403 Forbidden responses on different
         # scenarios:
         #
         # * when a user doesn't have permissions for a request:
-        #   <APIRequestForbiddenError: 403 {}>
+        #   - <APIRequestForbiddenError: 403 {}>
+        #   - <APIRequestForbiddenError: 403 {"errors":"Unauthorized Access"}>
         #
         # * when an asset operation cannot be performed:
-        #   <APIRequestForbiddenError: 403 {"message":"templates/gift_card.liquid could not be deleted"}>
-        if empty_response_error?(error)
-          return handle_permissions_error
+        #   - <APIRequestForbiddenError: 403 {"message":"templates/gift_card.liquid could not be deleted"}>
+        #
+        if empty_response?(error) || unauthorized_response?(error)
+          return permission_error
         end
 
         raise error
       end
 
-      def handle_permissions_error
+      def permission_error
         ensure_user_error = @ctx.message("theme.ensure_user_error", shop)
         ensure_user_try_this = @ctx.message("theme.ensure_user_try_this")
 
         @ctx.abort(ensure_user_error, ensure_user_try_this)
       end
 
-      def empty_response_error?(error)
-        error_message = error&.response&.body.to_s
-        error_message.empty?
+      def empty_response?(error)
+        response_body(error).empty?
+      end
+
+      def unauthorized_response?(error)
+        parsed_body = JSON.parse(response_body(error))
+        errors = parsed_body["errors"].to_s
+        errors.match?(/Unauthorized Access/)
+      rescue JSON::ParserError
+        false
+      end
+
+      def response_body(error)
+        error&.response&.body.to_s
       end
     end
   end

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -160,6 +160,23 @@ module ShopifyCLI
           socket.close
         end
 
+        def test_forbidden_error
+          start_server_and_wait_sync_files
+          error_message = "error message"
+          shop = "dev-theme-server-store.myshopify.com"
+
+          ShopifyCLI::Theme::DevelopmentTheme.stubs(:find_or_create!).raises(ShopifyCLI::API::APIRequestForbiddenError)
+
+          @ctx.stubs(:message).with("theme.serve.ensure_user", shop).returns(error_message)
+          @ctx.output_captured = true
+          io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
+          end
+          @ctx.output_captured = false
+
+          assert_message_output(io: io, expected_content: [error_message])
+        end
+
         private
 
         def start_server


### PR DESCRIPTION
### WHY are these changes introduced?

When developers run `theme serve` with a suspended account, they face an unfriendly error message. Generated by this error:
```
shopify_cli/api.rb:74:in `block in request': 403 (ShopifyCLI::API::APIRequestForbiddenError)
{"errors":"Unauthorized Access"}
```

### WHAT is this pull request doing?

This PR improves the `Theme::ThemeAdminAPI` class to handle unauthorized errors. Also, as some requests do not rely on `ThemeAdminAPI`, it also updates `Theme::DevServer`.

### How to test your changes?

- Suspend an user from your store
- Run `shopify theme serve`
- Notice that now the CLI shows a friendly message 

Before this PR: 
![before](https://user-images.githubusercontent.com/1079279/160368186-a5af9112-77b4-444b-ad63-4d9058af5fa3.gif)

After this PR: 
![after](https://user-images.githubusercontent.com/1079279/160368244-88c73621-5b4d-4f23-a3f5-3d45fa806a44.gif)

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).