### PR TITLE
[Feature]: Changed interactive apps list scope for extension create|register|connect commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#2189](https://github.com/Shopify/shopify-cli/pull/2189): Retrieve latest CLI version in the background
 
+### Changed
+* [#2272](https://github.com/Shopify/shopify-cli/pull/2272): [Feature]: Changed interactive apps list scope for extension create|register|connect commands
+
 ## Version 2.15.6 - 2022-04-12
 
 ### Fixed

--- a/lib/graphql/find_organization_with_apps.graphql
+++ b/lib/graphql/find_organization_with_apps.graphql
@@ -1,0 +1,30 @@
+query FindOrg($id: ID!) {
+  organizations(id: $id) {
+    nodes {
+      id
+      businessName
+      website
+      apps(first: 500) {
+        nodes {
+          id
+          title
+          apiKey
+          apiSecretKeys {
+            secret
+          }
+          appType
+        }
+      }
+      stores(first: 500) {
+        nodes {
+          shopId
+          link
+          shopDomain
+          shopName
+          transferDisabled
+          convertableToPartnerTest
+        }
+      }
+    }
+  }
+}

--- a/lib/graphql/find_organization_with_apps.graphql
+++ b/lib/graphql/find_organization_with_apps.graphql
@@ -1,5 +1,5 @@
 query FindOrg($id: ID!) {
-  organizations(id: $id) {
+  organizations(id: $id, first: 1) {
     nodes {
       id
       businessName
@@ -13,16 +13,6 @@ query FindOrg($id: ID!) {
             secret
           }
           appType
-        }
-      }
-      stores(first: 500) {
-        nodes {
-          shopId
-          link
-          shopDomain
-          shopName
-          transferDisabled
-          convertableToPartnerTest
         }
       }
     }

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -5,7 +5,7 @@ module Extension
   module Tasks
     class GetApps < ShopifyCLI::Task
       def call(context:)
-        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_app(context)
+        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_all_with_apps(context)
         apps_from_organizations(organizations)
       end
 

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -8,7 +8,7 @@ module Extension
         org_id = ShopifyCLI::DB.get(:organization_id)
         return [] unless org_id
 
-        organization = ShopifyCLI::PartnersAPI::Organizations.fetch_with_apps(context, id: org_id).first
+        organization = ShopifyCLI::PartnersAPI::Organizations.fetch_with_apps(context, id: org_id)
         apps_owned_by_organization(organization)
       end
 

--- a/lib/project_types/extension/tasks/get_extensions.rb
+++ b/lib/project_types/extension/tasks/get_extensions.rb
@@ -5,7 +5,10 @@ module Extension
   module Tasks
     class GetExtensions < ShopifyCLI::Task
       def call(context:, type:)
-        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type)
+        org_id = ShopifyCLI::DB.get(:organization_id)
+        return [] unless org_id
+
+        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type, id: org_id)
         extensions_from_organizations(organizations, context: context)
       end
 

--- a/lib/project_types/extension/tasks/get_extensions.rb
+++ b/lib/project_types/extension/tasks/get_extensions.rb
@@ -9,14 +9,13 @@ module Extension
         return [] unless org_id
 
         organization = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type, id: org_id)
+        return [] unless organization_with_apps?(organization)
         extensions_owned_by_organization(organization, context: context)
       end
 
       private
 
       def extensions_owned_by_organization(organization, context:)
-        return [] unless organization.key?("apps") && organization["apps"].any?
-
         organization["apps"].flat_map do |app|
           registrations = app["extensionRegistrations"] || []
           registrations.map do |registration|
@@ -24,6 +23,10 @@ module Extension
              Converters::RegistrationConverter.from_hash(context, registration)]
           end
         end
+      end
+
+      def organization_with_apps?(organization)
+        organization&.key?("apps") && organization["apps"].any?
       end
     end
   end

--- a/lib/project_types/extension/tasks/get_extensions.rb
+++ b/lib/project_types/extension/tasks/get_extensions.rb
@@ -24,7 +24,8 @@ module Extension
         return [] unless organization.key?("apps") && organization["apps"].any?
 
         organization["apps"].flat_map do |app|
