### PR TITLE
Add --no-update flag to skip the URL update on serve

### DIFF
--- a/lib/shopify_cli/command_options/command_serve_options.rb
+++ b/lib/shopify_cli/command_options/command_serve_options.rb
@@ -20,6 +20,10 @@ module ShopifyCLI
             end
             host
           end
+
+          def no_update
+            options.flags[:no_update] || false
+          end
         end
       end
 
@@ -35,6 +39,12 @@ module ShopifyCLI
         def parse_port_option
           options do |parser, flags|
             parser.on("--port=PORT") { |port| flags[:port] = port }
+          end
+        end
+
+        def parse_no_update_option
+          options do |parser, flags|
+            parser.on("--no-update") { flags[:no_update] = true }
           end
         end
       end

--- a/lib/shopify_cli/commands/app/serve.rb
+++ b/lib/shopify_cli/commands/app/serve.rb
@@ -43,7 +43,7 @@ module ShopifyCLI
         end
 
         def self.extended_help
-          ShopifyCLI::Context.message("app.core.serve.extended_help")
+          ShopifyCLI::Context.message("core.app.serve.extended_help")
         end
       end
     end

--- a/lib/shopify_cli/commands/app/serve.rb
+++ b/lib/shopify_cli/commands/app/serve.rb
@@ -8,12 +8,9 @@ module ShopifyCLI
 
         recommend_default_ruby_range
 
-        options do |parser, flags|
-          parser.on("--host=HOST") do |h|
-            flags[:host] = h.gsub('"', "")
-          end
-          parser.on("--port=PORT") { |port| flags[:port] = port }
-        end
+        parse_host_option
+        parse_port_option
+        parse_no_update_option
 
         def call(*)
           case detect_app
@@ -21,18 +18,21 @@ module ShopifyCLI
             Services::App::Serve::RailsService.call(
               host: host,
               port: port,
+              no_update: no_update,
               context: @ctx
             )
           when :node
             Services::App::Serve::NodeService.call(
               host: host,
               port: port,
+              no_update: no_update,
               context: @ctx
             )
           when :php
             Services::App::Serve::PHPService.call(
               host: host,
               port: port,
+              no_update: no_update,
               context: @ctx
             )
           end

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -714,6 +714,10 @@ module ShopifyCLI
             update_error:
               "{{x}} error: For authentication issues, run {{command:%s logout}} to clear invalid credentials",
             update_prompt: "Do you want to update your application url?",
