### PR TITLE
Only show update message when the new version is higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2297](https://github.com/Shopify/shopify-cli/pull/2297): Only show update message when the new version is higher
+
 ## Version 2.16.1 - 2022-04-26
 
 ### Fixed

--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -630,7 +630,7 @@ module ShopifyCLI
         end
       end
       latest_version = ShopifyCLI::Config.get(VERSION_CHECK_SECTION, LATEST_VERSION_FIELD, default: ShopifyCLI::VERSION)
-      latest_version unless latest_version == ShopifyCLI::VERSION
+      latest_version if ::Semantic::Version.new(latest_version) > ::Semantic::Version.new(ShopifyCLI::VERSION)
     end
 
     # Returns file extension depending on OS

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -275,7 +275,7 @@ module ShopifyCLI
 
         refute(@ctx.new_version)
       end
-    end    
+    end
 
     private
 

--- a/test/shopify-cli/context_test.rb
+++ b/test/shopify-cli/context_test.rb
@@ -268,6 +268,15 @@ module ShopifyCLI
       end
     end
 
+    def test_check_for_new_version_returns_nil_if_the_current_version_is_higher
+      with_stubbed_context do
+        Config.set(Context::VERSION_CHECK_SECTION, Context::LAST_CHECKED_AT_FIELD, Time.now.to_i - 86500)
+        mock_rubygems_https_call(response_body: "{\"version\":\"2.16.0\"}")
+
+        refute(@ctx.new_version)
+      end
+    end    
+
     private
 
     def mock_rubygems_https_call(response_body:)


### PR DESCRIPTION
### WHY are these changes introduced?

We are checking if there's a new update available once a day, but I've found a situation where it says this:

`⭑ A new version of Shopify CLI is available! You have version 2.16.1 and the latest version is 2.16.0.`

Related to https://github.com/Shopify/shopify-cli/pull/2189

This happened because:
- The CLI checked the latest version: 2.16.0 (and caches it for 24h)
- The CLI was updated to 2.16.1
- It detects that the version is different, so it supposes there's a new one

### WHAT is this pull request doing?

Only show update message when the new version is higher

### How to test your changes?

1. Enable [these lines](https://github.com/Shopify/shopify-cli/blob/cb0df573adb1aa9c07347d9401dfd2d974e12a60/lib/shopify_cli/core/entry_point.rb#L13-L14) in your dev environment (need to play with the `if/elsif` or just copy the lines to after the conditional)
2. Change the [version](https://github.com/Shopify/shopify-cli/blob/cb0df573adb1aa9c07347d9401dfd2d974e12a60/lib/shopify_cli/version.rb#L2) to something newer (like 3.0.0)
4. Run `bin/shopify version` a few times and it shouldn't warn about a new version

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).