### PR TITLE
Fix missing Pathname method when using shopify-cli-extensions

### DIFF
--- a/lib/project_types/extension/tasks/merge_server_config.rb
+++ b/lib/project_types/extension/tasks/merge_server_config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "shopify_cli"
 require "yaml"
+require "pathname"
 
 module Extension
   module Tasks


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

While developing [this PR](https://github.com/Shopify/shopify-cli-extensions/pull/237) we got an error that `Pathname` was not defined: https://github.com/Shopify/shopify-cli/blob/0b7e892868885edd05ee589db3e63a350dc65994/lib/project_types/extension/tasks/merge_server_config.rb#L12

To reproduce, see _Complete tophatting instructions_ in the PR description.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

It requires `pathname` which fixes the issue
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

There might be an easier way but [this PR](https://github.com/Shopify/shopify-cli-extensions/pull/237) has complete tophatting instructions.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).