### PR TITLE
Remove unneeded test helper

### DIFF
--- a/test/minitest_ext.rb
+++ b/test/minitest_ext.rb
@@ -95,14 +95,6 @@ module Minitest
       end.join("\n")
     end
 
-    def assert_raises_and_validate(exception_class, field_expectation_proc)
-      yield
-    rescue exception_class => e
-      field_expectation_proc.call(e)
-    else
-      flunk("Expected a #{exception_class} to be raised but it was not")
-    end
-
     private
 
     def stub_prompt_for_cli_updates

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -338,10 +338,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "raises NoScriptConfigFileError" do
-          assert_raises_and_validate(
-            Script::Layers::Infrastructure::Errors::NoScriptConfigFileError,
-            proc { |e| assert_equal(script_config_filename, e.filename) }
-          ) { subject }
+          e = assert_raises(Script::Layers::Infrastructure::Errors::NoScriptConfigFileError) { subject }
+          assert_equal(script_config_filename, e.filename)
         end
       end
 
@@ -354,13 +352,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { "*" }
 
           it "raises ScriptConfigParseError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigParseError,
-              proc do |e|
-                assert_equal(script_config_filename, e.filename)
-                assert_equal("YAML", e.serialization_format)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigParseError) { subject }
+            assert_equal(script_config_filename, e.filename)
+            assert_equal("YAML", e.serialization_format)
           end
         end
 
@@ -368,13 +362,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { "[]" }
 
           it "raises ScriptConfigParseError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigParseError,
-              proc do |e|
-                assert_equal(script_config_filename, e.filename)
-                assert_equal("YAML", e.serialization_format)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigParseError) { subject }
+            assert_equal(script_config_filename, e.filename)
+            assert_equal("YAML", e.serialization_format)
           end
         end
 
@@ -382,10 +372,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { {}.to_yaml }
 
           it "raises MissingScriptJsonFieldError" do
-            assert_raises_and_validate(
-              Script::Layers::Domain::Errors::MissingScriptConfigFieldError,
-              proc { |e| assert_equal(script_config_filename, e.filename) },
-            ) { subject }
+            e = assert_raises(Script::Layers::Domain::Errors::MissingScriptConfigFieldError) { subject }
+            assert_equal(script_config_filename, e.filename)
           end
         end
 
@@ -493,10 +481,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
       describe "when file does not exist" do
         it "raises NoScriptConfigFileError" do
-          assert_raises_and_validate(
-            Script::Layers::Infrastructure::Errors::NoScriptConfigFileError,
-            proc { |e| assert_equal(script_config_filename, e.filename) }
-          ) { subject }
+          e = assert_raises(Script::Layers::Infrastructure::Errors::NoScriptConfigFileError) { subject }
+          assert_equal(script_config_filename, e.filename)
         end
       end
 
@@ -509,13 +495,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { "{[}]" }
 
           it "raises ScriptConfigParseError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigParseError,
-              proc do |e|
-                assert_equal(script_config_filename, e.filename)
-                assert_equal("JSON", e.serialization_format)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigParseError) { subject }
+            assert_equal(script_config_filename, e.filename)
+            assert_equal("JSON", e.serialization_format)
           end
         end
 
@@ -523,13 +505,9 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { "[]" }
 
           it "raises ScriptConfigParseError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigParseError,
-              proc do |e|
-                assert_equal(script_config_filename, e.filename)
-                assert_equal("JSON", e.serialization_format)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigParseError) { subject }
+            assert_equal(script_config_filename, e.filename)
+            assert_equal("JSON", e.serialization_format)
           end
         end
 
@@ -537,10 +515,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
           let(:content) { {}.to_json }
 
           it "raises MissingScriptJsonFieldError" do
