### PR TITLE
Add --editor flag to open theme editor in the ``theme open`` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## Version 2.17.0 - 2022-05-12
 
 ### Added
+* [#2325](https://github.com/Shopify/shopify-cli/pull/2325): Add `-e/--editor` flag to open theme editor in the `theme open` command
 * [#2262](https://github.com/Shopify/shopify-cli/pull/2262): Add `capabilities` permissions to checkout extensions config
 * [#2292](https://github.com/Shopify/shopify-cli/pull/2292): Add support for App Bridge create/details URLs for scripts
 

--- a/lib/project_types/theme/commands/open.rb
+++ b/lib/project_types/theme/commands/open.rb
@@ -12,13 +12,18 @@ module Theme
         parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
         parser.on("-l", "--live") { flags[:live] = true }
         parser.on("-d", "--development") { flags[:development] = true }
+        parser.on("-e", "--editor") { flags[:editor] = true }
       end
 
       def call(_args, _name)
         theme = find_theme(**options.flags)
 
         @ctx.puts(@ctx.message("theme.open.details", theme.name, theme.preview_url, theme.editor_url))
-        @ctx.open_browser_url!(theme.preview_url)
+        if options.flags[:editor]
+          @ctx.open_browser_url!(theme.editor_url)
+        else
+          @ctx.open_browser_url!(theme.preview_url)
+        end
       end
 
       def self.help

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -293,6 +293,7 @@ module Theme
               {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of your theme.
               {{command:-l, --live}}             Open your live theme.
               {{command:-d, --development}}      Open your development theme.
+              {{command:-e, --editor}}           Open the editor to the specified/selected theme.
           HELP
         },
         list: {

--- a/test/project_types/theme/commands/open_test.rb
+++ b/test/project_types/theme/commands/open_test.rb
@@ -54,6 +54,48 @@ module Theme
         ])
       end
 
+      def test_open_with_editor_flag
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(ctx, identifier: 1234)
+          .returns(theme)
+
+        ctx.expects(:open_browser_url!).with("https://test.myshopify.io/editor")
+
+        io = capture_io do
+          @command.options.flags[:theme] = 1234
+          @command.options.flags[:editor] = true
+          @command.call([], "open")
+        end
+
+        assert_message_output(io: io, expected_content: [
+          "{{*}} {{bold:My test theme}}",
+
+          "\n\nPreview your theme:",
+          "{{green:https://test.myshopify.io/preview}}",
+
+          "\n\nCustomize your theme in the Theme Editor:",
+          "{{green:https://test.myshopify.io/editor}}",
+        ])
+      end
+
+      def test_open_with_editor_flag_when_theme_does_not_exist
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(ctx, identifier: 1234)
+          .returns(nil)
+
+        ctx.expects(:open_browser_url!).never
+
+        error = assert_raises CLI::Kit::Abort do
+          @command.options.flags[:theme] = 1234
+          @command.options.flags[:editor] = true
+          @command.call([], "open")
+        end
+
+        assert_equal("{{x}} Theme \"1234\" doesn't exist", error.message)
+      end
+
       def test_open_with_theme_flag_when_theme_does_not_exist
         ShopifyCLI::Theme::Theme
           .expects(:find_by_identifier)


### PR DESCRIPTION
### WHY are these changes introduced?

Adds editor flag feature requested in [@2198](https://github.com/Shopify/shopify-cli/issues/2198)

### WHAT is this pull request doing?

Adds the ability to open theme editor by entering the **-e / --editor** flag.

### How to test your changes?

Adding the **-e** / **--editor** flag to any ```shopify theme open``` command should result in the editor of the specified theme being opened in the browser.

- Run ``shopify theme open -t [THEME_NAME/THEME_ID] -e`` to open the theme editor for a given theme
- Run ``shopify theme open -d -e`` to open the theme editor for the development theme
- Run ``shopify theme open -l -e`` to open the theme editor for the live theme
- Run ``shopify theme open -e`` to open the theme editor for a theme selected at the prompt

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).