### PR TITLE
Follow-up of the #2295 (Fix error in `theme serve` with specific locale files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2287](https://github.com/Shopify/shopify-cli/pull/2287): Fix `Encoding::UndefinedConversionError` on `theme serve` and `theme pull`
+* [#2310](https://github.com/Shopify/shopify-cli/pull/2310): Fix live-reload to be resilient and no longer raise an error when a locale file is invalid
 * [#2297](https://github.com/Shopify/shopify-cli/pull/2297): Only show update message when the new version is higher
 * [#2270](https://github.com/Shopify/shopify-cli/pull/2270): Use ignore filter regex in watcher class
 

--- a/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
@@ -42,7 +42,7 @@ module ShopifyCLI
           end
 
           def files
-            @theme.json_files
+            @theme.json_files.filter(&:template?)
           end
         end
       end

--- a/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload/sections_index.rb
@@ -14,13 +14,12 @@ module ShopifyCLI
 
             files.each do |file|
               section_hash(file).each do |key, value|
-                name = key
-                type = value&.dig("type")
-
-                next if !name || !type
+                next unless key
+                next unless value.is_a?(Hash)
+                next unless (type = value&.dig("type"))
 
                 index[type] = [] unless index[type]
-                index[type] << name
+                index[type] << key
               end
             end
 
@@ -42,7 +41,7 @@ module ShopifyCLI
           end
 
           def files
-            @theme.json_files.filter(&:template?)
+            @theme.json_files
           end
         end
       end

--- a/test/fixtures/theme/locales/pt-BR.json
+++ b/test/fixtures/theme/locales/pt-BR.json
@@ -1,0 +1,5 @@
+{
+  "sections": {
+    "key": "value"
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is a follow-up of an enhancement (https://github.com/Shopify/shopify-cli/pull/2295) introduced by the community.

### WHAT is this pull request doing?

I've noticed that developers may have invalid JSON files that are a template. Thus, this PR solves the issue by making the `SectionsIndex` more resilient to avoid errors in that scenario.

This PR also includes a broken locale file similar. So, now we're unit testing this enhancement as well.

### How to test your changes?

- Add the `pt-BR.json` locale file to your theme
- Run `shopify theme serve`

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).