-            assert_raises_and_validate(
-              Script::Layers::Domain::Errors::MissingScriptConfigFieldError,
-              proc { |e| assert_equal(script_config_filename, e.filename) },
-            ) { subject }
+            e = assert_raises(Script::Layers::Domain::Errors::MissingScriptConfigFieldError) { subject }
+            assert_equal(script_config_filename, e.filename)
           end
         end
 

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -198,13 +198,9 @@ describe Script::Layers::Infrastructure::ScriptService do
         end
 
         it "should raise ScriptConfigurationDefinitionError" do
-          assert_raises_and_validate(
-            Script::Layers::Infrastructure::Errors::ScriptConfigurationDefinitionError,
-            proc do |e|
-              assert_equal(["error1", "error2"], e.messages)
-              assert_equal(script_config_filename, e.filename)
-            end,
-          ) { subject }
+          e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigurationDefinitionError) { subject }
+          assert_equal(["error1", "error2"], e.messages)
+          assert_equal(script_config_filename, e.filename)
         end
       end
 
@@ -224,13 +220,9 @@ describe Script::Layers::Infrastructure::ScriptService do
           let(:error_tag) { "configuration_definition_missing_keys_error" }
 
           it "should raise ScriptConfigMissingKeysError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigMissingKeysError,
-              proc do |e|
-                assert_equal(error_message, e.missing_keys)
-                assert_equal(script_config_filename, e.filename)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigMissingKeysError) { subject }
+            assert_equal(error_message, e.missing_keys)
+            assert_equal(script_config_filename, e.filename)
           end
         end
 
@@ -239,13 +231,9 @@ describe Script::Layers::Infrastructure::ScriptService do
           let(:error_tag) { "configuration_definition_schema_field_missing_keys_error" }
 
           it "should raise ScriptConfigFieldsMissingKeysError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigFieldsMissingKeysError,
-              proc do |e|
-                assert_equal(error_message, e.missing_keys)
-                assert_equal(script_config_filename, e.filename)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigFieldsMissingKeysError) { subject }
+            assert_equal(error_message, e.missing_keys)
+            assert_equal(script_config_filename, e.filename)
           end
         end
 
@@ -254,13 +242,9 @@ describe Script::Layers::Infrastructure::ScriptService do
           let(:error_tag) { "configuration_definition_invalid_value_error" }
 
           it "should raise ScriptConfigInvalidValueError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigInvalidValueError,
-              proc do |e|
-                assert_equal(error_message, e.valid_input_modes)
-                assert_equal(script_config_filename, e.filename)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigInvalidValueError) { subject }
+            assert_equal(error_message, e.valid_input_modes)
+            assert_equal(script_config_filename, e.filename)
           end
         end
 
@@ -269,13 +253,9 @@ describe Script::Layers::Infrastructure::ScriptService do
           let(:error_tag) { "configuration_definition_schema_field_invalid_value_error" }
 
           it "should raise ScriptConfigFieldsInvalidValueError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigFieldsInvalidValueError,
-              proc do |e|
-                assert_equal(error_message, e.valid_types)
-                assert_equal(script_config_filename, e.filename)
-              end,
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigFieldsInvalidValueError) { subject }
+            assert_equal(error_message, e.valid_types)
+            assert_equal(script_config_filename, e.filename)
           end
         end
 
@@ -284,10 +264,8 @@ describe Script::Layers::Infrastructure::ScriptService do
           let(:error_tag) { "configuration_definition_syntax_error" }
 
           it "should raise ScriptConfigSyntaxError" do
-            assert_raises_and_validate(
-              Script::Layers::Infrastructure::Errors::ScriptConfigSyntaxError,
-              proc { |e| assert_equal(script_config_filename, e.filename) },
-            ) { subject }
+            e = assert_raises(Script::Layers::Infrastructure::Errors::ScriptConfigSyntaxError) { subject }
+            assert_equal(script_config_filename, e.filename)
           end
         end
       end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

I did not realize that `assert_raises` returns the error, and I created a test helper method called `assert_raises_and_validate` to help with performing validations on a raised error. Since I learned that `assert_raises` returns the error, I am removing the method.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

Removes `assert_raises_and_validate` method as there is an easier way to achieve the same thing without it.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Run the unit tests

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).