### PR TITLE
Fix callback urls for app serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2246](https://github.com/Shopify/shopify-cli/pull/2246): Fix callback urls for app serve
+
 ## Version 2.15.5 - 2022-04-08
 
 ### Fixed

--- a/lib/shopify_cli/services/app/serve/serve_service.rb
+++ b/lib/shopify_cli/services/app/serve/serve_service.rb
@@ -36,7 +36,7 @@ module ShopifyCLI
             ShopifyCLI::Tasks::UpdateDashboardURLS.call(
               context,
               url: project.env.host,
-              callback_url: "/auth/shopify/callback",
+              callback_urls: %w(/auth/shopify/callback /auth/callback),
             )
           end
 

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module ShopifyCLI
   module Tasks
     class UpdateDashboardURLS < ShopifyCLI::Task

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -44,9 +44,11 @@ module ShopifyCLI
 
       private
 
-      def already_updated(app, constructed_urls, url)
-        app["applicationUrl"].match(url) &&
-          Set.new(constructed_urls) == Set.new(app["redirectUrlWhitelist"])
+      def already_updated(app, new_redirect_urls, new_url)
+        current_url = app["applicationUrl"]
+        current_redirect_urls = app["redirectUrlWhitelist"]
+        current_url.match(new_url) &&
+          Set.new(current_redirect_urls) == Set.new(new_redirect_urls)
       end
     end
   end

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -1,4 +1,4 @@
-require 'set'
+require "set"
 
 module ShopifyCLI
   module Tasks

--- a/lib/shopify_cli/tasks/update_dashboard_urls.rb
+++ b/lib/shopify_cli/tasks/update_dashboard_urls.rb
@@ -10,9 +10,10 @@ module ShopifyCLI
         result = ShopifyCLI::PartnersAPI.query(ctx, "get_app_urls", apiKey: api_key)
         app = result["data"]["app"]
 
-        return if app["applicationUrl"].match(url)
-
         constructed_urls = construct_redirect_urls(app["redirectUrlWhitelist"], url, callback_urls)
+
+        return if already_updated(app, constructed_urls, url)
+
         ShopifyCLI::PartnersAPI.query(@ctx, "update_dashboard_urls", input: {
           applicationUrl: url,
           redirectUrlWhitelist: constructed_urls,
@@ -39,6 +40,13 @@ module ShopifyCLI
           end
         end
         new_urls.uniq
+      end
+
+      private
+
+      def already_updated(app, constructed_urls, url)
+        app["applicationUrl"].match(url) &&
+          Set.new(constructed_urls) == Set.new(app["redirectUrlWhitelist"])
       end
     end
   end

--- a/test/shopify-cli/services/app/serve/node_service_test.rb
+++ b/test/shopify-cli/services/app/serve/node_service_test.rb
@@ -18,7 +18,11 @@ module ShopifyCLI
           end
 
           def test_call
-            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).with(
+              @context,
+              url: "https://example.com",
+              callback_urls: %w(/auth/shopify/callback /auth/callback)
+            )
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.expects(:system).with(
               "npm run dev",

--- a/test/shopify-cli/services/app/serve/php_service_test.rb
+++ b/test/shopify-cli/services/app/serve/php_service_test.rb
@@ -18,7 +18,11 @@ module ShopifyCLI
           end
 
           def test_server_command
-            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).with(
+              @context,
+              url: "https://example.com",
+              callback_urls: %w(/auth/shopify/callback /auth/callback)
+            )
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             ShopifyCLI::ProcessSupervision.expects(:running?).with(:npm_watch).returns(false)
             ShopifyCLI::ProcessSupervision.expects(:stop).never

--- a/test/shopify-cli/services/app/serve/rails_service_test.rb
+++ b/test/shopify-cli/services/app/serve/rails_service_test.rb
@@ -20,7 +20,11 @@ module ShopifyCLI
           end
 
           def test_server_command
-            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call)
+            ShopifyCLI::Tasks::UpdateDashboardURLS.expects(:call).with(
+              @context,
+              url: "https://example.com",
+              callback_urls: %w(/auth/shopify/callback /auth/callback)
+            )
             ShopifyCLI::Resources::EnvFile.any_instance.expects(:update)
             @context.stubs(:getenv).with("GEM_HOME").returns("/gem/path")
             @context.stubs(:getenv).with("GEM_PATH").returns("/gem/path")

--- a/test/shopify-cli/tasks/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/tasks/update_dashboard_urls_test.rb
@@ -28,7 +28,7 @@ module ShopifyCLI
         ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://123abc.ngrok.io",
-          callback_url: "/callback/fake",
+          callback_urls: ["/callback/fake"],
         )
         assert_requested(get_request)
       end
