### PR TITLE
Fix #2212 error in `theme serve` with specific locale files

### DIFF
--- a/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
@@ -42,7 +42,7 @@ module ShopifyCLI
           end
 
           def files
-            @theme.json_files
+            @theme.json_files.filter(&:template?)
           end
         end
       end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2212 

Some locale files crash `shopfiy theme serve`.
Here is a minimal `locales/en.default.json` to reproduce this issue.
With this file, the local server shows "undefined method `dig' for "Just a String":String".

~~~
{
  "sections": {
    "some_key": "Just a String"
  }
}
~~~

### WHAT is this pull request doing?

`theme serve` tries to inspect templates to know used sections.  In the process, it parses all json files in the theme.  Fixed the command to handle only templates files.

### How to test your changes?

- Run `shopify theme serve` with the above locale file


### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).