### PR TITLE
Diretories with the '.json' extension should not be handled as JSON files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2191](https://github.com/Shopify/shopify-cli/pull/2191): Diretories with the `.json` extension should not be handled as JSON files
+
 ## Version 2.15.2
 
 ### Fixed

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -37,10 +37,10 @@ module ShopifyCLI
       end
 
       def glob(pattern, raise_on_dir: false)
-        root.glob(pattern).map do |path|
-          abort_if_directory!(path) if raise_on_dir
-          File.new(path, root)
-        end
+        root
+          .glob(pattern)
+          .select { |path| file?(path, raise_on_dir) }
+          .map { |path| File.new(path, root) }
       end
 
       def theme_file?(file)
@@ -222,9 +222,12 @@ module ShopifyCLI
         self
       end
 
-      def abort_if_directory!(path)
-        return unless ::File.directory?(path)
-        @ctx.abort(@ctx.message("theme.serve.error.invalid_subdirectory", path.to_s))
+      def file?(path, raise_on_dir = false)
+        if raise_on_dir && ::File.directory?(path)
+          @ctx.abort(@ctx.message("theme.serve.error.invalid_subdirectory", path.to_s))
+        end
+
+        ::File.file?(path)
       end
     end
   end

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -25,6 +25,16 @@ module ShopifyCLI
         assert_message_output(io: io, expected_content: ctx.message("theme.serve.error.invalid_subdirectory", filepath))
       end
 
+      def test_json_files_when_a_directory_has_a_json_extension
+        root = @root
+        ctx = TestHelpers::FakeContext.new(root: root)
+        theme = Theme.new(ctx, root: root, id: "123")
+
+        json_files = theme.json_files.map(&:relative_path)
+
+        refute_includes(json_files, "directory.json")
+      end
+
       def test_static_assets
         assert_includes(@theme.static_asset_paths, "assets/theme.css")
       end


### PR DESCRIPTION
### WHY are these changes introduced?

Some users may have directories with the `.json` extension. These directories shouldn't be handled as JSON files.

### WHAT is this pull request doing?

This PR updates the `Theme::Theme::glob` to get only JSON files.

### How to test your changes?

- Create a directory called `a.json` at the root of your Theme
- Run `shopify theme serve`
- Notice the error no longer happens

**Before this PR:**
<img width="60%" src="https://user-images.githubusercontent.com/1079279/160608567-2dd4bb7b-ab6e-485e-9346-0b004c34d000.gif">

**After this PR:**
<img width="60%" src="https://user-images.githubusercontent.com/1079279/160608559-4f458652-6a98-43a4-bac6-33763606441b.gif">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).