### PR TITLE
Fix `Encoding::UndefinedConversionError` on `theme serve` and `theme pull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2287](https://github.com/Shopify/shopify-cli/pull/2287): Fix `Encoding::UndefinedConversionError` on `theme serve` and `theme pull`
+
 ## Version 2.16.1 - 2022-04-26
 
 ### Fixed

--- a/lib/shopify_cli/theme/development_theme.rb
+++ b/lib/shopify_cli/theme/development_theme.rb
@@ -79,12 +79,22 @@ module ShopifyCLI
 
         theme_name = "Development ()"
         hostname_character_limit = API_NAME_LIMIT - theme_name.length - hash.length - 1
-        identifier = "#{hash}-#{hostname[0, hostname_character_limit]}"
+        identifier = encode_identifier("#{hash}-#{hostname[0, hostname_character_limit]}")
         theme_name = "Development (#{identifier})"
 
         ShopifyCLI::DB.set(development_theme_name: theme_name)
 
         theme_name
+      end
+
+      ##
+      # In some cases, the identifier string encoding may be obfuscated by the hostname,
+      # which may be an ASCII string.
+      #
+      # This method ensures the result identifier is a UTF-8 valid string.
+      #
+      def encode_identifier(identifier)
+        identifier.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "-")
       end
     end
   end

--- a/lib/shopify_cli/theme/file.rb
+++ b/lib/shopify_cli/theme/file.rb
@@ -30,6 +30,15 @@ module ShopifyCLI
         else
           path.write(content, 0, mode: "wb")
         end
+      rescue Encoding::UndefinedConversionError
+        ##
+        # The CLI tries to write the file and normalize EOL characters to avoid
+        # errors on Windows when files are shared across different operational systems.
+        #
+        # The CLI fallbacks any error during the conversion by writing the file
+        # in binary mode when the normalization fails (e.g., ASCII files), so no data is lost.
+        #
+        path.write(content, 0, mode: "wb")
       end
 
       def delete

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -166,6 +166,20 @@ module ShopifyCLI
         assert_equal(theme_name, @theme.name)
       end
 
+      def test_name_is_valid_when_the_host_contains_an_ascii_character
+        ascii_string_char = 0x8f.chr
+        hostname = "theme-dev-#{ascii_string_char}.lan"
+        hash = "5676d"
+        theme_name = "Development (5676d-theme-dev--)"
+
+        ShopifyCLI::DB.stubs(:get).with(:development_theme_name).returns(nil)
+        SecureRandom.expects(:hex).returns(hash)
+        Socket.expects(:gethostname).returns(hostname)
+        ShopifyCLI::DB.expects(:set).with(development_theme_name: theme_name)
+
+        assert_equal(theme_name, @theme.name)
+      end
+
       def test_delete
         shop = "dev-theme-server-store.myshopify.com"
         theme_id = "12345678"

--- a/test/shopify-cli/theme/file_test.rb
+++ b/test/shopify-cli/theme/file_test.rb
@@ -67,6 +67,18 @@ module ShopifyCLI
         @file.write("content")
       end
 
+      def test_write_when_file_has_ascii_content
+        ascii_string_char = 0x8f.chr
+        content = "#{ascii_string_char} #{ascii_string_char}"
+
+        @path.parent.stubs(:directory?).returns(true)
+        @file.stubs(:text?).returns(true)
+
+        @path.expects(:write).with(content, universal_newline: true).raises(Encoding::UndefinedConversionError)
+        @path.expects(:write).with(content, 0, mode: "wb")
+        @file.write(content)
+      end
+
       def test_name
         file = fixture_file("layout/theme.liquid")
 


### PR DESCRIPTION
### WHY are these changes introduced?

This handles `Encoding::UndefinedConversionError` errors in two scenarios:
- the `theme serve` command - during the development theme name generation, it was failing if the hostname had any ASCII character
- the `theme pull` command - when files are written in the FS, `Pathname#write` was raising an and the `UndefinedConversionError` for ASCII files


### WHAT is this pull request doing?

In the `serve` command, we're detecting errors early and replacing any incompatible encoding character with `-`, as it's not crucial to preserve the hostname at that point.

In the `pull` command, as a fallback of the EOL normalization, we're writing the text file in binary mode to prevent the developers from losing data.


### How to test your changes?

- Download [this file](https://drive.google.com/file/d/18JHRHx787s-pFXs5JVK7jlu2YWEifAy6/view)
- `theme push -u -t <some theme>` it from Windows to some theme
- `theme pull -t <some theme>` on Windows or macOS
- Notice errors no longer happen

**Before this PR:**
<img width="60%" alt="image" src="https://user-images.githubusercontent.com/1079279/165305513-59fd6c6c-9a8c-4808-81d2-cb443b794a52.png">

**After this PR:**
<img width="60%" alt="image" src="https://user-images.githubusercontent.com/1079279/165305812-2f3650a8-fc51-4ac2-965e-b3ebd7a034f9.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).