-          app["extensionRegistrations"].map do |registration|
+          registrations = app["extensionRegistrations"] || []
+          registrations.map do |registration|
             [Converters::AppConverter.from_hash(app, organization),
              Converters::RegistrationConverter.from_hash(context, registration)]
           end

--- a/lib/project_types/extension/tasks/get_extensions.rb
+++ b/lib/project_types/extension/tasks/get_extensions.rb
@@ -8,17 +8,11 @@ module Extension
         org_id = ShopifyCLI::DB.get(:organization_id)
         return [] unless org_id
 
-        organizations = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type, id: org_id)
-        extensions_from_organizations(organizations, context: context)
+        organization = ShopifyCLI::PartnersAPI::Organizations.fetch_with_extensions(context, type, id: org_id)
+        extensions_owned_by_organization(organization, context: context)
       end
 
       private
-
-      def extensions_from_organizations(organizations, context:)
-        organizations.flat_map do |organization|
-          extensions_owned_by_organization(organization, context: context)
-        end
-      end
 
       def extensions_owned_by_organization(organization, context:)
         return [] unless organization.key?("apps") && organization["apps"].any?

--- a/lib/project_types/script/layers/application/connect_app.rb
+++ b/lib/project_types/script/layers/application/connect_app.rb
@@ -21,7 +21,7 @@ module Script
               if partner_proxy_bypass
                 stubbed_org
               else
-                orgs = ShopifyCLI::PartnersAPI::Organizations.fetch_with_app(ctx)
+                orgs = ShopifyCLI::PartnersAPI::Organizations.fetch_all_with_apps(ctx)
                 Forms::AskOrg.ask(ctx, orgs, nil).org
               end
 

--- a/lib/shopify_cli/partners_api/app_extensions.rb
+++ b/lib/shopify_cli/partners_api/app_extensions.rb
@@ -8,19 +8,19 @@ module ShopifyCLI
   class PartnersAPI
     class AppExtensions
       class << self
-        def fetch_apps_extensions(ctx, orgs, type)
-          jobs = apps(orgs).map { |app| AppExtensions::Job.new(ctx, app, type) }
+        def fetch_apps_extensions(ctx, org, type)
+          jobs = apps(org).map { |app| AppExtensions::Job.new(ctx, app, type) }
 
           consume_jobs!(jobs)
           patch_apps_with_extensions!(jobs)
 
-          orgs
+          org
         end
 
         private
 
-        def apps(orgs)
-          orgs.flat_map { |org| org["apps"] }
+        def apps(org)
+          (org && org["apps"]) || []
         end
 
         def consume_jobs!(jobs)

--- a/lib/shopify_cli/partners_api/organizations.rb
+++ b/lib/shopify_cli/partners_api/organizations.rb
@@ -36,8 +36,8 @@ module ShopifyCLI
           end
         end
 
-        def fetch_with_extensions(ctx, type)
-          organizations = fetch_all_with_apps(ctx)
+        def fetch_with_extensions(ctx, type, id:)
+          organizations = fetch_with_apps(ctx, id: id)
           AppExtensions.fetch_apps_extensions(ctx, organizations, type)
         end
       end

--- a/lib/shopify_cli/partners_api/organizations.rb
+++ b/lib/shopify_cli/partners_api/organizations.rb
@@ -27,6 +27,15 @@ module ShopifyCLI
           end
         end
 
+        def fetch_with_apps(ctx, id:)
+          resp = PartnersAPI.query(ctx, "find_organization_with_apps", id: id)
+          (resp&.dig("data", "organizations", "nodes") || []).map do |org|
+            org["stores"] = (org.dig("stores", "nodes") || [])
+            org["apps"] = (org.dig("apps", "nodes") || [])
+            org
+          end
+        end
+
         def fetch_with_extensions(ctx, type)
           organizations = fetch_all_with_apps(ctx)
           AppExtensions.fetch_apps_extensions(ctx, organizations, type)

--- a/lib/shopify_cli/partners_api/organizations.rb
+++ b/lib/shopify_cli/partners_api/organizations.rb
@@ -29,16 +29,15 @@ module ShopifyCLI
 
         def fetch_with_apps(ctx, id:)
           resp = PartnersAPI.query(ctx, "find_organization_with_apps", id: id)
