### PR TITLE
Add 2 new env vars: Admin token & store

### DIFF
--- a/lib/shopify_cli/admin_api.rb
+++ b/lib/shopify_cli/admin_api.rb
@@ -98,6 +98,8 @@ module ShopifyCLI
       end
 
       def get_shop_or_abort(ctx)
+        envStore = Environment.store
+        return envStore unless envStore.nil?
         ctx.abort(
           ctx.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME)
         ) unless ShopifyCLI::DB.exists?(:shop)
@@ -119,7 +121,8 @@ module ShopifyCLI
       end
 
       def access_token(ctx, shop)
-        ShopifyCLI::DB.get(:shopify_exchange_token) do
+        envToken = Environment.admin_auth_token
+        envToken || ShopifyCLI::DB.get(:shopify_exchange_token) do
           authenticate(ctx, shop)
           ShopifyCLI::DB.get(:shopify_exchange_token)
         end

--- a/lib/shopify_cli/admin_api.rb
+++ b/lib/shopify_cli/admin_api.rb
@@ -98,8 +98,8 @@ module ShopifyCLI
       end
 
       def get_shop_or_abort(ctx)
-        envStore = Environment.store
-        return envStore unless envStore.nil?
+        env_store = Environment.store
+        return env_store unless env_store.nil?
         ctx.abort(
           ctx.message("core.populate.error.no_shop", ShopifyCLI::TOOL_NAME)
         ) unless ShopifyCLI::DB.exists?(:shop)
@@ -121,8 +121,8 @@ module ShopifyCLI
       end
 
       def access_token(ctx, shop)
-        envToken = Environment.admin_auth_token
-        envToken || ShopifyCLI::DB.get(:shopify_exchange_token) do
+        env_token = Environment.admin_auth_token
+        env_token || ShopifyCLI::DB.get(:shopify_exchange_token) do
           authenticate(ctx, shop)
           ShopifyCLI::DB.get(:shopify_exchange_token)
         end

--- a/lib/shopify_cli/constants.rb
+++ b/lib/shopify_cli/constants.rb
@@ -53,9 +53,11 @@ module ShopifyCLI
 
       # Authentication
       AUTH_TOKEN = "SHOPIFY_CLI_AUTH_TOKEN"
+      ADMIN_AUTH_TOKEN = "SHOPIFY_CLI_ADMIN_AUTH_TOKEN"
 
       # Monorail
       MONORAIL_REAL_EVENTS = "MONORAIL_REAL_EVENTS"
+      STORE = "SHOPIFY_CLI_STORE"
     end
 
     module SupportedVersions

--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -166,6 +166,14 @@ module ShopifyCLI
       env_variables[Constants::EnvironmentVariables::AUTH_TOKEN]
     end
 
+    def self.admin_auth_token(env_variables: ENV)
+      env_variables[Constants::EnvironmentVariables::ADMIN_AUTH_TOKEN]
+    end
+
+    def self.store(env_variables: ENV)
+      env_variables[Constants::EnvironmentVariables::STORE]
+    end
+
     def self.env_variable_truthy?(variable_name, env_variables: ENV)
       TRUTHY_ENV_VARIABLE_VALUES.include?(env_variables[variable_name.to_s])
     end

--- a/test/shopify-cli/admin_api_test.rb
+++ b/test/shopify-cli/admin_api_test.rb
@@ -61,6 +61,21 @@ module ShopifyCLI
       )
     end
 
+    def test_query_uses_env_token_if_available
+      Environment.stubs(:admin_auth_token).returns("env_token")
+      api_stub = stub
+      AdminAPI.expects(:new).with(
+        ctx: @context,
+        token: "env_token",
+        url: "https://my-test-shop.myshopify.com/admin/api/2019-04/graphql.json",
+      ).returns(api_stub)
+      api_stub.expects(:query).with("query", variables: {}).returns("response")
+      assert_equal(
+        "response",
+        AdminAPI.query(@context, "query", shop: "my-test-shop.myshopify.com", api_version: "2019-04"),
+      )
+    end
+
     def test_query_can_reauth
       ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("token123").then.returns("token456")
       api_stub = stub

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -151,6 +151,32 @@ module ShopifyCLI
       assert_equal "token", got
     end
 
+    def test_admin_auth_token_returns_the_right_value
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::ADMIN_AUTH_TOKEN.to_s => "admin_token",
+      }
+
+      # When
+      got = Environment.admin_auth_token(env_variables: env_variables)
+
+      # Then
+      assert_equal "admin_token", got
+    end
+
+    def test_store_returns_the_right_value
+      # Given
+      env_variables = {
+        Constants::EnvironmentVariables::STORE.to_s => "store",
+      }
+
+      # When
+      got = Environment.store(env_variables: env_variables)
+
+      # Then
+      assert_equal "store", got
+    end
+
     def test_use_local_partners_instance_returns_false_when_the_env_variable_is_not_set
       # Given/When
       got = Environment.use_local_partners_instance?(env_variables: {})


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
We need a way to execute some commands (that need Admin API access) without any interaction.
With this PR we introduce two new Environment variables that allow us to set a **store** and a **token** (with access to that store).

If provided, a command like `theme pull` will ignore any cached session/store and use the ones from the environment.


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add `SHOPIFY_CLI_ADMIN_AUTH_TOKEN` to inject a custom admin token and avoid the auth process.
- Add `SHOPIFY_CLI_STORE` so all Admin requests use this store, the user must have access to this store.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Execute this command to get the list of themes of the given store.
`SHOPIFY_CLI_ADMIN_AUTH_TOKEN={your_token} SHOPIFY_CLI_STORE={store-name}.myshopify.com bundle exec shopify theme pull`

The provided {your_token} must grant access to {store-name}.
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).