### PR TITLE
[Improve] Use ignore filter regex in watcher class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+* [#2270](https://github.com/Shopify/shopify-cli/pull/2270): Use ignore filter regex in watcher class
+
 ### Added
 * [#2189](https://github.com/Shopify/shopify-cli/pull/2189): Retrieve latest CLI version in the background
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
 * [#2270](https://github.com/Shopify/shopify-cli/pull/2270): Use ignore filter regex in watcher class
 
 ### Added

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -32,7 +32,7 @@ module ShopifyCLI
           theme = DevelopmentTheme.find_or_create!(ctx, root: root)
           ignore_filter = IgnoreFilter.from_path(root)
           @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync)
-          watcher = Watcher.new(ctx, theme: theme, syncer: @syncer, poll: poll)
+          watcher = Watcher.new(ctx, theme: theme, ignore_filter: ignore_filter, syncer: @syncer, poll: poll)
           remote_watcher = RemoteWatcher.to(theme: theme, syncer: @syncer)
 
           # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -19,6 +19,8 @@ module ShopifyCLI
             notify_observers(modified, added, removed)
           end
 
+          @ignore_filter.regexes.each { |ignore| @listener.ignore ignore }
+
           add_observer(self, :upload_files_when_changed)
         end
 

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -14,12 +14,11 @@ module ShopifyCLI
           @theme = theme
           @syncer = syncer
           @ignore_filter = ignore_filter
-          @listener = Listen.to(@theme.root, force_polling: poll) do |modified, added, removed|
+          @listener = Listen.to(@theme.root, force_polling: poll,
+            ignore: @ignore_filter&.regexes) do |modified, added, removed|
             changed
             notify_observers(modified, added, removed)
           end
-
-          @ignore_filter&.regexes&.each { |regex| @listener.ignore(regex) }
 
           add_observer(self, :upload_files_when_changed)
         end

--- a/lib/shopify_cli/theme/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/dev_server/watcher.rb
@@ -19,7 +19,7 @@ module ShopifyCLI
             notify_observers(modified, added, removed)
           end
 
-          @ignore_filter.regexes.each { |ignore| @listener.ignore ignore }
+          @ignore_filter&.regexes&.each { |regex| @listener.ignore(regex) }
 
           add_observer(self, :upload_files_when_changed)
         end


### PR DESCRIPTION
### WHY are these changes introduced?

It didn't make sense that regexes in `.shopifyignore` did not cause the watcher to also ignore those folders.

### WHAT is this pull request doing?

Pass the `IgnoreFilter` class to the watcher class to ignore relevant folders. This will affect theme development functionality.

### How to test your changes?

Default ignore folders and folders in `.shopifyignore` should not be watched anymore.

No more node_modules issues.
![Screen Shot 2022-04-20 at 11 36 27 AM](https://user-images.githubusercontent.com/1567160/164289814-63ae4373-bb1c-4e19-a4d6-e807644fa98b.png)

No more 404 messages from non theme related Shopify files.
![Screen Shot 2022-04-20 at 11 36 56 AM](https://user-images.githubusercontent.com/1567160/164289882-5dd60a4a-2a49-46ed-b4de-83998fc0b5d1.png)

### Post-release steps


### Update checklist

- [X]  I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X]  I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X]  I've left the version number as is (we'll handle incrementing this when releasing).
- [X]  I've included any post-release steps in the section above (if needed).