-          (resp&.dig("data", "organizations", "nodes") || []).map do |org|
-            org["stores"] = (org.dig("stores", "nodes") || [])
-            org["apps"] = (org.dig("apps", "nodes") || [])
-            org
-          end
+          organization = resp&.dig("data", "organizations", "nodes")&.first
+          return unless organization
+
+          organization.tap { organization["apps"] = (organization.dig("apps", "nodes") || []) }
         end
 
         def fetch_with_extensions(ctx, type, id:)
-          organizations = fetch_with_apps(ctx, id: id)
-          AppExtensions.fetch_apps_extensions(ctx, organizations, type)
+          organization = fetch_with_apps(ctx, id: id)
+          AppExtensions.fetch_apps_extensions(ctx, organization, type)
         end
       end
     end

--- a/lib/shopify_cli/partners_api/organizations.rb
+++ b/lib/shopify_cli/partners_api/organizations.rb
@@ -18,7 +18,7 @@ module ShopifyCLI
           org
         end
 
-        def fetch_with_app(ctx)
+        def fetch_all_with_apps(ctx)
           resp = PartnersAPI.query(ctx, "all_orgs_with_apps")
           (resp&.dig("data", "organizations", "nodes") || []).map do |org|
             org["stores"] = (org.dig("stores", "nodes") || [])
@@ -28,8 +28,8 @@ module ShopifyCLI
         end
 
         def fetch_with_extensions(ctx, type)
-          orgs = fetch_with_app(ctx)
-          AppExtensions.fetch_apps_extensions(ctx, orgs, type)
+          organizations = fetch_all_with_apps(ctx)
+          AppExtensions.fetch_apps_extensions(ctx, organizations, type)
         end
       end
     end

--- a/lib/shopify_cli/tasks/ensure_env.rb
+++ b/lib/shopify_cli/tasks/ensure_env.rb
@@ -25,7 +25,7 @@ module ShopifyCLI
         if Shopifolk.check && wants_to_run_against_shopify_org?
           Shopifolk.act_as_shopify_organization
         end
-        orgs = PartnersAPI::Organizations.fetch_with_app(@ctx)
+        orgs = PartnersAPI::Organizations.fetch_all_with_apps(@ctx)
         org_id = if orgs.count == 1
           orgs.first["id"]
         else

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -6,11 +6,16 @@ module Extension
       module GetOrganizations
         include TestHelpers::Partners
 
-        def organization(name:, apps:)
+        def organization(id: rand(9999), name:, apps:)
           {
+            id: id,
             name: name,
             apps: apps,
           }
+        end
+
+        def stub_db_setup(organization_id:)
+          ShopifyCLI::DB.stubs(:get).with(:organization_id).returns(organization_id)
         end
 
         def stub_get_organizations(organizations)
@@ -26,23 +31,37 @@ module Extension
           )
         end
 
+        def stub_fetch_org_with_apps(organization)
+          stub_partner_req(
+            "find_organization_with_apps",
+            variables: { id: organization[:id] },
+            resp: {
+              data: {
+                organizations: {
+                  nodes: [create_organization_json(organization: organization)],
+                },
+              },
+            },
+          )
+        end
+
         def create_organizations_json(organizations)
           organizations.map do |organization|
-            create_organization_json(name: organization[:name], apps: organization[:apps])
+            create_organization_json(organization: organization)
           end
         end
 
-        def create_organization_json(name:, apps:)
+        def create_organization_json(organization:)
           {
-            'id': rand(9999),
-            'businessName': name,
+            'id': organization[:id],
+            'businessName': organization[:name],
             'stores': {
               'nodes': [
                 { 'shopDomain': "store.myshopify.com" },
               ],
             },
             'apps': {
-              nodes: create_apps_json(apps),
+              nodes: create_apps_json(organization[:apps]),
             },
           }
         end

--- a/test/project_types/extension/forms/questions/ask_app_test.rb
+++ b/test/project_types/extension/forms/questions/ask_app_test.rb
@@ -44,25 +44,26 @@ module Extension
           end
         end
 
