### PR TITLE
Hide input query related files behind beta flag

### DIFF
--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -62,6 +62,7 @@ module Script
       autoload :ScriptService, Project.project_filepath("layers/infrastructure/script_service")
       autoload :ScriptUploader, Project.project_filepath("layers/infrastructure/script_uploader")
       autoload :ServiceLocator, Project.project_filepath("layers/infrastructure/service_locator")
+      autoload :SparseCheckoutDetails, Project.project_filepath("layers/infrastructure/sparse_checkout_details")
 
       module Languages
         autoload :ProjectCreator, Project.project_filepath("layers/infrastructure/languages/project_creator")

--- a/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
@@ -10,9 +10,7 @@ module Script
           property! :type, accepts: String
           property! :project_name, accepts: String
           property! :path_to_project, accepts: String
-          property! :sparse_checkout_repo, accepts: String
-          property! :sparse_checkout_branch, accepts: String
-          property! :sparse_checkout_set_path, accepts: String
+          property! :sparse_checkout_details, accepts: SparseCheckoutDetails
 
           def self.for(
             ctx:,
@@ -20,9 +18,7 @@ module Script
             type:,
             project_name:,
             path_to_project:,
-            sparse_checkout_repo:,
-            sparse_checkout_branch:,
-            sparse_checkout_set_path:
+            sparse_checkout_details:
           )
 
             project_creators = {
@@ -36,9 +32,7 @@ module Script
               type: type,
               project_name: project_name,
               path_to_project: path_to_project,
-              sparse_checkout_repo: sparse_checkout_repo,
-              sparse_checkout_branch: sparse_checkout_branch,
-              sparse_checkout_set_path: sparse_checkout_set_path
+              sparse_checkout_details: sparse_checkout_details,
             )
           end
 
@@ -51,18 +45,13 @@ module Script
           private
 
           def setup_sparse_checkout
-            ShopifyCLI::Git.sparse_checkout(
-              sparse_checkout_repo,
-              sparse_checkout_set_path,
-              sparse_checkout_branch,
-              ctx
-            )
+            sparse_checkout_details.setup(ctx)
           end
 
           def clean
-            source = File.join(path_to_project, sparse_checkout_set_path, ".")
+            source = File.join(path_to_project, sparse_checkout_details.path, ".")
             FileUtils.cp_r(source, path_to_project)
-            ctx.rm_rf(sparse_checkout_set_path.split("/")[0])
+            ctx.rm_rf(sparse_checkout_details.path.split("/")[0])
             ctx.rm_rf(".git")
           end
 

--- a/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
@@ -38,15 +38,11 @@ module Script
 
           # the sparse checkout process is common to all script types
           def setup_dependencies
-            setup_sparse_checkout
+            sparse_checkout_details.setup(ctx)
             clean
           end
 
           private
-
-          def setup_sparse_checkout
-            sparse_checkout_details.setup(ctx)
-          end
 
           def clean
             source = File.join(path_to_project, sparse_checkout_details.path, ".")

--- a/lib/project_types/script/layers/infrastructure/sparse_checkout_details.rb
+++ b/lib/project_types/script/layers/infrastructure/sparse_checkout_details.rb
@@ -16,12 +16,12 @@ module Script
         end
 
         def setup(ctx)
-          ShopifyCLI::Git.sparse_checkout(repo, set_path, branch, ctx)
+          ShopifyCLI::Git.sparse_checkout(repo, patterns_to_checkout, branch, ctx)
         end
 
         private
 
-        def set_path
+        def patterns_to_checkout
           paths = [path]
           unless input_queries_enabled
             paths << "!#{path}/#{ScriptProjectRepository::INPUT_QUERY_PATH}"

--- a/lib/project_types/script/layers/infrastructure/sparse_checkout_details.rb
+++ b/lib/project_types/script/layers/infrastructure/sparse_checkout_details.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Infrastructure
+      class SparseCheckoutDetails
+        include SmartProperties
+        property! :repo, accepts: String
+        property! :branch, accepts: String
+        property! :path, accepts: String
+        property! :input_queries_enabled, accepts: [true, false]
+
+        def ==(other)
+          self.class == other.class &&
+            self.class.properties.all? { |name, _| self[name] == other[name] }
+        end
+
+        def setup(ctx)
+          ShopifyCLI::Git.sparse_checkout(repo, set_path, branch, ctx)
+        end
+
+        private
+
+        def set_path
+          paths = [path]
+          unless input_queries_enabled
+            paths << "!#{path}/#{ScriptProjectRepository::INPUT_QUERY_PATH}"
+            paths << "!#{path}/schema.graphql"
+          end
+          paths.join(" ")
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -133,7 +133,6 @@ describe Script::Layers::Application::CreateScript do
         let(:input_queries_beta_enabled?) { true }
 
         before do
