### PR TITLE
Add new extension point

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -63,6 +63,7 @@ shipping_discounts:
     rust:
       repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_rates_consolidation:
+  beta: true
   domain: 'checkout'
   libraries:
     wasm:


### PR DESCRIPTION
Related to https://github.com/Shopify/shopify-cli/issues/2267

Basically we need new extension point for our project of shipping rates consolidation with scripts. 
https://github.com/Shopify/shopify/issues/343328 for bigger context.

Is there anything else I should do? I've already introduced [PR](https://github.com/Shopify/scripts-apis-examples/pull/41) for [scripts-apis-examples](https://github.com/Shopify/scripts-apis-examples)