-        # def test_fetches_all_apps_if_no_api_key_was_given
-        #   apps = [
-        #     Models::App.new(title: "Fake 1", api_key: "1234", secret: "4567"),
-        #     Models::App.new(title: "Fake 2", api_key: "abcd", secret: "efgh"),
-        #   ]
-        #   stub_get_organizations([
-        #     organization(name: "Organization One", apps: apps),
-        #   ])
-        #
-        #   prompt = PromptToChooseOption.new
-        #   AskApp.new(ctx: FakeContext.new, prompt: prompt).call(OpenStruct.new).tap do |result|
-        #     assert_predicate(result, :success?)
-        #     result.value.app.tap do |app|
-        #       assert_kind_of(Models::App, app)
-        #     end
-        #   end
-        #
-        #   assert_equal 2, prompt.options.count
-        # end
+        def test_fetches_all_apps_if_no_api_key_was_given
+          apps = [
+            Models::App.new(title: "Fake 1", api_key: "1234", secret: "4567"),
+            Models::App.new(title: "Fake 2", api_key: "abcd", secret: "efgh"),
+          ]
+          test_organization = organization(name: "Organization One", apps: apps)
+          stub_db_setup(organization_id: test_organization[:id])
+          ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(false)
+          stub_fetch_org_with_apps(test_organization)
+
+          prompt = PromptToChooseOption.new
+          AskApp.new(ctx: FakeContext.new, prompt: prompt).call(OpenStruct.new).tap do |result|
+            assert_predicate(result, :success?)
+            result.value.app.tap do |app|
+              assert_kind_of(Models::App, app)
+            end
+          end
+
+          assert_equal 2, prompt.options.count
+        end
 
         def test_aborts_and_informs_user_if_there_are_no_apps
           stub_get_organizations([

--- a/test/project_types/extension/forms/questions/ask_app_test.rb
+++ b/test/project_types/extension/forms/questions/ask_app_test.rb
@@ -44,25 +44,25 @@ module Extension
           end
         end
 
-        def test_fetches_all_apps_if_no_api_key_was_given
-          apps = [
-            Models::App.new(title: "Fake 1", api_key: "1234", secret: "4567"),
-            Models::App.new(title: "Fake 2", api_key: "abcd", secret: "efgh"),
-          ]
-          stub_get_organizations([
-            organization(name: "Organization One", apps: apps),
-          ])
-
-          prompt = PromptToChooseOption.new
-          AskApp.new(ctx: FakeContext.new, prompt: prompt).call(OpenStruct.new).tap do |result|
-            assert_predicate(result, :success?)
-            result.value.app.tap do |app|
-              assert_kind_of(Models::App, app)
-            end
-          end
-
-          assert_equal 2, prompt.options.count
-        end
+        # def test_fetches_all_apps_if_no_api_key_was_given
+        #   apps = [
+        #     Models::App.new(title: "Fake 1", api_key: "1234", secret: "4567"),
+        #     Models::App.new(title: "Fake 2", api_key: "abcd", secret: "efgh"),
+        #   ]
+        #   stub_get_organizations([
+        #     organization(name: "Organization One", apps: apps),
+        #   ])
+        #
+        #   prompt = PromptToChooseOption.new
+        #   AskApp.new(ctx: FakeContext.new, prompt: prompt).call(OpenStruct.new).tap do |result|
+        #     assert_predicate(result, :success?)
+        #     result.value.app.tap do |app|
+        #       assert_kind_of(Models::App, app)
+        #     end
+        #   end
+        #
+        #   assert_equal 2, prompt.options.count
+        # end
 
         def test_aborts_and_informs_user_if_there_are_no_apps
           stub_get_organizations([

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -55,7 +55,7 @@ module Extension
 
       def test_returns_empty_array_if_there_are_no_apps
         test_org = {
-          "id" => "1234567",
+          "id" => 1234567,
           "businessName" => "test business name",
           "apps" => [],
         }
@@ -63,12 +63,6 @@ module Extension
         ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns([test_org])
 
         assert_empty(Tasks::GetApps.call(context: @context))
-      end
-
-      private
-
-      def stub_db_setup(organization_id:)
-        ShopifyCLI::DB.stubs(:get).with(:organization_id).returns(organization_id)
       end
     end
   end

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -22,7 +22,7 @@ module Extension
           ],
         }
         stub_db_setup(organization_id: test_org["id"])
-        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns([test_org])
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns(test_org)
 
         app_list = Tasks::GetApps.call(context: @context)
         app = app_list.first
@@ -42,14 +42,9 @@ module Extension
       end
 
       def test_returns_empty_list_with_no_organization
-        test_org = {
-          "id" => "1234567",
-          "businessName" => "test business name",
-          "apps" => [@app],
-        }
-        stub_db_setup(organization_id: test_org["id"])
-        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns([])
+        stub_db_setup(organization_id: "not-found")
 
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns(nil)
         assert_empty(Tasks::GetApps.call(context: @context))
       end
 
@@ -60,7 +55,7 @@ module Extension
           "apps" => [],
         }
         stub_db_setup(organization_id: test_org["id"])
-        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns([test_org])
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_apps).returns(test_org)
 
         assert_empty(Tasks::GetApps.call(context: @context))
       end

