### PR TITLE
Fix Homebrew Wrapper

### DIFF
--- a/packaging/homebrew/shopify-cli.base.rb
+++ b/packaging/homebrew/shopify-cli.base.rb
@@ -97,7 +97,7 @@ class ShopifyCli < Formula
     file = Pathname.new("#{brew_gem_prefix}/bin/#{exe}")
     (bin + file.basename).open("w") do |f|
       f << <<~RUBY
-        #!#{ruby_bin}/ruby --disable-gems
+        #!#{ruby_bin}/ruby -rjson --disable-gems
         ENV['ORIGINAL_ENV']=ENV.to_h.to_json
         ENV['GEM_HOME']="#{prefix}"
         ENV['GEM_PATH']="#{prefix}"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2227


### WHAT is this pull request doing?

Ensuring that we require the JSON library before first use.

### How to test your changes?

I actually don't know how to exactly test this change without releasing a new version. I created an example script that looked as follows to make sure that the `-r` flag behaves as expected:

```ruby
#!/usr/bin/env ruby -rjson

puts({a: 1}.to_json)
```

Testing instructions:

```
git checkout fix/homebrew-wrapper
rake build
rake package
cd packaging/builds/2.15.4
brew uninstall shopify-cli
brew install --formula ./shopify-cli.rb
/opt/homebrew/bin/shopify version # => 2.15.4 (Haven't bumped the version yet)
```

The script excuted as expected and output some JSON. Removing `-rjson` breaks the script.


### Update checklist

- [ ] ~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~~I've included any post-release steps in the section above (if needed).~~
