### PR TITLE
Fix issue where the specificiation identifier was returning in scream…

### DIFF
--- a/lib/project_types/extension/tasks/convert_server_config.rb
+++ b/lib/project_types/extension/tasks/convert_server_config.rb
@@ -30,7 +30,7 @@ module Extension
         renderer = Models::ServerConfig::DevelopmentRenderer.find(type)
         extension = Models::ServerConfig::Extension.new(
           uuid: registration_uuid,
-          type: type.upcase,
+          type: type,
           user: Models::ServerConfig::User.new,
           development: Models::ServerConfig::Development.new(
             build_dir: hash.dig("development", "build_dir") || DEFAULT_BUILD_DIR,

--- a/test/project_types/extension/tasks/convert_server_config_test.rb
+++ b/test/project_types/extension/tasks/convert_server_config_test.rb
@@ -19,7 +19,7 @@ module Extension
         @store = "my-test-store"
         @title = "Extension title"
         @tunnel_url = "https://shopify.ngrok.io"
-        @type = "CHECKOUT_UI_EXTENSION"
+        @type = "checkout_ui_extension"
         @metafields = [{ "namespace" => "my-namespace", "foo" => "bar" }, { "namespace" => "my-namespace" }]
         stub_renderer_package
       end
@@ -129,7 +129,7 @@ module Extension
       def mock_extension_config
         Models::ServerConfig::Extension.new(
           uuid: @registration_uuid,
-          type: @type.upcase,
+          type: @type,
           user: Models::ServerConfig::User.new,
           development: Models::ServerConfig::Development.new(
             build_dir: @build,


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/shopify-cli-extensions/issues/306

### WHAT is this pull request doing?

We were converting the specification identifier to upper case but this is not expected for the new Dev Server. It should be lower snake case for consistency and for local extensions to work in Admin

### How to test your changes?

1. Follow the instructions here to test with a local version of the CLI + the Go binary: https://github.com/Shopify/shopify-cli-extensions#testing-the-integration-with-the-shopify-cli. Ensure you follow the step to set up the `symlink` to the Go binary.
1. Create a new Product Subscription extension.
2. Run `shopify extension serve`
3. Click on the link to load in Admin
4. Verify that you're redirected to a the product details page and can render the extension

### Post-release steps

None

### Update checklist

~- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).

~- [ ] I've included any post-release steps in the section above (if needed).~