### PR TITLE
[Feature] Add `theme share` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2188](https://github.com/Shopify/shopify-cli/pull/2188): Update URLs by default on serve and add --no-update flag to skip it
 * [#2203](https://github.com/Shopify/shopify-cli/pull/2203): Use javy version 0.3.0
 
-### Added
-* [#2200](https://github.com/Shopify/shopify-cli/pull/2200): Add `theme share` command
-
 ### Fixed
 * [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
 * [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update
@@ -18,6 +15,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2190](https://github.com/Shopify/shopify-cli/pull/2190): Better login experience with spinner
+* [#2200](https://github.com/Shopify/shopify-cli/pull/2200): Add `theme share` command
 
 ## Version 2.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2188](https://github.com/Shopify/shopify-cli/pull/2188): Update URLs by default on serve and add --no-update flag to skip it
 * [#2203](https://github.com/Shopify/shopify-cli/pull/2203): Use javy version 0.3.0
 
+### Added
+* [#2200](https://github.com/Shopify/shopify-cli/pull/2200): Add `theme share` command
+
 ### Fixed
 * [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
 * [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -16,6 +16,7 @@ module Theme
     subcommand :Package, "package", Project.project_filepath("commands/package")
     subcommand :Open, "open", Project.project_filepath("commands/open")
     subcommand :List, "list", Project.project_filepath("commands/list")
+    subcommand :Share, "share", Project.project_filepath("commands/share")
     subcommand :LanguageServer, "language-server", Project.project_filepath("commands/language_server")
   end
   ShopifyCLI::Commands.register("Theme::Command", "theme")

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -104,9 +104,7 @@ module Theme
 
         if unpublished
           name = theme || ask_theme_name
-          new_theme = ShopifyCLI::Theme::Theme.new(@ctx, root: root, name: name, role: "unpublished")
-          new_theme.create
-          return new_theme
+          return ShopifyCLI::Theme::Theme.create_unpublished(@ctx, root: root, name: name)
         end
 
         if theme

--- a/lib/project_types/theme/commands/share.rb
+++ b/lib/project_types/theme/commands/share.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/syncer"
+require "project_types/theme/commands/common/root_helper"
+
+module Theme
+  class Command
+    class Share < ShopifyCLI::Command::SubCommand
+      include Common::RootHelper
+
+      recommend_default_ruby_range
+
+      def call(_args, name)
+        root = root_value(options, name)
+        theme = create_theme(root)
+
+        upload(theme)
+
+        @ctx.done(done_message(theme))
+      end
+
+      def self.help
+        tool = ShopifyCLI::TOOL_NAME
+        @ctx.message("theme.share.help", tool, tool)
+      end
+
+      private
+
+      def create_theme(root)
+        ShopifyCLI::Theme::Theme.create_unpublished(@ctx, root: root)
+      end
+
+      def upload(theme)
+        syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme)
+        syncer.start_threads
+
+        CLI::UI::Frame.open(upload_message(theme)) do
+          UI::SyncProgressBar.new(syncer).progress(:upload_theme!)
+        end
+
+        raise ShopifyCLI::AbortSilent if syncer.has_any_error?
+      ensure
+        syncer.shutdown
+      end
+
+      def upload_message(theme)
+        @ctx.message("theme.share.upload", theme.name, theme.id, theme.shop)
+      end
+
+      def done_message(theme)
+        @ctx.message("theme.share.done", theme.name, theme.preview_url, theme.editor_url)
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -290,6 +290,21 @@ module Theme
             Usage: {{command:%s theme list}}
           HELP
         },
+        share: {
+          help: <<~HELP,
+            {{command:%s theme share}}: Creates a shareable theme on your theme library.
+
+            Usage: {{command:%s theme share [ ROOT ]}}
+          HELP
+          done: <<~DONE,
+            {{green:The {{bold:%s}} theme was pushed successfully}}
+
+              {{info:Share your theme preview:}}
+              {{underline:%s}}
+
+          DONE
+          upload: "Pushing theme files to %s (#%s) on %s",
+        },
       },
     }.freeze
   end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -292,7 +292,8 @@ module Theme
         },
         share: {
           help: <<~HELP,
-            {{command:%s theme share}}: Creates a shareable theme on your theme library.
+            {{command:%s theme share}}: Creates a shareable, unpublished, and new theme on your theme library with a randomized name.
+                                 Works like an alias to {{command:theme push -u -t=RANDOMIZED_NAME}}.
 
             Usage: {{command:%s theme share [ ROOT ]}}
           HELP

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -155,6 +155,13 @@ module ShopifyCLI
       end
 
       class << self
+        def create_unpublished(ctx, root: nil, name: nil)
+          name ||= random_name
+          theme = new(ctx, root: root, name: name, role: "unpublished")
+          theme.create
+          theme
+        end
+
         def all(ctx, root: nil)
           _status, body = fetch_themes(ctx)
 
@@ -181,6 +188,10 @@ module ShopifyCLI
         end
 
         private
+
+        def random_name
+          ShopifyCLI::Helpers::Haikunator.haikunate(9999)
+        end
 
         def find(ctx, root, &block)
           _status, body = fetch_themes(ctx)

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -333,13 +333,11 @@ module Theme
       end
 
       def test_push_to_unpublished_theme
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", name: "NAME", role: "unpublished")
+        ShopifyCLI::Theme::Theme.expects(:create_unpublished)
+          .with(@ctx, root: ".", name: "NAME")
           .returns(@theme)
 
         CLI::UI::Prompt.expects(:ask).returns("NAME")
-
-        @theme.expects(:create)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -357,13 +355,11 @@ module Theme
       end
 
       def test_push_to_unpublished_theme_when_name_is_provided
-        ShopifyCLI::Theme::Theme.expects(:new)
-          .with(@ctx, root: ".", name: "NAME", role: "unpublished")
+        ShopifyCLI::Theme::Theme.expects(:create_unpublished)
+          .with(@ctx, root: ".", name: "NAME")
           .returns(@theme)
 
         CLI::UI::Prompt.expects(:ask).never
-
-        @theme.expects(:create)
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 

--- a/test/project_types/theme/commands/share_test.rb
+++ b/test/project_types/theme/commands/share_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+
+module Theme
+  module Commands
+    class ShareTest < MiniTest::Test
+      def setup
+        super
+        @command = Theme::Command::Share.new(ctx)
+      end
+
+      def test_share
+        ShopifyCLI::Theme::Theme.expects(:create_unpublished)
+          .with(ctx, root: ".")
+          .returns(theme)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme)
+          .returns(syncer)
+
+        syncer.expects(:start_threads)
+        syncer.expects(:shutdown)
+        syncer.expects(:upload_theme!)
+
+        io = capture_io { @command.call([], "share") }.join
+
+        expected_messages = [
+          "Pushing theme files to Test theme (#1234) on test.myshopify.io",
+          "Share your theme preview:",
+          "https://test.myshopify.io/preview",
+        ]
+
+        expected_messages.each do |message|
+          assert_includes(io, message)
+        end
+      end
+
+      private
+
+      def theme
+        @theme ||= stub(
+          "Theme",
+          id: 1234,
+          name: "Test theme",
+          shop: "test.myshopify.io",
+          editor_url: "https://test.myshopify.io/editor",
+          preview_url: "https://test.myshopify.io/preview",
+          live?: false,
+        )
+      end
+
+      def syncer
+        @syncer ||= stub(
+          "Syncer",
+          lock_io!: nil,
+          unlock_io!: nil,
+          has_any_error?: false
+        )
+      end
+
+      def ctx
+        @ctx ||= ShopifyCLI::Context.new
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Developers would like to have a convenient alias to create a sharable URL for their local theme.

### WHAT is this pull request doing?

Create an alias to the `theme push -u -t <name>` command for creating a new theme with a default name.

### How to test your changes?

- Run `shopify theme share`
- Notice the sharable (unpublished) theme is created

<img width="60%" alt="usage" src="https://user-images.githubusercontent.com/1079279/161013984-242825c2-a211-49c3-b17f-2515361b9582.png">

<img width="60%" alt="help" src="https://user-images.githubusercontent.com/1079279/161013971-abe1d0df-f2bf-400c-817a-ad4f116e42a5.png">

### Post-release steps

Include the `theme share` command in the [documentation](https://shopify.dev/themes/tools/cli/theme-commands).

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).


