### PR TITLE
Show an error without ngrok account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2230](https://github.com/Shopify/shopify-cli/pull/2230): Show an error without ngrok account
+
 ## Version 2.15.3 - 2022-04-07
 
 ### Changed

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -760,16 +760,12 @@ module ShopifyCLI
               " package manager for your system.",
             ngrok: "Something went wrong with ngrok installation,"\
               "please make sure %s exists within %s before trying again",
+            signup_required: "A free ngrok account is required: {{underline:https://ngrok.com/signup}}. After you "\
+              "signup, install your personal authorization token using {{command:%s app tunnel auth <token>}}.",
           },
           installing: "Installing ngrok…",
           not_running: "{{green:x}} ngrok tunnel not running",
           prereq_command_location: "%s @ %s",
-          signup_suggestion: <<~MESSAGE,
-            {{*}} To avoid tunnels that timeout, it is recommended to signup for a free ngrok
-            account at {{underline:https://ngrok.com/signup}}. After you signup, install your
-            personalized authorization token using {{command:%s app tunnel auth <token>}}.
-          MESSAGE
-          start: "{{v}} ngrok tunnel running at {{underline:%s}}",
           start_with_account: "{{v}} ngrok tunnel running at {{underline:%s}}, with account %s",
           stopped: "{{green:x}} ngrok tunnel stopped",
           timed_out: "{{x}} ngrok tunnel has timed out, restarting…",

--- a/lib/shopify_cli/tunnel.rb
+++ b/lib/shopify_cli/tunnel.rb
@@ -66,14 +66,9 @@ module ShopifyCLI
     #
     def start(ctx, port: PORT)
       install(ctx)
-      if authenticated?
-        url, account = start_ngrok(ctx, port)
-        ctx.puts(ctx.message("core.tunnel.start_with_account", url, account))
-      else
-        url, _ = restart_ngrok(ctx, port)
-        ctx.puts(ctx.message("core.tunnel.start", url))
-        ctx.puts(ctx.message("core.tunnel.signup_suggestion", ShopifyCLI::TOOL_NAME))
-      end
+      ctx.abort(ctx.message("core.tunnel.error.signup_required", ShopifyCLI::TOOL_NAME)) unless authenticated?
+      url, account = start_ngrok(ctx, port)
+      ctx.puts(ctx.message("core.tunnel.start_with_account", url, account))
       url
     end
 
@@ -206,11 +201,6 @@ module ShopifyCLI
       process = ShopifyCLI::ProcessSupervision.start(:ngrok, ngrok_command)
       log = fetch_url(ctx, process.log_path)
       [log.url, log.account]
-    end
-
-    def restart_ngrok(ctx, port)
-      ShopifyCLI::ProcessSupervision.stop(:ngrok)
-      start_ngrok(ctx, port)
     end
 
     def check_prereq_command(ctx, command)

--- a/test/fixtures/ngrok.log
+++ b/test/fixtures/ngrok.log
@@ -1,4 +1,4 @@
-t=2019-03-26T14:45:57-0400 lvl=dbug msg="decoded response" obj=csess id=63b552dbb648 sid=3 resp="&{Version:2 ClientID:640713d23ff34283f8d9c211fb8f2839 Error: Extra:{Version:prod Cookie:redacted AccountName: SessionDuration:28799 PlanName:Free}}" err=nil
+t=2019-08-09T15:35:57-0400 lvl=dbug msg="decoded response" obj=csess id=63b552dbb648 sid=3 resp="&{Version:2 ClientID:640713d23ff34283f8d9c211fb8f2839 Error: Extra:{Version:prod Cookie:redacted AccountName:Tom Cruise SessionDuration:0 PlanName:Free}}" err=nil
 t=2019-03-26T14:45:57-0400 lvl=dbug msg="start tunnel listen" obj=tunnels.session name="command_line (http)" proto=http opts="&{Hostname:example.ngrok.io Auth: Subdomain: HostHeaderRewrite:false LocalURLScheme:http}" err=nil
 t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name="command_line (http)" addr=http://localhost:8081 url=http://example.ngrok.io
 t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name=command_line addr=http://localhost:8081 url=https://example.ngrok.io

--- a/test/fixtures/ngrok_account.log
+++ b/test/fixtures/ngrok_account.log
@@ -1,4 +1,0 @@
-t=2019-08-09T15:35:57-0400 lvl=dbug msg="decoded response" obj=csess id=63b552dbb648 sid=3 resp="&{Version:2 ClientID:640713d23ff34283f8d9c211fb8f2839 Error: Extra:{Version:prod Cookie:redacted AccountName:Tom Cruise SessionDuration:0 PlanName:Free}}" err=nil
-t=2019-03-26T14:45:57-0400 lvl=dbug msg="start tunnel listen" obj=tunnels.session name="command_line (http)" proto=http opts="&{Hostname:example.ngrok.io Auth: Subdomain: HostHeaderRewrite:false LocalURLScheme:http}" err=nil
-t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name="command_line (http)" addr=http://localhost:8081 url=http://example.ngrok.io
-t=2019-03-26T14:45:57-0400 lvl=info msg="started tunnel" obj=tunnels name=command_line addr=http://localhost:8081 url=https://example.ngrok.io


### PR DESCRIPTION
### WHY are these changes introduced?

@Arkham realized we are recommending to create an ngrok account, but it's mandatory now (the tunnel won't work)

### WHAT is this pull request doing?

When there is no authentication, abort and show an error.

Before:
![before](https://user-images.githubusercontent.com/14979109/162401487-c2c4fbf4-1d2e-4e45-8a3c-b8a95eb45937.png)

After:
![after](https://user-images.githubusercontent.com/14979109/162401515-665ec6d2-86da-4d53-8c44-9d26cf00250b.png)

### How to test your changes?

Remove your ngrok token (`~/.ngrok2/ngrok.yml`) and run `shopify app serve`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).