-          Script::Layers::Infrastructure::Languages::ProjectCreator.unstub(:for)
           Script::Layers::Infrastructure::Languages::ProjectCreator
             .expects(:for)
             .with(

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -16,11 +16,16 @@ describe Script::Layers::Application::CreateScript do
   let(:extension_point_type) { "payment-methods" }
   let(:example_config) { extension_point_repository.example_config(extension_point_type) }
   let(:domain) { example_config["domain"] }
-  let(:sparse_checkout_repo) { example_config["libraries"][language]["repo"] }
-  let(:sparse_checkout_branch) do
-    "master"
-  end   # TODO: update once create script can take a command line argument
-  let(:sparse_checkout_set_path) { "#{domain}/#{language}/#{extension_point_type}/default" }
+  let(:sparse_checkout_branch) { "master" }
+  let(:input_queries_beta_enabled?) { false }
+  let(:sparse_checkout_details) do
+    Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+      repo: example_config["libraries"][language]["repo"],
+      branch: sparse_checkout_branch,
+      path: "#{domain}/#{language}/#{extension_point_type}/default",
+      input_queries_enabled: input_queries_beta_enabled?,
+    )
+  end
 
   let(:project_creator) { stub }
   let(:context) { TestHelpers::FakeContext.new }
@@ -50,14 +55,14 @@ describe Script::Layers::Application::CreateScript do
         type: extension_point_type,
         project_name: title,
         path_to_project: script_project.id,
-        sparse_checkout_repo: sparse_checkout_repo,
-        sparse_checkout_branch: sparse_checkout_branch,
-        sparse_checkout_set_path: sparse_checkout_set_path,
+        sparse_checkout_details: sparse_checkout_details,
       )
       .returns(project_creator)
 
-    project_creator.stubs(:sparse_checkout_repo).returns(sparse_checkout_repo)
+    project_creator.stubs(:sparse_checkout_details).returns(sparse_checkout_details)
     project_creator.stubs(:path_to_project).returns(script_project.id)
+
+    ShopifyCLI::Feature.stubs(:enabled?).with(:scripts_beta_input_queries).returns(input_queries_beta_enabled?)
   end
 
   describe ".call" do
@@ -122,6 +127,14 @@ describe Script::Layers::Application::CreateScript do
 
         script_config = script_project_repository.get.script_config
         assert_equal "1", script_config.version
+      end
+
+      describe "when scripts_beta_input_queries feature is enabled" do
+        let(:input_queries_beta_enabled?) { true }
+
+        it "passes correct arguments to project creator" do
+          subject
+        end
       end
     end
 

--- a/test/project_types/script/layers/application/create_script_test.rb
+++ b/test/project_types/script/layers/application/create_script_test.rb
@@ -132,6 +132,21 @@ describe Script::Layers::Application::CreateScript do
       describe "when scripts_beta_input_queries feature is enabled" do
         let(:input_queries_beta_enabled?) { true }
 
+        before do
+          Script::Layers::Infrastructure::Languages::ProjectCreator.unstub(:for)
+          Script::Layers::Infrastructure::Languages::ProjectCreator
+            .expects(:for)
+            .with(
+              ctx: context,
+              language: language,
+              type: extension_point_type,
+              project_name: title,
+              path_to_project: script_project.id,
+              sparse_checkout_details: sparse_checkout_details,
+            )
+            .returns(project_creator)
+        end
+
         it "passes correct arguments to project creator" do
           subject
         end

--- a/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/typescript_project_creator_test.rb
@@ -19,9 +19,14 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
   let(:domain) { "fake-domain" }
   let(:language) { "typescript" }
   let(:project_name) { "myscript" }
-  let(:sparse_checkout_repo) { extension_point_config["typescript"]["repo"] }
-  let(:sparse_checkout_branch) { "fake-branch" }
-  let(:sparse_checkout_set_path) { "#{domain}/#{language}/#{extension_point_type}/default" }
+  let(:sparse_checkout_details) do
+    Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+      repo: extension_point_config["typescript"]["repo"],
+      branch: "fake-branch",
+      path: "#{domain}/#{language}/#{extension_point_type}/default",
+      input_queries_enabled: false,
+    )
+  end
 
   let(:project_creator) do
     Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator
@@ -30,9 +35,7 @@ describe Script::Layers::Infrastructure::Languages::TypeScriptProjectCreator do
         type: extension_point_type,
         project_name: project_name,
         path_to_project: project_name,
