### PR TITLE
[Bug] Fix a bundler crash when running `bin/shopify help`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.3.8)
+  bundler (~> 2.3.11)
   byebug
   colorize (~> 0.8.1)
   cucumber (~> 7.0)
@@ -187,4 +187,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.8
+   2.3.11

--- a/Tests.dockerfile
+++ b/Tests.dockerfile
@@ -6,7 +6,7 @@ FROM cimg/ruby:2.7.5
 RUN git config --global user.email "development-lifecycle@shopify.com"
 RUN git config --global user.name "Development Lifecycle"
 
-RUN gem update bundler
+RUN gem install bundler -v 2.3.11
 
 WORKDIR /usr/src/app
 

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib", "vendor"]
   spec.executables << "shopify"
 
-  spec.add_development_dependency("bundler", "~> 2.3.8")
+  spec.add_development_dependency("bundler", "~> 2.3.11")
   spec.add_development_dependency("rake", "~> 12.3", ">= 12.3.3")
   spec.add_development_dependency("minitest", "~> 5.0")
 


### PR DESCRIPTION

Ran `bundle update --bundler` to bump to the latest bundler which fixed a bundler crash.

### WHY are these changes introduced?


Fixes a crash when running `bin/shopify help` on a fresh git pull of the main branch.
```
[58918, #<Thread:0x000000010504cd28 run>, #<NameError: uninitialized constant Gem::Source

      (defined?(@source) && @source) || Gem::Source::Installed.new
                                           ^^^^^^^^
```

Pulls [in this fix from ruby gems](https://github.com/rubygems/rubygems/pull/5386).




### WHAT is this pull request doing?

Setup before:
- Bundler 2.3.8 with Ruby 3.1.0 my M1 crashed running bin/shopify help

Setup after:
- Bundler 2.3.11 with Ruby 3.1.0 my M1 crashed running bin/shopify help

### How to test your changes?

Run `bundle` in the repo after checking out this branch.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).