### PR TITLE
Handle invalid App Bridge paths when pushing a script

### DIFF
--- a/lib/project_types/script/layers/infrastructure/errors.rb
+++ b/lib/project_types/script/layers/infrastructure/errors.rb
@@ -194,6 +194,17 @@ module Script
             messages.join("\n")
           end
         end
+
+        class InvalidAppBridgePathError < ScriptProjectError
+          def initialize(path_type)
+            @path_type = path_type
+            super()
+          end
+
+          def path_key
+            "app_bridge_#{@path_type}_path"
+          end
+        end
       end
     end
   end

--- a/lib/project_types/script/layers/infrastructure/script_service.rb
+++ b/lib/project_types/script/layers/infrastructure/script_service.rb
@@ -92,6 +92,10 @@ module Script
             raise Errors::InvalidInputQueryErrors, errors.map { |err| err["message"] }
           elsif user_errors.find { |err| %w(not_use_msgpack_error schema_version_argument_error).include?(err["tag"]) }
             raise Domain::Errors::MetadataValidationError
+          elsif user_errors.find { |err| err["tag"] == "invalid_app_bridge_create_path" }
+            raise Errors::InvalidAppBridgePathError, "create"
+          elsif user_errors.find { |err| err["tag"] == "invalid_app_bridge_details_path" }
+            raise Errors::InvalidAppBridgePathError, "details"
           else
             raise Errors::GraphqlError, user_errors
           end

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -164,6 +164,9 @@ module Script
           missing_env_file_variables: "The following are missing in the .env file: %s. ",
           missing_env_file_variables_solution: "To add it, connect your script with " \
           "{{command:%1$s script connect}} ",
+
+          invalid_app_bridge_path_cause: "The script couldn't be pushed because the App Bridge path is incorrect in .shopify-cli.yml.",
+          invalid_app_bridge_path_help: "The %{path_key} needs to be set to a path that starts with {{command:/}}.",
         },
 
         create: {

--- a/lib/project_types/script/ui/error_handler.rb
+++ b/lib/project_types/script/ui/error_handler.rb
@@ -316,6 +316,14 @@ module Script
               ),
             help_suggestion: ShopifyCLI::Context.message("script.error.language_library_for_api_not_found_help"),
           }
+        when Layers::Infrastructure::Errors::InvalidAppBridgePathError
+          {
+            cause_of_error: ShopifyCLI::Context.message("script.error.invalid_app_bridge_path_cause"),
+            help_suggestion: ShopifyCLI::Context.message(
+              "script.error.invalid_app_bridge_path_help",
+              path_key: e.path_key,
+            ),
+          }
         end
       end
     end

--- a/test/project_types/script/layers/infrastructure/script_service_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_service_test.rb
@@ -301,6 +301,40 @@ describe Script::Layers::Infrastructure::ScriptService do
           assert_raises(Script::Layers::Infrastructure::Errors::EmptyResponseError) { subject }
         end
       end
+
+      describe "when app_bridge is invalid" do
+        describe "when create path is invalid" do
+          let(:response) do
+            {
+              "data" => {
+                "appScriptSet" => {
+                  "userErrors" => [{ "message" => "error", "tag" => "invalid_app_bridge_create_path" }],
+                },
+              },
+            }
+          end
+
+          it "raises InvalidAppBridgePathError" do
+            assert_raises(Script::Layers::Infrastructure::Errors::InvalidAppBridgePathError) { subject }
+          end
+        end
+
+        describe "when details path is invalid" do
+          let(:response) do
+            {
+              "data" => {
+                "appScriptSet" => {
+                  "userErrors" => [{ "message" => "error", "tag" => "invalid_app_bridge_details_path" }],
+                },
+              },
+            }
+          end
+
+          it "raises InvalidAppBridgePathError" do
+            assert_raises(Script::Layers::Infrastructure::Errors::InvalidAppBridgePathError) { subject }
+          end
+        end
+      end
     end
   end
 

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -435,6 +435,14 @@ describe Script::UI::ErrorHandler do
           should_call_display_and_raise
         end
       end
+
+      describe "when InvalidAppBridgePathError" do
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidAppBridgePathError.new("create") }
+
+        it "should call display_and_raise" do
+          should_call_display_and_raise
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/script-service/issues/4785

### WHAT is this pull request doing?

This PR introduces code to specifically handle the invalid App Bridge path responses from the backend.

### How to test your changes?

Use [this](https://github.com/Shopify/script-service/pull/4836) backend branch and attempt to push an invalid path (e.g. it doesn't start with a leading `/`). You will see an error like the following:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/1742857/168163410-64a89ff5-a47c-43bf-a6c8-d579e545c549.png">

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] ~I've included any post-release steps in the section above (if needed).~