### PR TITLE
updated beacon_extension to use JSON.pretty_generate over hash.to_json

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/beacon_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/beacon_extension.rb
@@ -46,7 +46,7 @@ module Extension
             runtime_context: access_config_property(context, ext_config, "runtime_context"),
             serialized_script: Base64.strict_encode64(script_contents),
             runtime_configuration_definition: access_config_property(context, ext_config,
-              "configuration", &:to_json),
+              "configuration") { |config_def_hash| JSON.pretty_generate(config_def_hash) },
             config_version: access_config_property(context, ext_config,
               "version", &:to_s),
           }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->
Fixes: https://github.com/Shopify/shopify-cli/issues/2227

Context: 
<img width="643" alt="image" src="https://user-images.githubusercontent.com/66790620/162433644-07f1c2e4-b000-4873-8ec4-2c6cfd4540bf.png">



### WHAT is this pull request doing?

updating the use of `$HASH.to_json` to use `JSON.pretty_generate($HASH)`

### How to test your changes?



### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).