### PR TITLE
Revert "Extension serve port selection"

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -14,9 +14,6 @@ module Extension
         parser.on("--resourceUrl=RESOURCE_URL", "Provide a resource URL") do |resource_url|
           flags[:resource_url] = resource_url
         end
-        parser.on("-p", "--port=PORT", "Specify the port to use") do |port|
-          flags[:port] = port.to_i
-        end
       end
 
       class RuntimeConfiguration
@@ -25,14 +22,13 @@ module Extension
         property :tunnel_url, accepts: String, default: nil
         property :resource_url, accepts: String, default: nil
         property! :tunnel_requested, accepts: [true, false], reader: :tunnel_requested?, default: true
-        property :port, accepts: (1...(2**16))
+        property! :port, accepts: (1...(2**16)), default: DEFAULT_PORT
       end
 
       def call(_args, _command_name)
         config = RuntimeConfiguration.new(
           tunnel_requested: tunnel_requested?,
-          resource_url: options.flags[:resource_url],
-          port: options.flags[:port]
+          resource_url: options.flags[:resource_url]
         )
 
         ShopifyCLI::Result
@@ -55,11 +51,10 @@ module Extension
       end
 
       def find_available_port(runtime_configuration)
-        return runtime_configuration unless runtime_configuration.port.nil?
         return runtime_configuration unless specification_handler.choose_port?(@ctx)
 
         chosen_port = Tasks::ChooseNextAvailablePort
-          .call(from: DEFAULT_PORT)
+          .call(from: runtime_configuration.port)
           .unwrap { |_error| @ctx.abort(@ctx.message("serve.no_available_ports_found")) }
         runtime_configuration.tap { |c| c.port = chosen_port }
       end

--- a/lib/project_types/extension/features/argo_serve.rb
+++ b/lib/project_types/extension/features/argo_serve.rb
@@ -9,7 +9,7 @@ module Extension
       property! :specification_handler, accepts: Extension::Models::SpecificationHandlers::Default
       property :argo_runtime, accepts: -> (runtime) { runtime.class < Features::Runtimes::Base }
       property! :context, accepts: ShopifyCLI::Context
-      property! :port, accepts: Integer
+      property! :port, accepts: Integer, default: ShopifyCLI::Constants::Extension::DEFAULT_PORT
       property  :tunnel_url, accepts: String, default: nil
       property! :js_system, accepts: ->(jss) { jss.respond_to?(:call) }, default: ShopifyCLI::JsSystem
       property :resource_url, accepts: String, default: nil

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -194,9 +194,6 @@ module Extension
         "{{command:%1$s extension connect}} " \
         "or run {{command:%1$s extension register}} to register a new extension.",
         module_not_found: "Unable to find module %s. Ensure your dependencies are up-to-date and try again.",
