### PR TITLE
Packaging for release v2.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.15.6 - 2022-04-12
+
 ### Fixed
 * [#2246](https://github.com/Shopify/shopify-cli/pull/2246): Fix callback urls for app serve
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.15.5)
+    shopify-cli (2.15.6)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.1)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.15.5"
+  VERSION = "2.15.6"
 end


### PR DESCRIPTION
### Fixed
* [#2246](https://github.com/Shopify/shopify-cli/pull/2246): Fix callback urls for app serve