-        sparse_checkout_repo: sparse_checkout_repo,
-        sparse_checkout_branch: sparse_checkout_branch,
-        sparse_checkout_set_path: sparse_checkout_set_path,
+        sparse_checkout_details: sparse_checkout_details,
       )
   end
 

--- a/test/project_types/script/layers/infrastructure/languages/wasm_project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/wasm_project_creator_test.rb
@@ -11,10 +11,14 @@ describe Script::Layers::Infrastructure::Languages::WasmProjectCreator do
   let(:language) { "wasm" }
   let(:domain) { "fake-domain" }
   let(:project_name) { "myscript" }
-  let(:sparse_checkout_repo) { "fake-repo" }
-  let(:sparse_checkout_branch) { "fake-branch" }
-  let(:sparse_checkout_set_path) { "#{domain}/#{language}/#{type}/default" }
-
+  let(:sparse_checkout_details) do
+    Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+      repo: "fake-repo",
+      branch: "fake-branch",
+      path: "#{domain}/#{language}/#{type}/default",
+      input_queries_enabled: false,
+    )
+  end
   let(:project_creator) do
     Script::Layers::Infrastructure::Languages::WasmProjectCreator
       .new(
@@ -22,9 +26,7 @@ describe Script::Layers::Infrastructure::Languages::WasmProjectCreator do
         type: type,
         project_name: project_name,
         path_to_project: project_name,
-        sparse_checkout_repo: sparse_checkout_repo,
-        sparse_checkout_branch: sparse_checkout_branch,
-        sparse_checkout_set_path: sparse_checkout_set_path,
+        sparse_checkout_details: sparse_checkout_details,
       )
   end
 

--- a/test/project_types/script/layers/infrastructure/sparse_checkout_details_test.rb
+++ b/test/project_types/script/layers/infrastructure/sparse_checkout_details_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "project_types/script/test_helper"
+
+describe Script::Layers::Infrastructure::SparseCheckoutDetails do
+  let(:repo) { "fake-repo" }
+  let(:branch) { "fake-branch" }
+  let(:path) { "fake-path" }
+  let(:input_queries_enabled) { false }
+  let(:instance) do
+    Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+      repo: repo,
+      branch: branch,
+      path: path,
+      input_queries_enabled: input_queries_enabled,
+    )
+  end
+
+  describe "#==" do
+    subject { instance == other_instance }
+
+    describe "when the other instance has all the same properties" do
+      let(:other_instance) do
+        Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+          repo: repo,
+          branch: branch,
+          path: path,
+          input_queries_enabled: input_queries_enabled,
+        )
+      end
+
+      it "returns true" do
+        assert(subject)
+      end
+    end
+
+    describe "when the other instance has different properties" do
+      let(:other_instance) do
+        Script::Layers::Infrastructure::SparseCheckoutDetails.new(
+          repo: repo,
+          branch: branch,
+          path: path,
+          input_queries_enabled: !input_queries_enabled,
+        )
+      end
+
+      it "returns false" do
+        refute(subject)
+      end
+    end
+  end
+
+  describe "#setup" do
+    let(:context) { TestHelpers::FakeContext.new }
+
+    subject { instance.setup(context) }
+
+    describe "input_queries_enabled is false" do
+      it "excludes input.graphql and schema.graphql from set path" do
+        ShopifyCLI::Git
+          .expects(:sparse_checkout)
+          .with(
+            repo,
+            "#{path} !#{path}/input.graphql !#{path}/schema.graphql",
+            branch,
+            context,
+          )
+          .once
+        subject
+      end
+    end
+
+    describe "input_queries_enabled is true" do
+      let(:input_queries_enabled) { true }
+
+      it "does not exclude input.graphql and schema.graphql from set path" do
+        ShopifyCLI::Git
+          .expects(:sparse_checkout)
+          .with(
+            repo,
+            path,
+            branch,
+            context,
+          )
+          .once
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

https://github.com/Shopify/script-service/issues/4501

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR introduces a feature flag, `scripts_beta_input_queries`. When disabled, we will filter out input-query related files when performing the sparse-checkout of the project template. When enabled we will not filter out input-query related files.

I will make PR(s) in [scripts-apis-examples](https://github.com/Shopify/scripts-apis-examples) to add the schema and empty input query files.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Create a script without enabling the feature, see that the `input.graphql` and `schema.graphql` files are not included in the project:
```
shopify-dev script create --api=merchandise_discount_types --branch=ap.discounts-wasm-schema
```
Enable the feature
```
shopify-dev config feature scripts_beta_input_queries --enable
```
Create a script, see that the `input.graphql` and `schema.graphql` files are included in the project:
```
shopify-dev script create --api=merchandise_discount_types --branch=ap.discounts-wasm-schema
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).