### PR TITLE
allow unknown languages

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -7,6 +7,8 @@ payment_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_methods:
   domain: 'checkout'
   libraries:

--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -137,8 +137,6 @@ module Script
           end
         end
 
-        class ProjectCreatorNotFoundError < ScriptProjectError; end
-
         class SystemCallFailureError < ScriptProjectError
           attr_reader :out, :cmd
           def initialize(out:, cmd:)
@@ -157,7 +155,6 @@ module Script
         end
 
         class ScriptProjectAlreadyExistsError < ScriptProjectError; end
-        class TaskRunnerNotFoundError < ScriptProjectError; end
         class BuildScriptNotFoundError < ScriptProjectError; end
 
         class WebAssemblyBinaryNotFoundError < ScriptProjectError

--- a/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
@@ -26,7 +26,7 @@ module Script
               "wasm" => WasmProjectCreator,
             }
 
-            project_creator = project_creators[language] || ProjectCreator
+            project_creator = project_creators[language] || WasmProjectCreator
 
             project_creator.new(
               ctx: ctx,

--- a/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/project_creator.rb
@@ -26,8 +26,9 @@ module Script
               "wasm" => WasmProjectCreator,
             }
 
-            raise Errors::ProjectCreatorNotFoundError unless project_creators[language]
-            project_creators[language].new(
+            project_creator = project_creators[language] || ProjectCreator
+
+            project_creator.new(
               ctx: ctx,
               type: type,
               project_name: project_name,

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -13,8 +13,7 @@ module Script
               "wasm" => WasmTaskRunner,
             }
 
-            task_runner = task_runners[language] || TaskRunner
-
+            task_runner = task_runners[language] || WasmTaskRunner
             task_runner.new(ctx)
           end
 
@@ -22,22 +21,24 @@ module Script
             @ctx = ctx
           end
 
-          def build; end
+          def build
+            raise NotImplementedError
+          end
 
           def dependencies_installed?
-            true
+            raise NotImplementedError
           end
 
-          def install_dependencies; end
+          def install_dependencies
+            raise NotImplementedError
+          end
 
-          # this should be removed soon
           def metadata_file_location
-            "metadata.json"
+            raise NotImplementedError
           end
 
-          # this should be removed soon
           def library_version(_library_name)
-            "1.0.0"
+            raise NotImplementedError
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -13,32 +13,31 @@ module Script
               "wasm" => WasmTaskRunner,
             }
 
-            raise Errors::TaskRunnerNotFoundError unless task_runners[language]
-            task_runners[language].new(ctx)
+            task_runner = task_runners[language] || TaskRunner
+
+            task_runner.new(ctx)
           end
 
           def initialize(ctx)
             @ctx = ctx
           end
 
-          def build
-            raise NotImplementedError
-          end
+          def build; end
 
           def dependencies_installed?
-            raise NotImplementedError
+            true
           end
 
-          def install_dependencies
-            raise NotImplementedError
-          end
+          def install_dependencies; end
 
+          # this should be removed soon
           def metadata_file_location
-            raise NotImplementedError
+            "build/metadata.json"
           end
 
+          # this should be removed soon
           def library_version(_library_name)
-            raise NotImplementedError
+            "1.0.0"
           end
         end
       end

--- a/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
+++ b/lib/project_types/script/layers/infrastructure/languages/task_runner.rb
@@ -32,7 +32,7 @@ module Script
 
           # this should be removed soon
           def metadata_file_location
-            "build/metadata.json"
+            "metadata.json"
           end
 
           # this should be removed soon

--- a/test/project_types/script/layers/infrastructure/languages/project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/project_creator_test.rb
@@ -70,8 +70,8 @@ describe Script::Layers::Infrastructure::Languages::ProjectCreator do
     describe "when the script language doesn't match an entry in the registry" do
       let(:language) { "ArnoldC" }
 
-      it "should return a project creator" do
-        assert_instance_of(Script::Layers::Infrastructure::Languages::ProjectCreator, subject)
+      it "should return a wasm project creator" do
+        assert_instance_of(Script::Layers::Infrastructure::Languages::WasmProjectCreator, subject)
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/project_creator_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/project_creator_test.rb
@@ -70,8 +70,8 @@ describe Script::Layers::Infrastructure::Languages::ProjectCreator do
     describe "when the script language doesn't match an entry in the registry" do
       let(:language) { "ArnoldC" }
 
-      it "should raise dependency not supported error" do
-        assert_raises(Script::Layers::Infrastructure::Errors::ProjectCreatorNotFoundError) { subject }
+      it "should return a project creator" do
+        assert_instance_of(Script::Layers::Infrastructure::Languages::ProjectCreator, subject)
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
@@ -21,7 +21,10 @@ describe Script::Layers::Infrastructure::Languages::TaskRunner do
       let(:language) { "imaginary" }
 
       it "should raise a builder not found error" do
-        assert_raises(Script::Layers::Infrastructure::Errors::TaskRunnerNotFoundError) { subject }
+        Script::Layers::Infrastructure::Languages::TaskRunner
+          .expects(:new)
+          .with(@context)
+        subject
       end
     end
   end

--- a/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
+++ b/test/project_types/script/layers/infrastructure/languages/task_runner_test.rb
@@ -20,8 +20,8 @@ describe Script::Layers::Infrastructure::Languages::TaskRunner do
     describe "when the script language and compile type doesn't match an entry in the registry" do
       let(:language) { "imaginary" }
 
-      it "should raise a builder not found error" do
-        Script::Layers::Infrastructure::Languages::TaskRunner
+      it "should return the wasm task runner" do
+        Script::Layers::Infrastructure::Languages::WasmTaskRunner
           .expects(:new)
           .with(@context)
         subject


### PR DESCRIPTION
### WHY are these changes introduced?

I want to be able to use the CLI to create scripts from templates that don't yet have full support, like Rust, Zig, Go, etc.

The CLI currently has a lot of language specific code that makes that slow. As a result I'd have to make the script manually, then start using the tool again.

Pending the results of [this discussion](https://github.com/Shopify/script-service/discussions/4647), we might not have any language based code in the CLI long term anyway.

### WHAT is this pull request doing?

In cases that we do have a template for a language in scripts-apis-examples, but don't have CLI specific support, we just no-op on all the operations that would set up that language for your machine.

After this is merged, we'll be able to use Rust payment method scripts in the CLI.

### How to test your changes?

Try making a rust script:
```
shopify-dev script create --title=payment-rust-test8 --api=payment_methods --language=rust
```

### Post-release steps

No need, this is all in beta.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).