### PR TITLE
Add shipping rate presenter API

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -16,6 +16,11 @@ shipping_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
+shipping_rate_presenter:
+  domain: 'checkout'
+  libraries:
+    wasm:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
 merchandise_discount_types:
   beta: true
   domain: 'discounts'


### PR DESCRIPTION
### WHY are these changes introduced?

Issue: https://github.com/Shopify/script-service/issues/4620

We're renaming this API to Shipping Rate Presenter to avoid confusion with upcoming Shipping APIs.


### WHAT is this pull request doing?

I've added this API as a net new API. Once everything is in place for this new API, I'll delete the old one.

### How to test your changes?

WIP

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).