### PR TITLE
Remove redundant yaml library loads and dead 'yarn build' code

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -2,7 +2,6 @@
 
 require "pathname"
 require "json"
-require "yaml"
 
 module Extension
   class PackageResolutionFailed < RuntimeError; end

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -25,10 +25,6 @@ module Extension
 
       def config(context, include_renderer_version: true)
         js_system = ShopifyCLI::JsSystem.new(ctx: context)
-        if js_system.package_manager == "yarn"
-          run_yarn_install(context, js_system)
-          run_yarn_run_script(context, js_system)
-        end
         filepath = File.join(context.root, SCRIPT_PATH)
         context.abort(context.message("features.argo.missing_file_error")) unless File.exist?(filepath)
 
@@ -49,32 +45,6 @@ module Extension
 
       def renderer_package(context)
         Tasks::FindPackageFromJson.call(renderer_package_name, context: context)
-      end
-
-      private
-
-      def run_yarn_install(context, js_system)
-        _result, error, status = js_system.call(
-          yarn: YARN_INSTALL_COMMAND + YARN_INSTALL_PARAMETERS,
-          npm: [],
-          capture_response: true
-        )
-
-        context.abort(
-          context.message("features.argo.dependencies.yarn_install_error", error)
-        ) unless status.success?
-      end
-
-      def run_yarn_run_script(context, js_system)
-        _result, error, status = js_system.call(
-          yarn: YARN_RUN_COMMAND + YARN_RUN_SCRIPT_NAME,
-          npm: [],
-          capture_response: true
-        )
-
-        context.abort(
-          context.message("features.argo.dependencies.yarn_run_script_error", error)
-        ) unless status.success?
       end
     end
   end

--- a/lib/project_types/extension/features/argo_config.rb
+++ b/lib/project_types/extension/features/argo_config.rb
@@ -11,7 +11,6 @@ module Extension
 
           return {} unless File.size?(file_name)
 
-          require "yaml" # takes 20ms, so deferred as late as possible.
           begin
             config = YAML.load_file(file_name)
 

--- a/lib/project_types/extension/models/server_config/root.rb
+++ b/lib/project_types/extension/models/server_config/root.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "yaml"
-
 module Extension
   module Models
     module ServerConfig

--- a/lib/project_types/extension/tasks/merge_server_config.rb
+++ b/lib/project_types/extension/tasks/merge_server_config.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "shopify_cli"
-require "yaml"
 require "pathname"
 
 module Extension

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -125,55 +125,10 @@ module Extension
         end
       end
 
-      def test_runs_yarn_install_and_yarn_run_script_if_the_package_manager_is_yarn
-        with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
-          Argo.any_instance.expects(:run_yarn_install).returns(true).once
-          Argo.any_instance.expects(:run_yarn_run_script).returns(true).once
-          @dummy_argo.renderer_version = "0.0.1"
-
-          @dummy_argo.config(@context)
-        end
-      end
-
-      def test_does_not_run_yarn_install_and_yarn_run_script_if_the_package_manager_is_npm
-        with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("npm")
-          Argo.any_instance.expects(:run_yarn_install).never
-          Argo.any_instance.expects(:run_yarn_run_script).never
-          @dummy_argo.renderer_version = "0.0.1"
-
-          @dummy_argo.config(@context)
-        end
-      end
-
-      def test_aborts_with_error_if_yarn_install_command_fails
-        with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
-          ShopifyCLI::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
-          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
-          assert_includes error.message,
-            @context.message("features.argo.dependencies.yarn_install_error", @error_message)
-        end
-      end
-
-      def test_aborts_with_error_if_yarn_run_script_command_fails
-        with_stubbed_script(@context, Features::Argo::SCRIPT_PATH) do
-          ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
-          Argo.any_instance.stubs(:run_yarn_install).returns(true)
-          ShopifyCLI::JsSystem.any_instance.stubs(:call).returns([@result, @error_message, mock(success?: false)])
-          error = assert_raises(ShopifyCLI::Abort) { @dummy_argo.config(@context) }
-          assert_includes error.message,
-            @context.message("features.argo.dependencies.yarn_run_script_error", @error_message)
-        end
-      end
-
       private
 
       def stub_run_yarn_install_and_run_yarn_run_script_methods
         ShopifyCLI::JsSystem.any_instance.stubs(:package_manager).returns("yarn")
-        Argo.any_instance.stubs(:run_yarn_install).returns(true)
-        Argo.any_instance.stubs(:run_yarn_run_script).returns(true)
       end
 
       def stub_package_manager(package_manager_output)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

- Multiple `require "yaml"` recurring source of bugs -- It's included globally, so it's also redundant
- Remove dead `yarn run build` code encountered while researching another bug in `shopify extension push`. This is also redundant as this line already accomplishes this: https://github.com/Shopify/shopify-cli/blob/main/lib/project_types/extension/commands/push.rb#L36

Deferred "yaml" library loading is causing bugs. They are also redundant within the `extensions` directory, as it is loaded globally above.

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

CI tests to ensure existing tests pass is sufficient.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ x ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ x ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ x ] I've included any post-release steps in the section above (if needed).