### PR TITLE
Packaging for release 2.15.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.15.6)
+    shopify-cli (2.15.7)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.1)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.15.6"
+  VERSION = "2.15.7"
 end


### PR DESCRIPTION
## Version 2.15.7 - 2022-04-25

### Fixed
* [#2274](https://github.com/Shopify/shopify-cli/pull/2274): Fix broken `shopify extension register` and `shopify extension push`

### Added
* [#2189](https://github.com/Shopify/shopify-cli/pull/2189): Retrieve latest CLI version in the background
* [#2263](https://github.com/Shopify/shopify-cli/pull/2263): Add `POS UI Extension` to support third party developers to extend POS smart grid functionality using native retail components. 

### Changed
* [#2272](https://github.com/Shopify/shopify-cli/pull/2272): [Feature]: Changed interactive apps list scope for extension create|register|connect commands
