### PR TITLE
Fix extension loading for extension connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2285](https://github.com/Shopify/shopify-cli/pull/2285): Fix extension loading for extension connect
+
 ## Version 2.16.0 - 2022-04-25
 
 ### Fixed

--- a/lib/shopify_cli/partners_api/app_extensions.rb
+++ b/lib/shopify_cli/partners_api/app_extensions.rb
@@ -24,7 +24,7 @@ module ShopifyCLI
         end
 
         def consume_jobs!(jobs)
-          thread_pool = ShopifyCLI::ThreadPool.new
+          thread_pool = ShopifyCLI::ThreadPool.new(pool_size: 1)
           jobs.each do |job|
             thread_pool.schedule(job)
           end

--- a/lib/shopify_cli/services/app/create/rails_service.rb
+++ b/lib/shopify_cli/services/app/create/rails_service.rb
@@ -184,7 +184,7 @@ module ShopifyCLI
 
             context.puts(context.message("core.app.create.rails.adding_shopify_gem"))
             File.open(File.join(context.root, "Gemfile"), "a") do |f|
-              f.puts "\ngem 'shopify_app', '>=18.1.0'"
+              f.puts "\ngem 'shopify_app', '~>19.0.1'"
             end
             CLI::UI::Frame.open(context.message("core.app.create.rails.running_bundle_install")) do
               syscall(%w(bundle install))


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2234

There's an issue with the thread pool management, causing the `extension connect` command to not load all the existing extensions sometimes.

### WHAT is this pull request doing?

- Limit the pool size to 1 thread to ensure we get all the extensions. This is a temporary solution until we fix the threads management. So it will get all the extensions sequentially now, slower but safer.
- Pin `shopify_app` gem to v19, to avoid problems if there are breaking changes in the future (unrelated change).

### How to test your changes?

- Run `shopify extension connect` several times, having a few extensions on different apps

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).