### PR TITLE
Packaging for release v2.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.15.3 - 2022-04-07
+
 ### Changed
 * [#2188](https://github.com/Shopify/shopify-cli/pull/2188): Update URLs by default on serve and add --no-update flag to skip it
 * [#2203](https://github.com/Shopify/shopify-cli/pull/2203): Use javy version 0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.15.2)
+    shopify-cli (2.15.3)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.1)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.15.2"
+  VERSION = "2.15.3"
 end


### PR DESCRIPTION
### Changed
* [#2188](https://github.com/Shopify/shopify-cli/pull/2188): Update URLs by default on serve and add --no-update flag to skip it
* [#2203](https://github.com/Shopify/shopify-cli/pull/2203): Use javy version 0.3.0

### Fixed
* [#2162](https://github.com/Shopify/shopify-cli/pull/2162): Improve encoding error handling for Checkout Extension localization
* [#2187](https://github.com/Shopify/shopify-cli/pull/2187): Fix app serve after rails update
* [#2191](https://github.com/Shopify/shopify-cli/pull/2191): Directories with the `.json` extension should not be handled as JSON files
* [#2018](https://github.com/Shopify/shopify-cli/pull/2018): Run theme-check as a code dependency, not a pseudo-CLI invocation
* [#2211](https://github.com/Shopify/shopify-cli/pull/2211): Fix the `theme open` command to open the theme in the browser
* [#2183](https://github.com/Shopify/shopify-cli/pull/2183): Improve error message when suspended users run `theme serve`
* [#2219](https://github.com/Shopify/shopify-cli/pull/2219): Fix issues when creating Rails apps after the release of `shopify_app` v19

### Added
* [#2190](https://github.com/Shopify/shopify-cli/pull/2190): Better login experience with spinner
* [#2200](https://github.com/Shopify/shopify-cli/pull/2200): Add `theme share` command
