### PR TITLE
explicitly set renderer for beacon extension to nil

### DIFF
--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -13,8 +13,8 @@ module Extension
           "@shopify/retail-ui-extensions",
         ]
 
-        property! :name, accepts: VALID_RENDERERS
-        property! :version, accepts: String, default: "latest"
+        property :name, accepts: VALID_RENDERERS, required: false
+        property :version, accepts: String, default: "latest", required: false
 
         def self.find(type)
           case type.downcase
@@ -26,6 +26,8 @@ module Extension
             new(name: "@shopify/post-purchase-ui-extensions", version: "^0.13.2")
           when "pos_ui_extension"
             new(name: "@shopify/retail-ui-extensions", version: "^0.1.0")
+          when "beacon_extension"
+            nil
           else
             raise ArgumentError, "Unknown extension type: #{type}"
           end

--- a/lib/project_types/extension/models/server_config/development_renderer.rb
+++ b/lib/project_types/extension/models/server_config/development_renderer.rb
@@ -13,8 +13,8 @@ module Extension
           "@shopify/retail-ui-extensions",
         ]
 
-        property :name, accepts: VALID_RENDERERS, required: false
-        property :version, accepts: String, default: "latest", required: false
+        property! :name, accepts: VALID_RENDERERS
+        property! :version, accepts: String, default: "latest"
 
         def self.find(type)
           case type.downcase


### PR DESCRIPTION
https://github.com/Shopify/ce-customer-behaviour/issues/984

The cli was unable to create the beacon_extension because of defensive code preventing the creation of an extension without a renderer

### WHY are these changes introduced?

to allow for the creation of beacon extensions without having to specify a renderer

### WHAT is this pull request doing?

fixes bug that prevented the generation of the beacon extension project

### How to test your changes?

`shopify extension create`
select beacon_extension
select javascript
provide name

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).