+            auto_update_warning: <<~WARN,
+              {{warning:Note: starting with the next release (2.17.0), {{command:app serve}} will update application URLs by default.
+              To avoid an automatic URL update, use the {{command:--no-update}} flag.}}
+            WARN
           },
           select_org_and_shop: {
             authentication_issue: "For authentication issues, run {{command:%s logout}} to clear invalid credentials",

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -263,6 +263,7 @@ module ShopifyCLI
               {{bold:Options:}}
                 {{cyan:--host=HOST}}: Bypass running tunnel and use custom host. HOST must be HTTPS url.
                 {{cyan:--port=PORT}}: Use custom port.
+                {{cyan:--no-update}}: Skips the dashboard URL update step
             HELP
             open_info: <<~MESSAGE,
               {{*}} To install and start using your app, open this URL in your browser:

--- a/lib/shopify_cli/services.rb
+++ b/lib/shopify_cli/services.rb
@@ -5,6 +5,7 @@ module ShopifyCLI
 
     module App
       module Serve
+        autoload :ServeService, "shopify_cli/services/app/serve/serve_service"
         autoload :NodeService, "shopify_cli/services/app/serve/node_service"
         autoload :RailsService, "shopify_cli/services/app/serve/rails_service"
         autoload :PHPService, "shopify_cli/services/app/serve/php_service"

--- a/lib/shopify_cli/services/app/serve/node_service.rb
+++ b/lib/shopify_cli/services/app/serve/node_service.rb
@@ -2,32 +2,9 @@ module ShopifyCLI
   module Services
     module App
       module Serve
-        class NodeService < BaseService
-          attr_accessor :host, :port, :context
-
-          def initialize(host:, port:, context:)
-            @host = host
-            @port = port
-            @context = context
-            super()
-          end
-
+        class NodeService < ServeService
           def call
-            project = ShopifyCLI::Project.current
-            url = host || ShopifyCLI::Tunnel.start(context, port: port)
-            raise ShopifyCLI::Abort,
-              context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
-            project.env.update(context, :host, url)
-            ShopifyCLI::Tasks::UpdateDashboardURLS.call(
-              context,
-              url: url,
-              callback_url: "/auth/callback",
-            )
-
-            if project.env.shop
-              project_url = "#{project.env.host}/auth?shop=#{project.env.shop}"
-              context.puts("\n" + context.message("core.app.serve.open_info", project_url) + "\n")
-            end
+            generate_url
 
             CLI::UI::Frame.open(context.message("core.app.serve.running_server")) do
               env = project.env.to_h

--- a/lib/shopify_cli/services/app/serve/php_service.rb
+++ b/lib/shopify_cli/services/app/serve/php_service.rb
@@ -2,32 +2,9 @@ module ShopifyCLI
   module Services
     module App
       module Serve
-        class PHPService < BaseService
-          attr_accessor :host, :port, :context
-
-          def initialize(host:, port:, context:)
-            @host = host
-            @port = port
-            @context = context
-            super()
-          end
-
+        class PHPService < ServeService
           def call
-            project = ShopifyCLI::Project.current
-            url = host || ShopifyCLI::Tunnel.start(context, port: port)
-            raise ShopifyCLI::Abort,
-              context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
-            project.env.update(context, :host, url)
-            ShopifyCLI::Tasks::UpdateDashboardURLS.call(
-              context,
-              url: url,
-              callback_url: "/auth/callback",
-            )
-
-            if project.env.shop
-              project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
-              context.puts("\n" + context.message("core.app.serve.open_info", project_url) + "\n")
-            end
+            generate_url
 
             CLI::UI::Frame.open(context.message("core.app.serve.running_server")) do
               if ShopifyCLI::ProcessSupervision.running?(:npm_watch)

--- a/lib/shopify_cli/services/app/serve/rails_service.rb
+++ b/lib/shopify_cli/services/app/serve/rails_service.rb
@@ -2,32 +2,9 @@ module ShopifyCLI
   module Services
     module App
       module Serve
-        class RailsService < BaseService
-          attr_accessor :host, :port, :context
-
-          def initialize(host:, port:, context:)
-            @host = host
-            @port = port
-            @context = context
-            super()
-          end
-
+        class RailsService < ServeService
           def call
-            project = ShopifyCLI::Project.current
-            url = host || ShopifyCLI::Tunnel.start(context, port: port)
-            raise ShopifyCLI::Abort,
-              context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
-            project.env.update(context, :host, url)
-            ShopifyCLI::Tasks::UpdateDashboardURLS.call(
-              context,
-              url: url,
-              callback_url: "/auth/shopify/callback",
-            )
-
-            if project.env.shop
-              project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
-              context.puts("\n" + context.message("core.app.serve.open_info", project_url) + "\n")
-            end
+            generate_url
 
             CLI::UI::Frame.open(context.message("core.app.serve.running_server")) do
               env = ShopifyCLI::Project.current.env.to_h

--- a/lib/shopify_cli/services/app/serve/serve_service.rb
+++ b/lib/shopify_cli/services/app/serve/serve_service.rb
@@ -20,7 +20,7 @@ module ShopifyCLI
           private
 
           def generate_url
-            url = create_tunnel
+            create_tunnel
             update_url unless no_update
             show_app_url
           end

--- a/lib/shopify_cli/services/app/serve/serve_service.rb
+++ b/lib/shopify_cli/services/app/serve/serve_service.rb
@@ -1,0 +1,57 @@
+module ShopifyCLI
+  module Services
+    module App
+      module Serve
+        class ServeService < BaseService
+          attr_accessor :host, :port, :no_update, :context
+
+          def initialize(host:, port:, no_update:, context:)
+            @host = host
+            @port = port
+            @no_update = no_update
+            @context = context
+            super()
+          end
+
+          def call
+            raise NotImplementedError
+          end
+
+          private
+
+          def generate_url
+            url = create_tunnel
+            update_url unless no_update
+            show_app_url
+          end
+
+          def create_tunnel
+            url = host || ShopifyCLI::Tunnel.start(context, port: port)
+            raise ShopifyCLI::Abort,
+              context.message("core.app.serve.error.host_must_be_https") if url.match(/^https/i).nil?
+            project.env.update(context, :host, url)
+          end
+
+          def update_url
+            ShopifyCLI::Tasks::UpdateDashboardURLS.call(
+              context,
+              url: project.env.host,
+              callback_url: "/auth/shopify/callback",
+            )
+          end
+
+          def show_app_url
+            return unless project.env.shop
+
+            project_url = "#{project.env.host}/login?shop=#{project.env.shop}"
+            context.puts("\n" + context.message("core.app.serve.open_info", project_url) + "\n")
+          end
+
+          def project
+            @project ||= ShopifyCLI::Project.current
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -16,7 +16,7 @@ module ShopifyCLI
         ShopifyCLI::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
           applicationUrl: url,
           redirectUrlWhitelist: constructed_urls,
-          apiKey: api_key
+          apiKey: api_key,
         })
 
         @ctx.puts(@ctx.message("core.tasks.update_dashboard_urls.updated"))

