### PR TITLE
[Theme App Extension] - Fix liquid file size validation to disclude locales directory

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -38,7 +38,10 @@ module Extension
                   # Other assets should be treated as UTF-8 encoded text
                   mode = "rt"
                   encoding = "UTF-8"
-                  current_liquid_size += File.size(filename)
+
+                  if dirname == "snippets" || dirname == "blocks"
+                    current_liquid_size += File.size(filename)
+                  end
                 end
                 current_size += File.size(filename)
                 if current_size > BUNDLE_SIZE_LIMIT

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -145,6 +145,16 @@ module Extension
           end
         end
 
+        def test_locales_does_not_impact_liquid_limit
+          stub_const(ThemeAppExtension, :LIQUID_SIZE_LIMIT, 50) do
+            write("locales/en.default.json", "1" * 25)
+            write("locales/en.default.schema.json", "2" * 26)
+            assert_nothing_raised do
+              @spec.config(@context)
+            end
+          end
+        end
+
         private
 
         def write(filename, content, mode: "w", encoding: "utf-8")


### PR DESCRIPTION
# WHY are these changes introduced?

Fixes [346424](https://github.com/Shopify/shopify/issues/346424) which is a bug that includes locales directory in the liquid file size validation.

# WHAT is this pull request doing?
1. Adding a condition to only increment the total size for liquid files for blocks and snippets directory within a theme app extension

# How to test your changes?
Push your theme app extension code and ensure that the locales file size is not counted towards the validation for the maximum of 100KB for liquid files.

# Post-release steps
1. Follow up with the partner to ensure that they are no longer having an issue with the `locales` directory being counted towards the maximum of 100KB for liquid files

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).