### PR TITLE
[Feature]: Adding POS UI Extension configuration into Shopify CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2189](https://github.com/Shopify/shopify-cli/pull/2189): Retrieve latest CLI version in the background
+* [#2263](https://github.com/Shopify/shopify-cli/pull/2263): Add `POS UI Extension` to support third party developers to extend POS smart grid functionality using native retail components. 
 
 ## Version 2.15.6 - 2022-04-12
 
 ### Fixed
-* [#2246](https://github.com/Shopify/shopify-cli/pull/2246): Fix callback urls for app serve
+* [#2246](https://github.com/Shopify/shopify-cli/pull/2246): Fix callback urls for app serve 
 
 ## Version 2.15.5 - 2022-04-08
 

--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -10,6 +10,7 @@ module Extension
         "checkout_post_purchase",
         "product_subscription",
         "beacon_extension",
+        "pos_ui_extension",
       ]
 
       class << self

--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -10,6 +10,7 @@ module Extension
           "@shopify/admin-ui-extensions",
           "@shopify/post-purchase-ui-extensions",
           "@shopify/checkout-ui-extensions",
+          "@shopify/retail-ui-extensions",
         ]
 
         property! :name, accepts: VALID_RENDERERS
@@ -23,6 +24,10 @@ module Extension
             new(name: "@shopify/checkout-ui-extensions", version: "^0.15.0")
           when "checkout_post_purchase"
             new(name: "@shopify/post-purchase-ui-extensions", version: "^0.13.2")
+          when "pos_ui_extension"
+            new(name: "@shopify/retail-ui-extensions", version: "^0.1.0")
+          else
+            raise ArgumentError, "Unknown extension type: #{type}"
           end
         end
       end

--- a/lib/project_types/extension/tasks/configure_features.rb
+++ b/lib/project_types/extension/tasks/configure_features.rb
@@ -62,6 +62,10 @@ module Extension
             required_fields: [:shop],
             cli_package_name: "@shopify/checkout-ui-extensions-run",
           },
+          point_of_sale: {
+            git_template: "",
+            renderer_package_name: "@shopify/retail-ui-extensions",
+          },
         }
       end
     end

--- a/test/project_types/extension/models/development_server_requirements_test.rb
+++ b/test/project_types/extension/models/development_server_requirements_test.rb
@@ -10,6 +10,7 @@ module Extension
         "checkout_post_purchase",
         "product_subscription",
         "beacon_extension",
+        "pos_ui_extension",
       ]
 
       def setup

--- a/test/project_types/extension/models/server_config/development_renderer_test.rb
+++ b/test/project_types/extension/models/server_config/development_renderer_test.rb
@@ -25,7 +25,7 @@ module Extension
         end
 
         def test_find_sets_specific_versions
-          %w[product_subscription checkout_ui_extension checkout_post_purchase].each do |type|
+          %w[product_subscription checkout_ui_extension checkout_post_purchase pos_ui_extension].each do |type|
             renderer = ServerConfig::DevelopmentRenderer.find(type)
             refute_nil renderer
             refute_equal("latest", renderer.version)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2195

As we are developing `retail-ui-extension` for POS, we want 3P developers to install our package within Shopify CLI. `POS UI Extension` option needs to show up when the 3P developer runs command `shopify extension create`.

### WHAT is this pull request doing?

Added a new extension point and also surface area to render. Surface area does not need `git template` as we added the extension template into `shopify-cli-extension` (PR : https://github.com/Shopify/shopify-cli-extensions/pull/286)


### How to test your changes?

Tested against development build. Here is the video: https://videobin.shopify.io/v/P0XEke
Steps:
1. Created a `extensions` spin environment which will automatically run all dependent process in a single spin environment.
2. Switched partner repo to `pos-ui-extensions` from `master`. (PR: https://github.com/Shopify/partners/pull/38956)
3. Clone Shopify-cli-extension and switched to `pos-ui-extension-cli-extension` from `main`. Then, follow the development build process https://github.com/Shopify/shopify-cli-extensions#testing-the-integration-with-the-shopify-cli
4. One running the extensions, Shopify development build will show up to test.

### Post-release steps

We are preparing the documentation that will go in `shopify.dev`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above (if needed).