--- a/test/project_types/extension/tasks/get_extensions_test.rb
+++ b/test/project_types/extension/tasks/get_extensions_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+require "test_helper"
+require "project_types/extension/extension_test_helpers"
+
+module Extension
+  module Tasks
+    class GetExtensionsTest < MiniTest::Test
+      include ExtensionTestHelpers::Stubs::GetApp
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        ShopifyCLI::ProjectType.load_type(:extension)
+      end
+
+      def test_return_empty_list_with_no_organization_id
+        stub_db_setup(organization_id: nil)
+
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_extensions).never
+        assert_empty(Tasks::GetExtensions.call(context: @context, type: extension_type))
+      end
+
+      def test_return_empty_list_with_no_organization
+        stub_db_setup(organization_id: "not-found")
+
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_extensions).returns(nil)
+        assert_empty(Tasks::GetExtensions.call(context: @context, type: extension_type))
+      end
+
+      def test_return_empty_list_with_no_apps
+        test_org = organization(name: "Test organization", apps: [])
+        stub_db_setup(organization_id: test_org[:id])
+
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_extensions).returns(test_org)
+        assert_empty(Tasks::GetExtensions.call(context: @context, type: extension_type))
+      end
+
+      def test_return_empty_list_with_no_extension_registration
+        test_app = { "id" => 9940, "title" => "App One", "apiKey" => "1234",
+                     "apiSecretKeys" => [{ "secret" => "5678" }] }
+        test_org = organization(name: "Test organization", apps: [test_app])
+        stub_db_setup(organization_id: test_org[:id])
+
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_extensions).returns(test_org)
+        assert_empty(Tasks::GetExtensions.call(context: @context, type: extension_type))
+      end
+
+      def test_return_list_of_extensions_owned_by_organziation
+        ShopifyCLI::DB.stubs(:get).with(:acting_as_shopify_organization).returns(false)
+        organization_id = 1234567
+        stub_db_setup(organization_id: organization_id)
+        stub_fetch_with_extensions(organization_id)
+
+        extensions_list = Tasks::GetExtensions.call(context: @context, type: extension_type)
+        assert_equal 1, extensions_list.size
+        assert_equal 2, extensions_list.first.size
+        assert_instance_of(Extension::Models::App, extensions_list.dig(0, 0))
+        assert_instance_of(Extension::Models::Registration, extensions_list.dig(0, 1))
+      end
+
+      private
+
+      def stub_fetch_with_extensions(organization_id)
+        test_org = {
+          "id" => organization_id,
+          "businessName" => "test business name",
+          "apps" => [
+            {
+              "id" => 9940,
+              "title" => "App One",
+              "apiKey" => "1234",
+              "apiSecretKeys" => [{ "secret" => "5678" }],
+              "extensionRegistrations" => [
+                { "id" => 3,
+                  "uuid" => "1234",
+                  "type" => extension_type,
+                  "title" => "test extension name",
+                  "draftVersion" => {
+                    "registrationId" => 3,
+                    "lastUserInteractionAt" => Time.now.to_s,
+                  } },
+              ],
+            },
+          ],
+        }
+
+        ShopifyCLI::PartnersAPI::Organizations.stubs(:fetch_with_extensions).returns(test_org)
+      end
+
+      def extension_type
+        "THEME_APP_EXTENSION"
+      end
+
+      def stub_get_extension_registrations(app)
+        stub_partner_req(
+          "get_extension_registrations",
+          variables: {
+            "api_key": app["apiKey"],
+            "type": extension_type,
+          },
+          resp: {
+            data: {
+              app: {
+                "id": app["id"],
+                "apiKey": app["apiKey"],
+                "extensionRegistrations": [{ id: 3 }],
+              },
+            },
+          },
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/script/layers/application/connect_app_test.rb
+++ b/test/project_types/script/layers/application/connect_app_test.rb
@@ -95,7 +95,7 @@ describe Script::Layers::Application::ConnectApp do
           org.merge({ "apps" => apps })
         end
         ShopifyCLI::PartnersAPI::Organizations
-          .stubs(:fetch_with_app)
+          .stubs(:fetch_all_with_apps)
           .returns(orgs_with_apps)
 
         selected_org = orgs_with_apps.first

--- a/test/shopify-cli/partners_api/app_extensions_test.rb
+++ b/test/shopify-cli/partners_api/app_extensions_test.rb
@@ -15,9 +15,7 @@ module ShopifyCLI
       def test_fetch_apps_extensions
         stub_get_extension_registrations
 
-        orgs = PartnersAPI::AppExtensions.fetch_apps_extensions(@context, fake_orgs, @type)
-
-        org = orgs.first
+        org = PartnersAPI::AppExtensions.fetch_apps_extensions(@context, fake_org, @type)
         apps = org["apps"]
         app = apps.first
         registration = app["extensionRegistrations"].first
@@ -32,9 +30,9 @@ module ShopifyCLI
 
       private
 
-      def fake_orgs
+      def fake_org
         fake_app = { "apiKey" => 3 }
-        [{ "apps" => [fake_app]  }]
+        { "apps" => [fake_app]  }
       end
 
       def stub_get_extension_registrations

--- a/test/shopify-cli/partners_api/app_extensions_test.rb
+++ b/test/shopify-cli/partners_api/app_extensions_test.rb
@@ -32,7 +32,7 @@ module ShopifyCLI
 
       def fake_org
         fake_app = { "apiKey" => 3 }
-        { "apps" => [fake_app]  }
+        { "apps" => [fake_app] }
       end
 
       def stub_get_extension_registrations

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -307,10 +307,10 @@ module ShopifyCLI
 
       def test_fetch_with_extensions
         type = "THEME_APP_EXTENSION"
-        stub_all_orgs_with_apps
+        stub_fetch_org_with_apps
         stub_get_extension_registrations(type)
 
-        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type)
+        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
 
         assert_equal(1, orgs.size)
         org = orgs.first
