### PR TITLE
Changes `shopify-app-node` to `shopify-app-template-node`

### DIFF
--- a/lib/shopify_cli/services/app/create/node_service.rb
+++ b/lib/shopify_cli/services/app/create/node_service.rb
@@ -117,7 +117,7 @@ module ShopifyCLI
           end
 
           def build(name)
-            ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-node.git", name)
+            ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-template-node.git#cli_two", name)
 
             context.root = File.join(context.root, name)
 

--- a/test/shopify-cli/services/app/create/node_service_test.rb
+++ b/test/shopify-cli/services/app/create/node_service_test.rb
@@ -50,7 +50,10 @@ module ShopifyCLI
             @context.expects(:capture2).with("npm config get @shopify:registry").returns(
               ["https://registry.yarnpkg.com", nil]
             )
-            ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+            ShopifyCLI::Git.expects(:clone).with(
+              "https://github.com/Shopify/shopify-app-template-node.git#cli_two",
+              "test-app"
+            )
             ShopifyCLI::JsDeps.expects(:install)
             ShopifyCLI::Tasks::CreateApiClient.stubs(:call).returns({
               "apiKey" => "ljdlkajfaljf",
@@ -83,7 +86,10 @@ module ShopifyCLI
               chdir: @context.root + "/test-app"
             )
 
-            ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+            ShopifyCLI::Git.expects(:clone).with(
+              "https://github.com/Shopify/shopify-app-template-node.git#cli_two",
+              "test-app"
+            )
             ShopifyCLI::JsDeps.expects(:install)
             ShopifyCLI::Tasks::CreateApiClient.stubs(:call).returns({
               "apiKey" => "ljdlkajfaljf",
@@ -105,7 +111,10 @@ module ShopifyCLI
             @context.expects(:capture2).with("npm config get @shopify:registry").returns(
               ["https://registry.yarnpkg.com", nil]
             )
-            ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+            ShopifyCLI::Git.expects(:clone).with(
+              "https://github.com/Shopify/shopify-app-template-node.git#cli_two",
+              "test-app"
+            )
             ShopifyCLI::JsDeps.expects(:install)
 
             stub_partner_req(
@@ -150,7 +159,10 @@ module ShopifyCLI
             @context.expects(:capture2).with("npm config get @shopify:registry").returns(
               ["https://badregistry.com", nil]
             )
-            ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-node.git", "test-app")
+            ShopifyCLI::Git.expects(:clone).with(
+              "https://github.com/Shopify/shopify-app-template-node.git#cli_two",
+              "test-app"
+            )
             @context.expects(:system).with(
               "npm",
               "--userconfig",


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation to launch new Node app template, the Node app repo used by `shopify app create node` is being renamed from `shopify-app-node` to `shopify-app-template-node`.

Closes Shopify/first-party-library-planning#212

Prerequisites before merging:
- repo rename to occur
- https://github.com/Shopify/shopify-cli/pull/2376 to be merged

### WHAT is this pull request doing?

☝🏻 See above!

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing) - not applicable
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).