### PR TITLE
Improve the unauthorized API errors when doing theme development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2297](https://github.com/Shopify/shopify-cli/pull/2297): Only show update message when the new version is higher
 
+### Changed
+* [#2299](https://github.com/Shopify/shopify-cli/pull/2299): Improve the unauthorized API errors when doing theme development
+
 ## Version 2.16.1 - 2022-04-26
 
 ### Fixed

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -8,6 +8,11 @@ module Theme
             Usage: {{command:%1$s theme [ %2$s ]}}
         HELP
         ensure_user_error: "You are not authorized to edit themes on %s.",
+        unauthorized_error: <<~EOD,
+          You can't use Shopify CLI with development stores if you only have Partner staff member access. If you want to use Shopify CLI to work on a development store, then you should be the store owner or create a staff account on the store.
+
+          If you're the store owner, then you need to log in to the store directly using the store URL at least once (for example, using %s.myshopify.com/admin) before you log in using Shopify CLI. Logging in to the Shopify admin directly connects the development store with your Shopify login.
+        EOD
         ensure_user_try_this: <<~ENSURE_USER,
           Check if your user is activated, has permission to edit themes at the store, and try to re-login.
         ENSURE_USER

--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -53,8 +53,10 @@ module ShopifyCLI
         # * when an asset operation cannot be performed:
         #   - <APIRequestForbiddenError: 403 {"message":"templates/gift_card.liquid could not be deleted"}>
         #
-        if empty_response?(error) || unauthorized_response?(error)
+        if empty_response?(error)
           return permission_error
+        elsif unauthorized_response?(error)
+          raise ShopifyCLI::Abort, @ctx.message("theme.unauthorized_error", @shop)
         end
 
         raise error

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -49,7 +49,6 @@ module ShopifyCLI
         shop = "dev-theme-server-store.myshopify.com"
         theme_id = "12345678"
         error_message = "error message"
-        try_this_message = "try this message"
         unauthorized_error_response = stub(body: '{"errors":"Unauthorized Access"}')
         unauthorized_error = ShopifyCLI::API::APIRequestForbiddenError.new("403", response: unauthorized_error_response)
 
@@ -64,14 +63,12 @@ module ShopifyCLI
           path: "themes/#{theme_id}.json",
         ).raises(unauthorized_error)
 
-        @ctx.expects(:message).with("theme.ensure_user_error", shop).returns(error_message)
-        @ctx.expects(:message).with("theme.ensure_user_try_this").returns(try_this_message)
+        @ctx.expects(:message).with("theme.unauthorized_error", shop).returns(error_message)
 
-        io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
+        io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
           @theme.ensure_exists!
         end
-
-        assert_message_output(io: io, expected_content: [error_message, try_this_message])
+        assert_message_output(io: io, expected_content: [error_message])
       end
 
       def test_creates_development_theme_if_missing_from_api

--- a/test/shopify-cli/theme/theme_admin_api_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_test.rb
@@ -152,18 +152,21 @@ module ShopifyCLI
         path = "themes.json"
         error_response = stub(body: '{"errors":"Unauthorized Access"}')
         expected_error = ShopifyCLI::API::APIRequestForbiddenError.new("403", response: error_response)
+        error_message = "Unauthorized message"
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
           .with(@ctx, shop: @shop, api_version: @api_version, method: "POST", path: path)
           .raises(expected_error)
 
-        @ctx.expects(:message).with("theme.ensure_user_error", @shop).returns("ensure_user_error")
-        @ctx.expects(:message).with("theme.ensure_user_try_this").returns("ensure_user_try_this")
-        @ctx.expects(:abort).with("ensure_user_error", "ensure_user_try_this")
+        @ctx.expects(:message).with("theme.unauthorized_error", @shop).returns(error_message)
 
-        @api_client.post(
-          path: path
-        )
+        error = assert_raises(ShopifyCLI::Abort) do
+          @api_client.post(
+            path: path
+          )
+        end
+
+        assert_equal error_message, error.message
       end
 
       def test_forbiden_errors_not_related_to_unauthorized_access


### PR DESCRIPTION
Related: https://github.com/Shopify/shopify-cli/issues/1309

### WHY are these changes introduced?
Developing themes requires the authenticated user to be a staff member of the store. Because we don't make partners staff members of the development stores that they create, developers often run into unauthorized errors that are not very actionable.

### WHAT is this pull request doing?
A better experience requires making some changes server-side to make the partner staff member of the store at creation-time. Until that happens, we can improve the errors that we present to make them more actionable.

### How to test your changes?
Try to develop a theme against a store you are not staff member of.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).