### PR TITLE
Fix the `theme open` command to open the theme in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update
 * [#2191](https://github.com/Shopify/shopify-cli/pull/2191): Diretories with the `.json` extension should not be handled as JSON files
 * [#2018](https://github.com/Shopify/shopify-cli/pull/2018): Run theme-check as a code dependency, not a pseudo-CLI invocation
+* [#2211](https://github.com/Shopify/shopify-cli/pull/2211): Fix the `theme open` command to open the theme in the browser
 
 ## Version 2.15.2
 

--- a/lib/project_types/theme/commands/open.rb
+++ b/lib/project_types/theme/commands/open.rb
@@ -17,8 +17,8 @@ module Theme
       def call(_args, _name)
         theme = find_theme(**options.flags)
 
-        @ctx.puts(@ctx.message("theme.open.details", theme.name, theme.editor_url))
-        @ctx.open_url!(theme.preview_url)
+        @ctx.puts(@ctx.message("theme.open.details", theme.name, theme.preview_url, theme.editor_url))
+        @ctx.open_browser_url!(theme.preview_url)
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -264,6 +264,9 @@ module Theme
           details: <<~DETAILS,
             {{*}} {{bold:%s}}
 
+            Preview your theme:
+            {{green:%s}}
+
             Customize your theme in the Theme Editor:
             {{green:%s}}
 

--- a/test/project_types/theme/commands/open_test.rb
+++ b/test/project_types/theme/commands/open_test.rb
@@ -13,6 +13,8 @@ module Theme
       def test_open_without_flags
         CLI::UI::Prompt.expects(:ask).returns(theme)
 
+        ctx.expects(:open_browser_url!).with("https://test.myshopify.io/preview")
+
         io = capture_io do
           @command.call([], "open")
         end
@@ -20,11 +22,11 @@ module Theme
         assert_message_output(io: io, expected_content: [
           "{{*}} {{bold:My test theme}}",
 
+          "\n\nPreview your theme:",
+          "{{green:https://test.myshopify.io/preview}}",
+
           "\n\nCustomize your theme in the Theme Editor:",
           "{{green:https://test.myshopify.io/editor}}",
-
-          "Please open this URL in your browser:",
-          "{{green:https://test.myshopify.io/preview}}",
         ])
       end
 
@@ -34,6 +36,8 @@ module Theme
           .with(ctx, identifier: 1234)
           .returns(theme)
 
+        ctx.expects(:open_browser_url!).with("https://test.myshopify.io/preview")
+
         io = capture_io do
           @command.options.flags[:theme] = 1234
           @command.call([], "open")
@@ -42,11 +46,11 @@ module Theme
         assert_message_output(io: io, expected_content: [
           "{{*}} {{bold:My test theme}}",
 
+          "\n\nPreview your theme:",
+          "{{green:https://test.myshopify.io/preview}}",
+
           "\n\nCustomize your theme in the Theme Editor:",
           "{{green:https://test.myshopify.io/editor}}",
-
-          "Please open this URL in your browser:",
-          "{{green:https://test.myshopify.io/preview}}",
         ])
       end
 
@@ -55,6 +59,8 @@ module Theme
           .expects(:find_by_identifier)
           .with(ctx, identifier: 1234)
           .returns(nil)
+
+        ctx.expects(:open_browser_url!).never
 
         error = assert_raises CLI::Kit::Abort do
           @command.options.flags[:theme] = 1234
@@ -70,6 +76,8 @@ module Theme
           .with(ctx)
           .returns(theme)
 
+        ctx.expects(:open_browser_url!).with("https://test.myshopify.io/preview")
+
         io = capture_io do
           @command.options.flags[:live] = true
           @command.call([], "open")
@@ -78,11 +86,11 @@ module Theme
         assert_message_output(io: io, expected_content: [
           "{{*}} {{bold:My test theme}}",
 
+          "\n\nPreview your theme:",
+          "{{green:https://test.myshopify.io/preview}}",
+
           "\n\nCustomize your theme in the Theme Editor:",
           "{{green:https://test.myshopify.io/editor}}",
-
-          "Please open this URL in your browser:",
-          "{{green:https://test.myshopify.io/preview}}",
         ])
       end
 
@@ -92,6 +100,8 @@ module Theme
           .with(ctx)
           .returns(theme)
 
+        ctx.expects(:open_browser_url!).with("https://test.myshopify.io/preview")
+
         io = capture_io do
           @command.options.flags[:development] = true
           @command.call([], "open")
@@ -100,11 +110,11 @@ module Theme
         assert_message_output(io: io, expected_content: [
           "{{*}} {{bold:My test theme}}",
 
+          "\n\nPreview your theme:",
+          "{{green:https://test.myshopify.io/preview}}",
+
           "\n\nCustomize your theme in the Theme Editor:",
           "{{green:https://test.myshopify.io/editor}}",
-
-          "Please open this URL in your browser:",
-          "{{green:https://test.myshopify.io/preview}}",
         ])
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

When users run the `theme open` command, the CLI should open the browser with the preview.

### WHAT is this pull request doing?

Now the `theme open` command relies on `Context#open_browser_url!` instead of `Context#open_url!`.

### How to test your changes?

1. Run `shopify theme open -d`
2. Notice the CLI opens the browser


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).