### PR TITLE
Fix issues with Rails apps after v19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2018](https://github.com/Shopify/shopify-cli/pull/2018): Run theme-check as a code dependency, not a pseudo-CLI invocation
 * [#2211](https://github.com/Shopify/shopify-cli/pull/2211): Fix the `theme open` command to open the theme in the browser
 * [#2183](https://github.com/Shopify/shopify-cli/pull/2183): Improve error message when suspended users run `theme serve`
+* [#2219](https://github.com/Shopify/shopify-cli/pull/2219): Fix issues when creating Rails apps after the release of `shopify_app` v19
 
 ### Added
 * [#2190](https://github.com/Shopify/shopify-cli/pull/2190): Better login experience with spinner

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -642,6 +642,20 @@ module ShopifyCLI
       end
     end
 
+    # Uses bundle to grab the version of a gem
+    #
+    # #### Parameters
+    # - gem: the name of the gem to check
+    #
+    # #### Returns
+    # - version: a Semantic::Version object with the gem version
+    def ruby_gem_version(gem)
+      output, status = capture2e("bundle", "info", gem)
+      abort(message("core.errors.bundle_info_failure", gem)) unless status.success?
+      version = output.match(/\s+\* #{gem} \((\d+\.\d+\.\d+)\)/)[1]
+      ::Semantic::Version.new(version)
+    end
+
     private
 
     def ctx_path(fname)

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "rbconfig"
 require "net/http"
 require "json"
+require "bundler"
 
 module ShopifyCLI
   ##
@@ -650,10 +651,8 @@ module ShopifyCLI
     # #### Returns
     # - version: a Semantic::Version object with the gem version
     def ruby_gem_version(gem)
-      output, status = capture2e("bundle", "info", gem)
-      abort(message("core.errors.bundle_info_failure", gem)) unless status.success?
-      version = output.match(/\s+\* #{gem} \((\d+\.\d+\.\d+)\)/)[1]
-      ::Semantic::Version.new(version)
+      version = Bundler.load.specs.find { |s| s.name == gem }.version
+      ::Semantic::Version.new(version.to_s)
     end
 
     private

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -18,6 +18,7 @@ module ShopifyCLI
           missing_node: "Node.js is required to continue. Install Node.js here: https://nodejs.org/en/download.",
           missing_npm: "npm is required to continue. Install npm here: https://www.npmjs.com/get-npm.",
           missing_ruby: "Ruby is required to continue. Install Ruby here: https://www.ruby-lang.org/en/downloads.",
+          bundle_info_failure: "Error getting version for %s gem",
           option_parser: {
             invalid_option: "The option {{command:%s}} is not supported.",
             invalid_option_store_equals: <<~MESSAGE,

--- a/lib/shopify_cli/services/app/create/rails_service.rb
+++ b/lib/shopify_cli/services/app/create/rails_service.rb
@@ -207,6 +207,12 @@ module ShopifyCLI
           end
 
           def set_custom_ua
+            requires_ua_file = Dir.chdir(context.root) do
+              context.ruby_gem_version("shopify_app") < ::Semantic::Version.new("19.0.0")
+            end
+
+            return unless requires_ua_file
+
             ua_path = File.join("config", "initializers", "user_agent.rb")
             context.write(ua_path, USER_AGENT_CODE)
           end

--- a/lib/shopify_cli/services/app/serve/rails_service.rb
+++ b/lib/shopify_cli/services/app/serve/rails_service.rb
@@ -9,7 +9,7 @@ module ShopifyCLI
             CLI::UI::Frame.open(context.message("core.app.serve.running_server")) do
               original_env = JSON.parse(ENV["ORIGINAL_ENV"] || "{}")
               env = original_env.merge(ShopifyCLI::Project.current.env.to_h)
-              env.delete("HOST")
+              env.delete("HOST") if context.ruby_gem_version("shopify_app") < ::Semantic::Version.new("19.0.0")
               env["PORT"] = port.to_s
               env["GEM_PATH"] =
                 [env["GEM_PATH"], Rails::Gem.gem_path(context)].compact

--- a/test/fixtures/app_types/node/.env
+++ b/test/fixtures/app_types/node/.env
@@ -1,5 +1,5 @@
 SHOPIFY_API_KEY=mykey
 SHOPIFY_API_SECRET=mysecretkey
-HOST=https://example.com
 SHOP=my-test-shop.myshopify.com
 SCOPES=read_products
+HOST=https://example.com

--- a/test/fixtures/app_types/rails/.env
+++ b/test/fixtures/app_types/rails/.env
@@ -1,5 +1,5 @@
 SHOPIFY_API_KEY=api_key
 SHOPIFY_API_SECRET=secret
+SHOP=my-test-shop.myshopify.com
 SCOPES=write_products,write_customers,write_orders
 HOST=https://example.com
-SHOP=my-test-shop.myshopify.com

--- a/test/shopify-cli/services/app/create/rails_service_test.rb
+++ b/test/shopify-cli/services/app/create/rails_service_test.rb
@@ -145,7 +145,7 @@ module ShopifyCLI
 
             assert_equal SHOPIFYCLI_FILE, File.read("test-app/.shopify-cli.yml")
             assert_equal ENV_FILE, File.read("test-app/.env")
-            refute File.exists?("test-app/config/initializers/user_agent.rb")
+            refute File.exist?("test-app/config/initializers/user_agent.rb")
 
             delete_gem_path_and_binaries
             FileUtils.rm_r("test-app")

--- a/test/shopify-cli/services/app/create/rails_service_test.rb
+++ b/test/shopify-cli/services/app/create/rails_service_test.rb
@@ -30,6 +30,7 @@ module ShopifyCLI
             Services::App::Create::RailsService.any_instance.stubs(:check_node).returns(true)
             ShopifyCLI::Tasks::EnsureAuthenticated.stubs(:call)
             ShopifyCLI::Shopifolk.stubs(:acting_as_shopify_organization?).returns(false)
+            @context.stubs(:ruby_gem_version).with("shopify_app").returns(Semantic::Version.new("18.0.0"))
           end
 
           def test_will_abort_if_bad_ruby
@@ -95,7 +96,9 @@ module ShopifyCLI
             FileUtils.rm_r("test-app")
           end
 
-          def test_can_create_new_app
+          def test_skips_user_agent_initializer_after_app_v19
+            @context.stubs(:ruby_gem_version).with("shopify_app").returns(Semantic::Version.new("19.0.0"))
+
             create_mock_dirs
 
             gem_path = create_gem_path_and_binaries
@@ -142,7 +145,7 @@ module ShopifyCLI
 
             assert_equal SHOPIFYCLI_FILE, File.read("test-app/.shopify-cli.yml")
             assert_equal ENV_FILE, File.read("test-app/.env")
-            assert_equal RailsService::USER_AGENT_CODE, File.read("test-app/config/initializers/user_agent.rb")
+            refute File.exists?("test-app/config/initializers/user_agent.rb")
 
             delete_gem_path_and_binaries
             FileUtils.rm_r("test-app")


### PR DESCRIPTION
### WHY are these changes introduced?

We recently released a new major version of the `shopify_app` gem, used by the rails app. In v19, we don't need the CLI to set up the user agent initializer, and we don't need to remove the `HOST` value from the env vars.

### WHAT is this pull request doing?

Adding a new check to get the version of a gem in a project, and using that to tell whether we need to take the above actions when setting up a rails app.

I'm not entirely sure the context is the best place for this check, but I think it's useful enough that it can be quite generic.

### How to test your changes?

By 🎩 ing and via unit tests.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).