### PR TITLE
Fix changelog parsing and reading

### DIFF
--- a/lib/shopify_cli/changelog.rb
+++ b/lib/shopify_cli/changelog.rb
@@ -104,6 +104,8 @@ module ShopifyCLI
           if line.chomp == "\#\# [Unreleased]"
             state = :unreleased
             current_version = "Unreleased"
+            # Ensure Unreleased changeset exists even if no changes have happened yet
+            changes["Unreleased"]
           else
             @heading << line
           end

--- a/lib/shopify_cli/release.rb
+++ b/lib/shopify_cli/release.rb
@@ -90,7 +90,7 @@ module ShopifyCLI
         "main",
         release_branch_name,
         "Packaging for release v#{new_version}",
-        release_notes("Unreleased")
+        release_notes(new_version)
       ).tap { |results| puts "Created #{repo} PR ##{results["number"]}" }
     end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes some issues spotted in #2220 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
I noticed 2 problems:

1. The build failed because the generated changelog when there are no Unreleased contents doesn't include an Unreleased section.
2. The release notes weren't present.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Fixes:

1. Force an Unreleased section to be created during changelog parsing
2. The release notes were missing because following [these changes](https://github.com/Shopify/shopify-cli/pull/2197/commits/0d345d5a924e2917331d37fd2de47411d42a84df) we are actually reloading the changelog in memory during version update. So we shouldn't pull the version changes from the Unreleased section, but rather from the newly created `new_version` section.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
1. The tests should cover it (and are actually probably the only situation where this would actually break!)
2. I'm pretty confident in the change, but I guess we'll get confirmation next release.

### Update checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).