### PR TITLE
Warn when shopify-cli-extensions is not installed but required

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -194,9 +194,15 @@ module Extension
         "{{command:%1$s extension connect}} " \
         "or run {{command:%1$s extension register}} to register a new extension.",
         module_not_found: "Unable to find module %s. Ensure your dependencies are up-to-date and try again.",
-        development_server_binary_not_found: <<~ERROR,
-          Development server binary not found! If you're running a development version of the CLI, please run `rake extensions:install` to install it. Otherwise, please file a bug report via https://github.com/Shopify/shopify-cli/issues/new.
-        ERROR
+        development_server_binary_not_found: {
+          title: "Development Server Binary Missing",
+          message: <<~ERROR,
+            The extension development server binary could not be found!
+
+            If you're running a development version of the CLI, please run `rake extensions:install` to install it.
+            Otherwise, please file a bug report via https://github.com/Shopify/shopify-cli/issues/new.
+          ERROR
+        },
         outdated_extensions: {
           unknown: <<~TEXT.strip,
             Please refer to the documentation for more information on how to upgrade your extension:

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -14,7 +14,12 @@ module Extension
 
       class << self
         def supported?(type)
-          binary_installed? && type_supported?(type) && type_enabled?(type)
+          if type_supported?(type) && type_enabled?(type)
+            return true if binary_installed?
+            warn_about_missing_binary
+          end
+
+          false
         end
 
         def beta_enabled?
@@ -34,6 +39,16 @@ module Extension
 
         def binary_installed?
           Models::DevelopmentServer.new.executable_installed?
+        end
+
+        def warn_about_missing_binary
+          CLI::UI::Frame.open(message("errors.development_server_binary_not_found.title"), color: :yellow) do
+            context.puts(message("errors.development_server_binary_not_found.message"))
+          end
+        end
+
+        def message(key)
+          context.message(key)
         end
 
         def context

--- a/test/project_types/extension/models/development_server_requirements_test.rb
+++ b/test/project_types/extension/models/development_server_requirements_test.rb
@@ -77,6 +77,16 @@ module Extension
 
         refute DevelopmentServerRequirements.supported?("unknown")
       end
+
+      def test_emits_debug_message_when_binary_missing
+        Extension::Models::DevelopmentServerRequirements.stubs(:binary_installed?).returns(false)
+        Extension::Models::DevelopmentServerRequirements.stubs(:beta_enabled?).returns(true)
+        ShopifyCLI::Context.any_instance
+          .expects(:puts)
+          .with(ShopifyCLI::Context.message("errors.development_server_binary_not_found.message"))
+
+        refute Extension::Models::DevelopmentServerRequirements.supported?("checkout_ui_extension")
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

To make users aware that they might be missing the development server binary. The warning is only displayed under the following conditions:

* the user has the necessary feature flag *or*
* the extension type supports the new development server in production already

### WHAT is this pull request doing?

Adding a warning if the extension development server is missing but the beta is active or the type generally supported.

<img width="1115" alt="Screen Shot 2022-04-18 at 10 35 59 AM" src="https://user-images.githubusercontent.com/77060/163824087-fff791ea-b8bb-4066-9df4-e34847a16ec2.png">

### How to test your changes?

Give yourself the `extension_server_beta` feature flag, remove `ext/shopify-extensions/shopify-extensions` and test whether


```
shopify extension create
```

displays a warning message and subsequently falls back to the legacy flow.

### Post-release steps

None. This is just adding a debug statement.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).