--- a/test/shopify-cli/services/app/serve/node_service_test.rb
+++ b/test/shopify-cli/services/app/serve/node_service_test.rb
@@ -14,10 +14,10 @@ module ShopifyCLI
             project_context("app_types", "node")
             ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
             @context.stubs(:system)
+            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
           end
 
           def test_call
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.expects(:system).with(
@@ -56,14 +56,13 @@ module ShopifyCLI
           end
 
           def test_open_while_run
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
               @context, :host, "https://example.com"
             )
             @context.expects(:puts).with(
               "\n" +
-              @context.message("core.app.serve.open_info", "https://example.com/auth?shop=my-test-shop.myshopify.com") +
+              @context.message("core.app.serve.open_info", "https://example.com/login?shop=my-test-shop.myshopify.com") +
               "\n"
             )
             run_cmd("app serve")
@@ -119,13 +118,17 @@ module ShopifyCLI
 
           def test_call_when_invalid_port_passed
             invalid_port = "NOT_PORT"
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.expects(:abort).with(
               @context.message("core.app.serve.error.invalid_port", invalid_port)
             )
             run_cmd("app serve --port=#{invalid_port}")
+          end
+
+          def test_call_when_no_update_passed
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
+            run_cmd('app serve --no-update')
           end
         end
       end

--- a/test/shopify-cli/services/app/serve/node_service_test.rb
+++ b/test/shopify-cli/services/app/serve/node_service_test.rb
@@ -62,7 +62,8 @@ module ShopifyCLI
             )
             @context.expects(:puts).with(
               "\n" +
-              @context.message("core.app.serve.open_info", "https://example.com/login?shop=my-test-shop.myshopify.com") +
+              @context.message("core.app.serve.open_info",
+                "https://example.com/login?shop=my-test-shop.myshopify.com") +
               "\n"
             )
             run_cmd("app serve")
@@ -128,7 +129,7 @@ module ShopifyCLI
 
           def test_call_when_no_update_passed
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
-            run_cmd('app serve --no-update')
+            run_cmd("app serve --no-update")
           end
         end
       end