@@ -329,17 +329,18 @@ module ShopifyCLI
       end
 
       def test_fetch_with_extensions_with_nil_resp
-        stub_partner_req_not_found("all_orgs_with_apps")
+        stub_partner_req_not_found("find_organization_with_apps", variables: { id: 1 })
         type = "THEME_APP_EXTENSION"
-        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type)
+        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
         assert_equal([], orgs)
       end
 
       private
 
-      def stub_all_orgs_with_apps
+      def stub_fetch_org_with_apps
         stub_partner_req(
-          "all_orgs_with_apps",
+          "find_organization_with_apps",
+          variables: { id: 1 },
           resp: {
             data: {
               organizations: {

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -220,11 +220,6 @@ module ShopifyCLI
                   {
                     'id': 42,
                     'businessName': "One",
-                    'stores': {
-                      'nodes': [
-                        { 'shopDomain': "store.myshopify.com" },
-                      ],
-                    },
                     'apps': {
                       nodes: [
                         {
@@ -242,11 +237,8 @@ module ShopifyCLI
             },
           },
         )
-        orgs = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
-        assert_equal(1, orgs.count)
-        expected_organization = orgs.first
+        expected_organization = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
         assert_equal(42, expected_organization["id"])
-        assert_equal("store.myshopify.com", expected_organization["stores"].first["shopDomain"])
         assert_equal("first_app", expected_organization["apps"].first["title"])
       end
 
@@ -262,8 +254,8 @@ module ShopifyCLI
             },
           },
         )
-        orgs = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
-        assert_equal([], orgs)
+        org = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
+        assert_equal(nil, org)
       end
 
       def test_fetch_org_with_no_apps
@@ -277,11 +269,6 @@ module ShopifyCLI
                   {
                     'id': 42,
                     'businessName': "No apps",
-                    'stores': {
-                      'nodes': [
-                        { 'shopDomain': "store.myshopify.com" },
-                      ],
-                    },
                     'apps': {
                       nodes: [],
                     },
@@ -291,11 +278,8 @@ module ShopifyCLI
             },
           },
         )
