### PR TITLE
Fix 'CHANGELOG.md'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2121](https://github.com/Shopify/shopify-cli/pull/2121): Fix the hot-reload to work when the section name is not equal to the type
 
+### Added
+* [#2174](https://github.com/Shopify/shopify-cli/pull/2174): Add optional 2-way sync between the CLI (`theme serve`) and the Theme Editor
+
 ## Version 2.15.1
 
 ### Added
 * [#1934](https://github.com/Shopify/shopify-cli/pull/1934): Block directories in theme assets
 * [#1880](https://github.com/Shopify/shopify-cli/pull/1880): Recognize attempts to pass a store name and suggest correction
-* [#2174](https://github.com/Shopify/shopify-cli/pull/2174): Add optional 2-way sync between the CLI (`theme serve`) and the Theme Editor
 
 ### Fixed
 * [#1874](https://github.com/Shopify/shopify-cli/pull/1874): Make ngrok errors more robust and helpful


### PR DESCRIPTION
I've noticed the https://github.com/Shopify/shopify-cli/pull/2174 was not included in the https://github.com/Shopify/shopify-cli/releases page.

Also, I've checked the tags, and I'm updating the https://github.com/Shopify/shopify-cli/releases page and the 'CHANGELOG.md' file accordingly.