### PR TITLE
[Feature] Add `capabilities` permissions to checkout extensions config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#2262](https://github.com/Shopify/shopify-cli/pull/2262): Add `capabilities` permissions to checkout extensions config
+
 ## Version 2.16.1 - 2022-04-26
 
 ### Fixed

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -122,6 +122,7 @@ module Extension
     module ServerConfig
       autoload :Base, Project.project_filepath("models/server_config/base")
       autoload :App, Project.project_filepath("models/server_config/app")
+      autoload :Capabilities, Project.project_filepath("models/server_config/capabilities")
       autoload :Development, Project.project_filepath("models/server_config/development")
       autoload :DevelopmentEntries, Project.project_filepath("models/server_config/development_entries")
       autoload :DevelopmentRenderer, Project.project_filepath("models/server_config/development_renderer")

--- a/lib/project_types/extension/models/server_config/capabilities.rb
+++ b/lib/project_types/extension/models/server_config/capabilities.rb
@@ -1,0 +1,11 @@
+module Extension
+  module Models
+    module ServerConfig
+      class Capabilities < Base
+        include SmartProperties
+
+        property :network_access, accepts: [true, false], default: false
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/server_config/extension.rb
+++ b/lib/project_types/extension/models/server_config/extension.rb
@@ -10,6 +10,7 @@ module Extension
         property! :type, accepts: String
         property! :user, accepts: ServerConfig::User
         property! :development, accepts: ServerConfig::Development
+        property  :capabilities, accepts: ServerConfig::Capabilities
         property  :extension_points, accepts: Array
         property  :version, accepts: String
         property  :title, accepts: String
@@ -26,7 +27,10 @@ module Extension
               template: template,
               renderer: renderer,
               entries: entry
-            )
+            ),
+            capabilities: ServerConfig::Capabilities.new(
+              network_access: false
+            ),
           )
         end
 

--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -15,7 +15,7 @@ module Extension
            (?<region>[a-zA-Z]{2}) # Optional region subtag
           )?
           \z}x
-        PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name]
+        PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name, :capabilities]
 
         def config(context)
           {

--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -27,7 +27,6 @@ module Extension
         context.abort(context.message("tasks.errors.parse_error")) if hash.nil?
 
         renderer = Models::ServerConfig::DevelopmentRenderer.find(type)
-
         extension = Models::ServerConfig::Extension.new(
           uuid: registration_uuid,
           type: type.upcase,
@@ -40,6 +39,9 @@ module Extension
             )
           ),
           extension_points: hash.dig("extension_points"),
+          capabilities: Models::ServerConfig::Capabilities.new(
+            network_access: hash.dig("capabilities", "network_access") || false
+          ),
           version: renderer ? version(renderer.name, context) : nil,
           title: title
         )

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -92,7 +92,7 @@ module Extension
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig
             .expects(:parse_yaml)
-            .with(@context, [:extension_points, :metafields, :name])
+            .with(@context, [:extension_points, :metafields, :name, :capabilities])
             .once
             .returns({})
 

--- a/test/project_types/extension/tasks/convert_server_config_test.rb
+++ b/test/project_types/extension/tasks/convert_server_config_test.rb
@@ -13,6 +13,7 @@ module Extension
         @config_file = YAML.load(mock_extension_config_yaml)
         @entry_main = "src/index.js"
         @extension_points = ["Checkout::Feature::Render"]
+        @network_access = true
         @fake_context = TestHelpers::FakeContext.new
         @registration_uuid = "00000000-0000-0000-0000-000000000000"
         @store = "my-test-store"
@@ -82,7 +83,7 @@ module Extension
         File.write(project_directory.join("src/index.js"), "")
 
         assert_nothing_raised do
-          Tasks::ConvertServerConfig.call(
+          result = Tasks::ConvertServerConfig.call(
             api_key: @api_key,
             context: @fake_context,
             hash: {},
@@ -92,6 +93,8 @@ module Extension
             tunnel_url: @tunnel_url,
             type: @type
           )
+
+          refute(result.extensions.first.capabilities.network_access)
         end
       ensure
         FileUtils.rm_r(project_directory.join("src/"))
@@ -108,6 +111,8 @@ module Extension
             build_dir: "build"
           extension_points:
             - Checkout::Feature::Render
+          capabilities:
+            network_access: true
         YAML
       end
 
@@ -128,6 +133,9 @@ module Extension
             )
           ),
           extension_points: @extension_points,
+          capabilities: Models::ServerConfig::Capabilities.new(
+            network_access: @network_access
+          ),
           version: @version,
           title: @title
         )


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves internal Shopify issue, should be paired with: https://github.com/Shopify/shopify-cli-extensions/pull/288.

Thanks to @ecbrodie for pairing!

Adds support for a `capabilities` dictionary within an extension's `extension.config.yml`, this dict will expand but for now includes only the `network_access` with a boolean flag.

### WHAT is this pull request doing?

All changes in this PR are only relevant to Checkout Extensions and hence if the [Extensions Dev Server](https://github.com/Shopify/shopify-cli-extensions) is being used via enabling the `extension_server_beta` feature.

No other `shopify` commands should be affected by this change. There should also be no changes to the legacy checkout extensions endpoint, `/query`.

### How to test your changes?

<details>
<summary>Manual testing instructions</summary>

### Manual Testing Instructions

When running the below steps, make sure that you are using the local version of `shopify` rather than the production installation. The strategy I took was `alias shopifydev="path/to/shopify-cli/bin/shopify` and replace `shopify` with `shopifydev` for the commands below.

1. Follow environment setup instructions for both `shopify-cli` and `shopify-cli-extensions`. For Shopify employees, `dev up` will be useful for setting up both projects quickly.
1. Symlink the `shopify-cli-extensions` binary to `shopify-cli` via `rake extensions:symlink`
1. Enable the extensions dev server feature: `shopify config feature extension_server_beta --enable`
1. Create a new Checkout Extension via `shopify extension create`. Make sure you can select "Checkout Extension" as the type. This will require your Partner Organization and App having some beta flags enabled (refer to internal documentation or talk to @ecbrodie if you need help with this)
1. Modify `extension.config.yml` as necessary in your new extension (see below for test cases)
1. For each test case below, run `shopify extension serve` and observe the result in the extensions endpoint: `https://NGROK-TUNNEL-URL/extensions`. You will need to check the value of the `capabilities` list for the extension in the JSON. You also need to re-run this command for each test case because there is no hot reloading on config changes.

| Test Cases | Setup | Expected Results |
| ----------- | ------ | ----------------- |
| Test Case 1  | Set `capabilities: network_access:true` in `extension.config.yml`  |  Observe `"capabilities": {"network_access": true}` in the `/extensions` JSON |
| Test Case 2  | Omit `capabilities` in `extension.config.yml`  |  Observe `"capabilities": {"network_access": false}` in the `/extensions` JSON |
| Test Case 3 | Set `capabilities: { "network_access": "I shall throw"}` in `extension.config.yml`  |  `shopify extension serve` will error out (prepend the command with `SHOPIFY_CLI_STACKTRACE=1` to see the stack trace) |

</details>

### Post-release steps

* ship with https://github.com/Shopify/shopify-cli-extensions/pull/288.
* package the latest version of the `shopify-cli-extensions` binary in with `shopify-cli` during next release.

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).