### PR TITLE
App Bridge create/details URLs for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2262](https://github.com/Shopify/shopify-cli/pull/2262): Add `capabilities` permissions to checkout extensions config
+* [#2292](https://github.com/Shopify/shopify-cli/pull/2292): Add support for App Bridge create/details URLs for scripts
 
 ## Version 2.16.1 - 2022-04-26
 

--- a/lib/project_types/script/cli.rb
+++ b/lib/project_types/script/cli.rb
@@ -50,6 +50,7 @@ module Script
       autoload :ExtensionPoint, Project.project_filepath("layers/domain/extension_point")
       autoload :ScriptConfig, Project.project_filepath("layers/domain/script_config")
       autoload :ScriptProject, Project.project_filepath("layers/domain/script_project")
+      autoload :AppBridge, Project.project_filepath("layers/domain/app_bridge")
     end
 
     module Infrastructure

--- a/lib/project_types/script/graphql/app_script_set.graphql
+++ b/lib/project_types/script/graphql/app_script_set.graphql
@@ -12,6 +12,7 @@ mutation AppScriptSet(
   $moduleUploadUrl: String!,
   $library: LibraryInput,
   $inputQuery: String,
+  $appBridge: AppBridgeInput!,
 ) {
   appScriptSet(
     uuid: $uuid
@@ -27,6 +28,7 @@ mutation AppScriptSet(
     moduleUploadUrl: $moduleUploadUrl,
     library: $library,
     inputQuery: $inputQuery,
+    appBridge: $appBridge
 ) {
     userErrors {
       field

--- a/lib/project_types/script/layers/application/push_script.rb
+++ b/lib/project_types/script/layers/application/push_script.rb
@@ -55,6 +55,7 @@ module Script
                   force: force,
                   metadata: package.metadata,
                   script_config: package.script_config,
+                  app_bridge: script_project.app_bridge,
                   module_upload_url: module_upload_url,
                   library: package.library,
                   input_query: script_project.input_query,

--- a/lib/project_types/script/layers/domain/app_bridge.rb
+++ b/lib/project_types/script/layers/domain/app_bridge.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Script
+  module Layers
+    module Domain
+      class AppBridge
+        attr_reader :create_path, :details_path
+
+        def initialize(create_path:, details_path:)
+          @create_path = create_path
+          @details_path = details_path
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/script/layers/domain/script_project.rb
+++ b/lib/project_types/script/layers/domain/script_project.rb
@@ -17,6 +17,7 @@ module Script
         property! :language, accepts: String
 
         property :script_config, accepts: ScriptConfig
+        property :app_bridge, accepts: AppBridge
         property :input_query, accepts: String
 
         def initialize(*)

--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -54,6 +54,7 @@ module Script
             extension_point_type: extension_point_type,
             language: language,
             script_config: script_config_repository.get!,
+            app_bridge: app_bridge,
             input_query: read_input_query,
           )
         end
@@ -94,6 +95,7 @@ module Script
             extension_point_type: extension_point_type,
             language: language,
             script_config: script_config,
+            app_bridge: app_bridge,
           )
         end
 
@@ -119,6 +121,16 @@ module Script
 
         def language
           project_config_value("language")&.downcase || default_language
+        end
+
+        def app_bridge
+          create_path = project_config_value("app_bridge_create_path") || "/"
+          details_path = project_config_value("app_bridge_details_path") || "/"
+
+          Domain::AppBridge.new(
+            create_path: create_path,
+            details_path: details_path,
+          )
         end
 
         def project_config_value(key)

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -20,6 +20,7 @@ module Script
           force: false,
           metadata:,
           script_config:,
+          app_bridge:,
           module_upload_url:,
           library:,
           input_query: nil
@@ -36,6 +37,10 @@ module Script
             scriptConfigVersion: script_config.version,
             configurationUi: script_config.configuration_ui,
             configurationDefinition: script_config.configuration&.to_json,
+            appBridge: {
+              createPath: app_bridge.create_path,
+              detailsPath: app_bridge.details_path,
+            },
             moduleUploadUrl: module_upload_url,
             inputQuery: input_query,
           }

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -111,9 +111,13 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         "title" => title,
         "description" => description,
         "script_config" => script_config,
+        "app_bridge_create_path" => app_bridge_create_path,
+        "app_bridge_details_path" => app_bridge_details_path,
       }
     end
     let(:actual_config) { valid_config }
+    let(:app_bridge_create_path) { nil }
+    let(:app_bridge_details_path) { nil }
     let(:current_project) do
       TestHelpers::FakeProject.new(directory: File.join(ctx.root, title), config: actual_config)
     end
@@ -165,6 +169,16 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         let(:input_query) { "{ aField }" }
         it "populates the input_query field" do
           assert_equal input_query, subject.input_query
+        end
+      end
+
+      describe "when app bridge paths are present" do
+        let(:app_bridge_create_path) { "/new" }
+        let(:app_bridge_details_path) { "/details" }
+
+        it "populates the app bridge paths" do
+          assert_equal "/new", subject.app_bridge.create_path
+          assert_equal "/details", subject.app_bridge.details_path
         end
       end
     end
@@ -220,6 +234,17 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         it "should succeed" do
           assert subject
           assert_nil subject.uuid
+        end
+      end
+
+      describe "when missing app bridge paths" do
+        let(:app_bridge_create_path) { nil }
+        let(:app_bridge_details_path) { nil }
+
+        it "should default to /" do
+          assert subject
+          assert "/", subject.app_bridge.create_path
+          assert "/", subject.app_bridge.details_path
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -18,6 +18,12 @@ describe Script::Layers::Infrastructure::ScriptService do
       filename: script_config_filename,
     )
   end
+  let(:app_bridge) do
+    Script::Layers::Domain::AppBridge.new(
+      create_path: "/new",
+      details_path: "/details",
+    )
+  end
   let(:title) { "script name" }
   let(:script_config_version) { "1" }
   let(:expected_description) { "some description" }
@@ -80,6 +86,7 @@ describe Script::Layers::Infrastructure::ScriptService do
           use_msgpack,
         ),
         script_config: script_config,
+        app_bridge: app_bridge,
         module_upload_url: url,
         library: library
       )


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/script-service/issues/4707

### WHAT is this pull request doing?

This PR reads App Bridge create/edit URLs from the script project's `.shopify-cli.yml` file.

### How to test your changes?

These changes can be tested against the `ah.store-app-bridge-urls` branch in Script Service.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] ~I've included any post-release steps in the section above (if needed).~