--- a/test/shopify-cli/services/app/serve/php_service_test.rb
+++ b/test/shopify-cli/services/app/serve/php_service_test.rb
@@ -14,10 +14,10 @@ module ShopifyCLI
             project_context("app_types", "php")
             ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
             @context.stubs(:system)
+            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
           end
 
           def test_server_command
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)
@@ -51,7 +51,6 @@ module ShopifyCLI
           end
 
           def test_restarts_npm_watch_if_running
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(true)
@@ -158,7 +157,6 @@ module ShopifyCLI
 
           def test_server_command_when_invalid_port_passed
             invalid_port = "NOT_PORT"
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)
@@ -169,6 +167,11 @@ module ShopifyCLI
             )
 
             run_cmd("app serve --port=#{invalid_port}")
+          end
+
+          def test_server_command_when_no_update_passed
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
+            run_cmd('app serve --no-update')
           end
         end
       end

--- a/test/shopify-cli/services/app/serve/php_service_test.rb
+++ b/test/shopify-cli/services/app/serve/php_service_test.rb
@@ -171,7 +171,7 @@ module ShopifyCLI
 
           def test_server_command_when_no_update_passed
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
-            run_cmd('app serve --no-update')
+            run_cmd("app serve --no-update")
           end
         end
       end

--- a/test/shopify-cli/services/app/serve/rails_service_test.rb
+++ b/test/shopify-cli/services/app/serve/rails_service_test.rb
@@ -114,7 +114,7 @@ module ShopifyCLI
 
           def test_server_command_when_no_update_passed
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
-            run_cmd('app serve --no-update')
+            run_cmd("app serve --no-update")
           end
         end
       end

--- a/test/shopify-cli/services/app/serve/rails_service_test.rb
+++ b/test/shopify-cli/services/app/serve/rails_service_test.rb
@@ -15,10 +15,10 @@ module ShopifyCLI
             ShopifyCLI::Tasks::EnsureDevStore.stubs(:call)
             ShopifyCLI::Tasks::EnsureProjectType.stubs(:call)
             @context.stubs(:system)
+            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
           end
 
           def test_server_command
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")
@@ -38,7 +38,6 @@ module ShopifyCLI
           end
 
           def test_open_while_run
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update).with(
               @context, :host, "https://example.com"
@@ -103,7 +102,6 @@ module ShopifyCLI
 
           def test_server_command_when_invalid_port_passed
             invalid_port = "NOT_PORT"
-            ShopifyCLI::Tunnel.stubs(:start).returns("https://example.com")
             ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")
@@ -112,6 +110,11 @@ module ShopifyCLI
               @context.message("core.app.serve.error.invalid_port", invalid_port)
             )
             run_cmd("app serve --port=#{invalid_port}")
+          end
+
+          def test_server_command_when_no_update_passed
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).never
+            run_cmd('app serve --no-update')
           end
         end
       end

--- a/test/shopify-cli/tasks/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/tasks/update_dashboard_urls_test.rb
@@ -282,7 +282,8 @@ module ShopifyCLI
             },
           }
         )
-        CLI::UI::Prompt.expects(:confirm).returns(true)
+        @context.expects(:puts).with(@context.message("core.tasks.update_dashboard_urls.auto_update_warning"))
+        CLI::UI::Prompt.expects(:confirm).returns(false)
         ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://123adifferenturl.ngrok.io",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2137, https://github.com/Shopify/shopify-cli-planning/issues/137

### WHAT is this pull request doing?

- Adds a new flag (`--no-update`) to `app serve` to skip the dashboard URL update prompt
- Adds a warning about the future default behavior and this new flag:

![warning](https://user-images.githubusercontent.com/14979109/160115487-d47cbc3b-2ba5-4698-a09a-e644ab865812.png)

### How to test your changes?

`shopify app serve --no-update`

### Post-release steps

Documentation of the new flag should be published after releasing.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).