@@ -67,7 +67,7 @@ module ShopifyCLI
         ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
-          callback_url: "/callback/fake",
+          callback_urls: ["/callback/fake"],
         )
         assert_requested(get_request)
         assert_requested(update_request)
@@ -113,7 +113,7 @@ module ShopifyCLI
         ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
-          callback_url: "/callback/fake",
+          callback_urls: ["/callback/fake"],
         )
         assert_requested(get_request)
         assert_requested(update_request)
@@ -152,7 +152,51 @@ module ShopifyCLI
         ShopifyCLI::Tasks::UpdateDashboardURLS.call(
           @context,
           url: "https://newone123.ngrok.io",
-          callback_url: "/callback/fake",
+          callback_urls: ["/callback/fake"],
+        )
+        assert_requested(get_request)
+        assert_requested(update_request)
+      end
+
+      def test_multiple_callbacks
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "1234", secret: "foo"))
+        api_key = "1234"
+        get_request = stub_partner_req(
+          "get_app_urls",
+          variables: {
+            apiKey: api_key,
+          },
+          resp: {
+            data: {
+              app: {
+                applicationUrl: "https://oldone123.ngrok.io",
+                redirectUrlWhitelist: [
+                  "https://123abc.ngrok.io",
+                  "https://newone123.ngrok.io/callback/fake",
+                ],
+              },
+            },
+          },
+        )
+
+        update_request = stub_partner_req(
+          "update_dashboard_urls",
+          variables: {
+            input: {
+              applicationUrl: "https://newone123.ngrok.io",
+              redirectUrlWhitelist: [
+                "https://newone123.ngrok.io",
+                "https://newone123.ngrok.io/callback/fake",
+                "https://newone123.ngrok.io/callback/shopify/fake",
+              ],
+              apiKey: api_key,
+            },
+          },
+        )
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
+          @context,
+          url: "https://newone123.ngrok.io",
+          callback_urls: ["/callback/fake", "/callback/shopify/fake"],
         )
         assert_requested(get_request)
         assert_requested(update_request)

--- a/test/shopify-cli/tasks/update_dashboard_urls_test.rb
+++ b/test/shopify-cli/tasks/update_dashboard_urls_test.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     class UpdateDashboardURLSTest < MiniTest::Test
       include TestHelpers::Partners
 
-      def test_url_is_not_transformed_if_same
+      def test_url_is_not_transformed_if_same_url_and_callbacks
         Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
         api_key = "123"
         get_request = stub_partner_req(
@@ -31,6 +31,49 @@ module ShopifyCLI
           callback_urls: ["/callback/fake"],
         )
         assert_requested(get_request)
+      end
+
+      def test_url_is_not_transformed_if_same_url_and_different_callbacks
+        Project.current.stubs(:env).returns(Resources::EnvFile.new(api_key: "123", secret: "foo"))
+        api_key = "123"
+        get_request = stub_partner_req(
+          "get_app_urls",
+          variables: {
+            apiKey: api_key,
+          },
+          resp: {
+            data: {
+              app: {
+                applicationUrl: "https://123abc.ngrok.io/",
+                redirectUrlWhitelist: [
+                  "https://123abc.ngrok.io",
+                  "https://123abc.ngrok.io/callback/fake",
+                ],
+              },
+            },
+          },
+        )
+        update_request = stub_partner_req(
+          "update_dashboard_urls",
+          variables: {
+            input: {
+              applicationUrl: "https://123abc.ngrok.io",
+              redirectUrlWhitelist: [
+                "https://123abc.ngrok.io",
+                "https://123abc.ngrok.io/callback/fake",
+                "https://123abc.ngrok.io/callback/shopify/fake",
+              ],
+              apiKey: api_key,
+            },
+          },
+        )
+        ShopifyCLI::Tasks::UpdateDashboardURLS.call(
+          @context,
+          url: "https://123abc.ngrok.io",
+          callback_urls: ["/callback/shopify/fake", "/callback/fake"],
+        )
+        assert_requested(get_request)
+        assert_requested(update_request)
       end
 
       def test_url_is_transformed_if_different_and_callback_is_appended


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Related to [#1367 ](https://github.com/Shopify/shopify_app/issues/1367), [#198 ](https://github.com/Shopify/first-party-library-planning/issues/198)


After we run `shopify app serve` and accessing the url generated by the CLI we receive error 400


### WHAT is this pull request doing?
- Added functionality to support both callback paths: `"/auth/shopify/callback"` and `"/auth/callback"`  

### How to test your changes?

1. Go to App Setup  -> Edit 
2. Replace `Allowed redirection URL(s)` values with `https://google.com/`
3. From your local app directory start the server:
```ruby
shopify app serve
```
Accessing the generated url works as expected

### Post-release steps

_none_

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).