### PR TITLE
[Scripts] Add rust support for three new discount eps

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -18,31 +18,13 @@ shipping_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
-merchandise_discount_types:
-  beta: true
-  domain: 'discounts'
-  libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-discounts-apis"
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-    wasm:
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-delivery_discount_types:
-  beta: true
-  domain: 'discounts'
-  libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-discounts-apis"
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-    wasm:
-      repo: "https://github.com/Shopify/scripts-apis-examples"
 product_discount_type:
   beta: true
   domain: 'discounts'
   libraries:
     wasm:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
       repo: "https://github.com/Shopify/scripts-apis-examples"
 order_discount_type:
   beta: true
@@ -50,9 +32,13 @@ order_discount_type:
   libraries:
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_discount_type:
   beta: true
   domain: 'discounts'
   libraries:
     wasm:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
       repo: "https://github.com/Shopify/scripts-apis-examples"


### PR DESCRIPTION
### WHY are these changes introduced?

#gsd:23145
Issue: https://github.com/Shopify/script-service/issues/4540

### WHAT is this pull request doing?

This PR

* Add rust support for three new discount eps
* Remove the old two discount eps at the same time

### How to test your changes?

```sh
shopify script create --api=product_discount_type --branch=discounts-demo --language=rust
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).