### PR TITLE
version bump checkout-ui-extensions 0.15.0

### DIFF
--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -20,7 +20,7 @@ module Extension
           when "product_subscription"
             new(name: "@shopify/admin-ui-extensions", version: "^1.0.1")
           when "checkout_ui_extension"
-            new(name: "@shopify/checkout-ui-extensions", version: "^0.14.0")
+            new(name: "@shopify/checkout-ui-extensions", version: "^0.15.0")
           when "checkout_post_purchase"
             new(name: "@shopify/post-purchase-ui-extensions", version: "^0.13.2")
           end

--- a/test/project_types/extension/models/npm_package_test.rb
+++ b/test/project_types/extension/models/npm_package_test.rb
@@ -62,7 +62,7 @@ module Extension
         package_json = StringIO.new(<<~JSON)
           {
             "dependencies": {
-              "@shopify/checkout-ui-extensions": "^0.14.0"
+              "@shopify/checkout-ui-extensions": "^0.15.0"
             },
             "devDependencies": {
               "@shopify/shopify-cli-extensions": "latest"
@@ -80,7 +80,7 @@ module Extension
         assert_equal "checkout_ui_extension", package.name
         assert_equal "shopify-cli-extensions build", package.scripts.fetch("build")
         assert_equal "shopify-cli-extensions develop", package.scripts.fetch("develop")
-        assert_equal "^0.14.0", package.dependencies.fetch("@shopify/checkout-ui-extensions")
+        assert_equal "^0.15.0", package.dependencies.fetch("@shopify/checkout-ui-extensions")
         assert_equal "latest", package.dev_dependencies.fetch("@shopify/shopify-cli-extensions")
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR updates the version of `@shopify/checkout-ui-extensions` used in template generation to `^0.15.0`.

For reference as to what changes are `0.15.0` [please see this PR](https://github.com/Shopify/ui-extensions/pull/284).

### WHAT is this pull request doing?
Ups the version number.

### How to test your changes?
1. Clone this patch locally.
2. Alias to your local cli install `alias shopifyl='DEBUG=1 SHOPIFY_CLI_DEVELOPMENT=1 SHOPIFY_CLI_STACKTRACE=1 $HOME/src/github.com/Shopify/shopify-cli/bin/shopify'`
3. Run `shopifyl extension create` to initialize a new extension project.
4. Verify the contents of `package.json` and that the version of `@shopify/checkout-ui-extensions` is `^0.15.0`.
![Screen Shot 2022-04-12 at 11 17 12 AM](https://user-images.githubusercontent.com/12719665/162995911-c314e2bc-2713-47aa-8576-2b96c22ea322.png)

### Post-release steps
N/A

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).