-        orgs = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
-        assert_equal(1, orgs.count)
-        expected_organization = orgs.first
+        expected_organization = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
         assert_equal(42, expected_organization["id"])
-        assert_equal("store.myshopify.com", expected_organization["stores"].first["shopDomain"])
         assert_equal([], expected_organization["apps"])
       end
 
@@ -310,13 +294,10 @@ module ShopifyCLI
         stub_fetch_org_with_apps
         stub_get_extension_registrations(type)
 
-        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
-
-        assert_equal(1, orgs.size)
-        org = orgs.first
+        org = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
 
         assert_equal(1, org["apps"].size)
-        app = orgs.first["apps"].first
+        app = org["apps"].first
 
         assert_equal(1, app["extensionRegistrations"].size)
         registration = app["extensionRegistrations"].first
@@ -331,8 +312,8 @@ module ShopifyCLI
       def test_fetch_with_extensions_with_nil_resp
         stub_partner_req_not_found("find_organization_with_apps", variables: { id: 1 })
         type = "THEME_APP_EXTENSION"
-        orgs = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
-        assert_equal([], orgs)
+        org = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
+        assert_equal(nil, org)
       end
 
       private

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -255,7 +255,7 @@ module ShopifyCLI
           },
         )
         org = PartnersAPI::Organizations.fetch_with_apps(@context, id: 42)
-        assert_equal(nil, org)
+        assert_nil(org)
       end
 
       def test_fetch_org_with_no_apps
@@ -313,7 +313,7 @@ module ShopifyCLI
         stub_partner_req_not_found("find_organization_with_apps", variables: { id: 1 })
         type = "THEME_APP_EXTENSION"
         org = PartnersAPI::Organizations.fetch_with_extensions(@context, type, id: 1)
-        assert_equal(nil, org)
+        assert_nil(org)
       end
 
       private

--- a/test/shopify-cli/partners_api/organizations_test.rb
+++ b/test/shopify-cli/partners_api/organizations_test.rb
@@ -130,7 +130,7 @@ module ShopifyCLI
         assert_equal(0, org["stores"].count)
       end
 
-      def test_fetch_org_with_app_info
+      def test_fetch_all_org_with_app_info
         stub_partner_req(
           "all_orgs_with_apps",
           resp: {
@@ -178,13 +178,13 @@ module ShopifyCLI
             },
           },
         )
-        orgs = PartnersAPI::Organizations.fetch_with_app(@context)
+        orgs = PartnersAPI::Organizations.fetch_all_with_apps(@context)
         assert_equal(2, orgs.count)
         assert_equal(421, orgs.first["id"])
         assert_equal("store.myshopify.com", orgs.first["stores"].first["shopDomain"])
       end
 
-      def test_fetch_org_with_empty_app_info
+      def test_fetch_all_org_with_empty_app_info
         stub_partner_req(
           "all_orgs_with_apps",
           resp: {
@@ -202,7 +202,7 @@ module ShopifyCLI
             },
           },
         )
-        orgs = PartnersAPI::Organizations.fetch_with_app(@context)
+        orgs = PartnersAPI::Organizations.fetch_all_with_apps(@context)
         assert_equal(1, orgs.count)
         assert_equal(421, orgs.first["id"])
         assert_equal(0, orgs.first["stores"].count)

--- a/test/shopify-cli/tasks/ensure_env_test.rb
+++ b/test/shopify-cli/tasks/ensure_env_test.rb
@@ -24,7 +24,7 @@ module ShopifyCLI
           }],
           "apps" => [],
         }]
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_all_with_apps).with(@context).returns(response)
         CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_name")).returns("new app")
         CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.app_type.select")).returns("public")
         ShopifyCLI::Tasks::CreateApiClient.expects(:call).with(
@@ -58,7 +58,7 @@ module ShopifyCLI
             }],
           }],
         }]
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(response)
+        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_all_with_apps).with(@context).returns(response)
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
         env_file.expect(:write, nil, [@context])