-        development_server_binary_not_found: <<~ERROR,
-          Development server binary not found! If you're running a development version of the CLI, please run `rake extensions:install` to install it. Otherwise, please file a bug report via https://github.com/Shopify/shopify-cli/issues/new.
-        ERROR
       },
       warnings: {
         resource_url_auto_generation_failed: "{{*}} {{yellow:Warning:}} Unable to auto generate " \

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -14,13 +14,7 @@ module Extension
 
       class << self
         def supported?(type)
-          if type_supported?(type) && type_enabled?(type)
-            return true if binary_installed?
-
-            context.debug(context.message("errors.development_server_binary_not_found"))
-          end
-
-          false
+          binary_installed? && type_supported?(type) && type_enabled?(type)
         end
 
         def beta_enabled?
@@ -40,10 +34,6 @@ module Extension
         # Some types are enabled unconditionally; others require beta_enabled
         def type_enabled?(type)
           beta_enabled? || "checkout_ui_extension" == type.downcase
-        end
-
-        def context
-          @context ||= ShopifyCLI::Context.new
         end
       end
     end

--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -9,7 +9,7 @@ module Extension
       property! :api_key, accepts: String
       property! :context, accepts: ShopifyCLI::Context
       property! :hash, accepts: Hash
-      property! :port, accepts: Integer
+      property  :port, accepts: Integer, default: ShopifyCLI::Constants::Extension::DEFAULT_PORT
       property! :registration_uuid, accepts: String
       property  :resource_url, accepts: String
       property! :store, accepts: String

--- a/lib/project_types/extension/tasks/merge_server_config.rb
+++ b/lib/project_types/extension/tasks/merge_server_config.rb
@@ -10,7 +10,7 @@ module Extension
 
       property! :context, accepts: ShopifyCLI::Context
       property! :file_path, accepts: ->(path) { Pathname(path).yield_self(&:absolute?) }
-      property! :port, accepts: Integer
+      property  :port, accepts: Integer, default: ShopifyCLI::Constants::Extension::DEFAULT_PORT
       property  :resource_url, accepts: String
       property  :tunnel_url, accepts: String
       property! :type, accepts: Models::DevelopmentServerRequirements::SUPPORTED_EXTENSION_TYPES
@@ -33,8 +33,7 @@ module Extension
           store: project.env.shop || "",
           title: project.title,
           tunnel_url: tunnel_url,
-          type: type,
-          port: port
+          type: type
         )
       rescue Psych::SyntaxError => e
         raise(

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -100,7 +100,7 @@ module Extension
       def test_resource_url_is_forwarded_to_specification_handler_if_one_is_provided
         serve = ::Extension::Command::Serve.new(@context)
         expected_resource_url = "foo/bar"
-        stub_specification_handler_options(serve, choose_port: true)
+        stub_specification_handler_options(serve)
 
         serve.specification_handler
           .expects(:serve)

--- a/test/project_types/extension/features/argo_serve_test.rb
+++ b/test/project_types/extension/features/argo_serve_test.rb
@@ -18,8 +18,7 @@ module Extension
           context: @context,
           argo_runtime: admin_ui_extension_runtime,
           specification_handler: specification_handler,
-          js_system: fake_js_system,
-          port: 1234,
+          js_system: fake_js_system
         )
 
         argo_serve.expects(:validate_env!).once
@@ -32,8 +31,7 @@ module Extension
           context: @context,
           argo_runtime: admin_ui_extension_runtime,
           specification_handler: specification_handler,
-          js_system: fake_js_system(success: false),
-          port: 1234,
+          js_system: fake_js_system(success: false)
         )
 
         argo_serve.expects(:validate_env!).once
@@ -64,8 +62,7 @@ module Extension
           context: @context,
           argo_runtime: checkout_ui_extension_runtime,
           specification_handler: specification_handler,
-          js_system: js_system,
-          port: 1234,
+          js_system: js_system
         )
 
         argo_serve.call
@@ -88,8 +85,7 @@ module Extension
           argo_runtime: checkout_ui_extension_runtime,
           specification_handler: specification_handler,
           js_system: js_system,
-          resource_url: "/provided",
-          port: 1234,
+          resource_url: "/provided"
         )
 
         argo_serve.call

--- a/test/project_types/extension/tasks/convert_server_config_test.rb
+++ b/test/project_types/extension/tasks/convert_server_config_test.rb
@@ -31,8 +31,7 @@ module Extension
           store: @store,
           title: @title,
           tunnel_url: @tunnel_url,
-          type: @type,
-          port: 1234
+          type: @type
         )
 
         extension = result.extensions.first
@@ -53,8 +52,7 @@ module Extension
           store: @store,
           title: @title,
           tunnel_url: @tunnel_url,
-          type: @type,
-          port: 1234
+          type: @type
         )
 
         extension = result.extensions.first
@@ -72,8 +70,7 @@ module Extension
           store: @store,
           title: @title,
           tunnel_url: @tunnel_url,
-          type: @type,
-          port: 1234
+          type: @type
         )
 
         assert_equal(resource_url, result.extensions.first.development.resource.url)
@@ -93,8 +90,7 @@ module Extension
             store: @store,
             title: @title,
             tunnel_url: @tunnel_url,
-            type: @type,
-            port: 1234
+            type: @type
           )
         end
       ensure


### PR DESCRIPTION
Reverts Shopify/shopify-cli#2228

This change broke `shopify extension build`. 