### PR TITLE
[Feature] Adds CanAccessNetwork to checkout extensions config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2190](https://github.com/Shopify/shopify-cli/pull/2190): Better login experience with spinner
+* [#2222](https://github.com/Shopify/shopify-cli/pull/2222): Adds support for `can_access_network` config for checkout extensions
 
 ## Version 2.15.2 - 2022-03-28
 

--- a/lib/project_types/extension/models/server_config/extension.rb
+++ b/lib/project_types/extension/models/server_config/extension.rb
@@ -10,6 +10,7 @@ module Extension
         property! :type, accepts: String
         property! :user, accepts: ServerConfig::User
         property! :development, accepts: ServerConfig::Development
+        property  :can_access_network, accepts: [TrueClass, FalseClass]
         property  :extension_points, accepts: Array
         property  :version, accepts: String
         property  :title, accepts: String

--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -39,6 +39,7 @@ module Extension
               main: hash.dig("development", "entries", "main") || determine_default_entry_main(project_directory),
             )
           ),
+          can_access_network: hash.dig("can_access_network") || false,
           extension_points: hash.dig("extension_points"),
           version: version(renderer.name, context),
           title: title

--- a/test/project_types/extension/tasks/convert_server_config_test.rb
+++ b/test/project_types/extension/tasks/convert_server_config_test.rb
@@ -82,7 +82,7 @@ module Extension
         File.write(project_directory.join("src/index.js"), "")
 
         assert_nothing_raised do
-          Tasks::ConvertServerConfig.call(
+          result = Tasks::ConvertServerConfig.call(
             api_key: @api_key,
             context: @fake_context,
             hash: {},
@@ -92,6 +92,8 @@ module Extension
             tunnel_url: @tunnel_url,
             type: @type
           )
+
+          refute(result.extensions.first.can_access_network)
         end
       ensure
         FileUtils.rm_r(project_directory.join("src/"))
@@ -108,6 +110,7 @@ module Extension
             build_dir: "build"
           extension_points:
             - Checkout::Feature::Render
+          can_access_network: true
         YAML
       end
 
@@ -120,6 +123,7 @@ module Extension
           uuid: @registration_uuid,
           type: @type.upcase,
           user: Models::ServerConfig::User.new,
+          can_access_network: true,
           development: Models::ServerConfig::Development.new(
             build_dir: @build,
             renderer: Models::ServerConfig::DevelopmentRenderer.find(@type),


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves an internal Shopify checkout issue (will link that issue to this PR directly)

The change being shipped is paired with https://github.com/Shopify/shopify-cli-extensions/pull/281

**This PR adds support for adding support for the `can_access_network` config property in `extension.config.yml`, which will be used by extension developers to opt their extensions in to enabling network access.**

### WHAT is this pull request doing?

All changes in this PR are only relevant to Checkout Extensions and hence if the [Extensions Dev Server](https://github.com/Shopify/shopify-cli-extensions) is being used via enabling the `extension_server_beta` feature.

Support for a root-level optional boolean property `can_access_network` has been added to `extension.config.yml`. If this property is not provided, then it defaults to `false`. There is also validation via existing `property` DSL to ensure that a non-boolean attribute will fail-fast.

This config will then be sent forward to the `shopify-cli-extensions` Dev Server, where it will eventually be served up through the `/extensions` JSON endpoint to populate the `canAccessNetwork` property in Checkout, for testing local extensions (ie, through `shopify extension serve`).

No other `shopify` commands should be affected by this change. There should also be no changes to the legacy checkout extensions endpoint, `/query`.

### How to test your changes?

Some new unit tests have been added (**Reviewers' Note:** Are there additional layers of tests that I need to add to or change?)

These changes can also be manually tested. See below for instructions:

<details>
<summary>Manual testing instructions</summary>

### Manual Testing Instructions

When running the below steps, make sure that you are using the local version of `shopify` rather than the production installation. The strategy I took was `alias shopify-local="path/to/shopify-cli/bin/shopify` and replace `shopify` with `shopify-local` for the commands below.

You also may need to login first via `shopify login`, depending on whether you get an error in any of the commands below. And if you still get errors, then you will need to use `shopify login --store STORE`, with STORE replaced by the URL to a development shop.

1. Follow environment setup instructions for both `shopify-cli` and `shopify-cli-extensions`. For Shopify employees, `dev up` will be useful for setting up both projects quickly.
1. Symlink the `shopify-cli-extensions` binary to `shopify-cli` via `rake extensions:install`
1. Enable the extensions dev server feature: `shopify config feature extension_server_beta --enable`
1. Create a new Checkout Extension via `shopify extension create`. Make sure you can select "Checkout Extension" as the type. This will require your Partner Organization and App having some beta flags enabled (refer to internal documentation or talk to @ecbrodie if you need help with this)
1. Modify `extension.config.yml` as necessary in your new extension (see below for test cases)
1. For each test case below, run `shopify extension serve` and observe the result in the extensions endpoint: `https://NGROK-TUNNEL-URL/extensions`. You will need to check the value of the `canAccessNetwork` property for the extension in the JSON. You also need to re-run this command for each test case because there is no hot reloading on config changes.

| Test Cases | Setup | Expected Results |
| ----------- | ------ | ----------------- |
| Test Case 1  | Set `can_access_network: true` in `extension.config.yml`  |  Observe `"canAccessNetwork": true` in the `/extensions` JSON |
| Test Case 2  | Set `can_access_network: false` in `extension.config.yml`  |  Observe `"canAccessNetwork": false` in the `/extensions` JSON |
| Test Case 3  | Omit `can_access_network: false` from `extension.config.yml`  |  Observe `"canAccessNetwork": false` in the `/extensions` JSON |
| Test Case 4 | Set `can_access_network: "nonsense"` in `extension.config.yml`  |  `shopify extension serve` will error out (prepend the command with `SHOPIFY_CLI_STACKTRACE=1` to see the stack trace) |

</details>

### Post-release steps

We need to ensure that https://github.com/Shopify/shopify-cli-extensions/pull/281 is shipped at the same time as this PR. We also need to ensure that we package the latest version of the `shopify-cli-extensions` binary in with `shopify-cli` during our next release.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).