@@ -67,7 +67,10 @@ module ShopifyCLI
 
       def test_uses_default_values_for_env_file
         Resources::EnvFile.expects(:parse_external_env).raises(Errno::ENOENT)
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations
+          .expects(:fetch_all_with_apps)
+          .with(@context)
+          .returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
@@ -77,7 +80,10 @@ module ShopifyCLI
 
       def test_keep_existing_env_values
         Resources::EnvFile.expects(:parse_external_env).returns({ host: "host" })
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations
+          .expects(:fetch_all_with_apps)
+          .with(@context)
+          .returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values.merge({ host: "host" })).returns(env_file)
@@ -87,7 +93,10 @@ module ShopifyCLI
 
       def test_not_all_required_values_found
         Resources::EnvFile.expects(:parse_external_env).returns(existing_env_file_values)
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations
+          .expects(:fetch_all_with_apps)
+          .with(@context)
+          .returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
@@ -105,7 +114,10 @@ module ShopifyCLI
         Resources::EnvFile
           .expects(:parse_external_env)
           .returns(existing_env_file_values.merge({ shop: "shop", host: "host" }))
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations
+          .expects(:fetch_all_with_apps)
+          .with(@context)
+          .returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values.merge({ host: "host" })).returns(env_file)
@@ -115,7 +127,10 @@ module ShopifyCLI
 
       def test_regenerate_empty_env_file
         Resources::EnvFile.expects(:parse_external_env).returns({})
-        ShopifyCLI::PartnersAPI::Organizations.expects(:fetch_with_app).with(@context).returns(partners_api_response)
+        ShopifyCLI::PartnersAPI::Organizations
+          .expects(:fetch_all_with_apps)
+          .with(@context)
+          .returns(partners_api_response)
         expect_user_prompts
         env_file = Minitest::Mock.new
         Resources::EnvFile.expects(:new).with(new_env_file_values).returns(env_file)
@@ -126,10 +141,14 @@ module ShopifyCLI
       private
 
       def expect_user_prompts
-        CLI::UI::Prompt.expects(:ask).with(@context.message("core.tasks.ensure_env.organization_select")).returns(101)
-        CLI::UI::Prompt.expects(:ask).with(
-          @context.message("core.tasks.ensure_env.development_store_select")
-        ).returns("store.myshopify.com")
+        CLI::UI::Prompt
+          .expects(:ask)
+          .with(@context.message("core.tasks.ensure_env.organization_select"))
+          .returns(101)
+        CLI::UI::Prompt
+          .expects(:ask)
+          .with(@context.message("core.tasks.ensure_env.development_store_select"))
+          .returns("store.myshopify.com")
       end
 
       def new_env_file_values


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes: https://github.com/Shopify/shopify-cli-planning/issues/90

When we show you apps to potentially connect your extension to via any of the `extension create / register / connect` commands, we show you all the apps that you have access to across all your partner accounts, not only the apps that are in your currently logged in partner account.

That behavior's a bit odd from an auth / permissions angle and we should fix that.

Related:
https://github.com/Shopify/shopify-cli/issues/1839 for `extension create`
https://github.com/Shopify/shopify-cli/issues/1899 for `extension connect`
https://github.com/Shopify/shopify-cli/issues/2234

### WHAT is this pull request doing?
- Updated `Task::GetApps.call` to return a list of apps for logged in organization
- Created new method `ShopifyCLI::PartnersAPI::Organizations.fetch_with_app` that returns data about organization and their apps 
- Renamed `ShopifyCLI::PartnersAPI::Organizations.fetch_with_app` to `ShopifyCLI::PartnersAPI::Organizations.fetch_all_with_apps` for better context fit

### How to test your changes?
Pre-requisites: Have 2 or more partner accounts. .
1. Test `extension create`
- Log out from all partner accounts.
- Login into one partner account `shopify login`
- From your application directory run `shopify extension create`
You see only the apps that are in your currently logged in partner account.

2. Test `extension register`
- Log out from all partner accounts.
- Login into one partner account `shopify login`
- From your extension directory run `shopify extension register`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).