### PR TITLE
Remove VS Code Color Scheme Preference

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,4 @@
     "**/.DS_Store": true
   },
   "editor.formatOnSave": false,
-  "workbench.colorTheme": "Dracula Soft",
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To help me stay sane! I need to manually reset the theme every time.

### WHAT is this pull request doing?

Deletes the hard coded VS Code colour scheme that overrides users' editor preferences. This is simply not inclusive. Some people require colour-blind friendly or high contrast themes. We should not dictate a user's colour scheme.

### How to test your changes?

By updating the `.vscode/settings.json` file.

### Post-release steps

None. This only effects the development environment.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).
