### PR TITLE
Fix app serve after rails update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
+* [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update
 
 ## Version 2.15.2
 

--- a/lib/shopify_cli/services/app/create/rails_service.rb
+++ b/lib/shopify_cli/services/app/create/rails_service.rb
@@ -109,7 +109,9 @@ module ShopifyCLI
 
           def check_ruby
             ruby_version = Environment.ruby_version(context: context)
-            return if ruby_version.satisfies?("~>2.5") || ruby_version.satisfies?("~>3.1.0")
+            return if ruby_version.satisfies?("~>2.5") ||
+              ruby_version.satisfies?("~>3.0.0") ||
+              ruby_version.satisfies?("~>3.1.0")
             context.abort(context.message("core.app.create.rails.error.invalid_ruby_version"))
           end
 

--- a/lib/shopify_cli/services/app/serve/rails_service.rb
+++ b/lib/shopify_cli/services/app/serve/rails_service.rb
@@ -30,10 +30,13 @@ module ShopifyCLI
             end
 
             CLI::UI::Frame.open(context.message("core.app.serve.running_server")) do
-              env = ShopifyCLI::Project.current.env.to_h
+              original_env = JSON.parse(ENV["ORIGINAL_ENV"] || "{}")
+              env = original_env.merge(ShopifyCLI::Project.current.env.to_h)
               env.delete("HOST")
               env["PORT"] = port.to_s
-              env["GEM_PATH"] = Rails::Gem.gem_path(context)
+              env["GEM_PATH"] =
+                [env["GEM_PATH"], Rails::Gem.gem_path(context)].compact
+                  .join(CLI::UI::OS.current.path_separator)
               if context.windows?
                 context.system("ruby bin\\rails server", env: env)
               else

--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -98,6 +98,7 @@ class ShopifyCli < Formula
     (bin + file.basename).open("w") do |f|
       f << <<~RUBY
         #!#{ruby_bin}/ruby --disable-gems
+        ENV['ORIGINAL_ENV']=ENV.to_h.to_json
         ENV['GEM_HOME']="#{prefix}"
         ENV['GEM_PATH']="#{prefix}"
         ENV['RUBY_BINDIR']="#{ruby_bin}/"

--- a/vendor/deps/cli-ui/lib/cli/ui/os.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/os.rb
@@ -35,6 +35,10 @@ module CLI
           def shift_cursor_on_line_reset?
             false
           end
+
+          def path_separator
+            ":"
+          end
         end
       end
 
@@ -57,6 +61,10 @@ module CLI
 
           def shift_cursor_on_line_reset?
             true
+          end
+
+          def path_separator
+            ";"
           end
         end
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

For whatever reason, it seems that the wrong Rails is found if the versions of Rails in the homebrew-installed CLI vs. your app have gotten out of sync, at least in certain environments.

Part of the issue seems to be that the gem path isn't passed through, and instead ends up pointing to the homebrew-installed gem path, but that won't be the same as the gems you've `bundle install`ed in your Rails app, so your app thinks it's missing dependencies!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
After debugging with @pepicrft and @isaacroldan, it seems that we need to pass through the original environment when running the `bin/rails` executable; something in there is necessary for gems to load properly. And anyway, it makes sense to keep the environment consistent with what the user actually has set.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
I'm honestly not sure. Locally, I can serve from my local copy of the CLI repo even without these changes, but I can't serve from the homebrew-installed CLI. I did verify that this changeset is sufficient to serve in my case, and the tests aren't broken, so maybe that helps?

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).