### PR TITLE
Apply the same ignore logic across the `Syncer`, `Watcher`, and the `RemoteWatcher`

### DIFF
--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -32,7 +32,7 @@ module ShopifyCLI
           theme = DevelopmentTheme.find_or_create!(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
           @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync)
-          watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, ignore_filter: ignore_filter, poll: poll)
+          watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, poll: poll)
           remote_watcher = RemoteWatcher.to(theme: theme, syncer: @syncer)
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order

--- a/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
+++ b/lib/shopify_cli/theme/dev_server/remote_watcher/json_files_update_job.rb
@@ -26,6 +26,7 @@ module ShopifyCLI
               .json_files
               .reject { |file| @syncer.pending_updates.include?(file) }
               .reject { |file| @syncer.broken_file?(file) }
+              .reject { |file| @syncer.ignore_file?(file) }
           end
         end
       end

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -46,20 +46,14 @@ module ShopifyCLI
           files
             .select { |file| @theme.theme_file?(file) }
             .map { |file| @theme[file] }
-            .reject { |file| ignore_file?(file) }
+            .reject { |file| @syncer.ignore_file?(file) }
         end
 
         def filter_remote_files(files)
           files
             .select { |file| @syncer.remote_file?(file) }
             .map { |file| @theme[file] }
-            .reject { |file| ignore_file?(file) }
-        end
-
-        private
-
-        def ignore_file?(file)
-          @ignore_filter&.ignore?(file.relative_path)
+            .reject { |file| @syncer.ignore_file?(file) }
         end
       end
     end

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -13,7 +13,7 @@ module ShopifyCLI
           root = ShopifyCLI::ROOT + "/test/fixtures/theme"
           @ctx = TestHelpers::FakeContext.new(root: root)
           @theme = Theme.new(@ctx, root: root)
-          @syncer = stub("Syncer", enqueue_uploads: true, enqueue_updates: true)
+          @syncer = stub("Syncer", enqueue_uploads: true, enqueue_updates: true, ignore_file?: false)
           @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer)
           @mode = "off"
         end

--- a/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
+++ b/test/shopify-cli/theme/dev_server/remote_watcher/json_files_update_job_test.rb
@@ -20,10 +20,15 @@ module ShopifyCLI
             file2 = mock
             file3 = mock
             file4 = mock
+            file5 = mock
+
             syncer.stubs(pending_updates: [file2])
             syncer.stubs(:broken_file?).returns(false)
+            syncer.stubs(:ignore_file?).returns(false)
             syncer.stubs(:broken_file?).with(file3).returns(true)
-            theme.stubs(json_files: [file1, file2, file3, file4])
+            syncer.stubs(:ignore_file?).with(file5).returns(true)
+
+            theme.stubs(json_files: [file1, file2, file3, file4, file5])
 
             syncer.expects(:fetch_checksums!)
             syncer.expects(:enqueue_get).with([file1, file4])


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the CLI is adopting the same ignore-logic across the **Syncer**, **Watcher**, and the **Remote Watcher**.

Even with the flags disabled in the `theme serve` command (for now, as we plan to activate them at some point), having consistency across the ignore logic already brings value as it incorporates the `IgnoreFilter::DEFAULT_REGEXES` (that's currently not applied at the **Remote Watcher** level).

### WHAT is this pull request doing?

This PR converges the ignore logic in the **Syncer** (that relies on the `Syncer::IgnoreHelper`).

In the future, if we decide to support `--ignore/--only` in the `theme serve`, it's probably a good idea to completely extract the `Syncer::IgnoreHelper` from the `Syncer`.

### How to test your changes?

- Run `shopify theme serve --theme-editor-sync`
- Notice that `IgnoreFilter::DEFAULT_REGEXES` are no longer auto updated

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).