### PR TITLE
Add remote file deleted warning message on ``theme serve --theme-editor-sync``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## Version 2.17.0 - 2022-05-12
 
 ### Added
+* [#2330](https://github.com/Shopify/shopify-cli/pull/2330): Add remote file deleted warning flow to `theme serve --theme-editor-sync`
 * [#2325](https://github.com/Shopify/shopify-cli/pull/2325): Add `-e/--editor` flag to open theme editor in the `theme open` command
 * [#2262](https://github.com/Shopify/shopify-cli/pull/2262): Add `capabilities` permissions to checkout extensions config
 * [#2292](https://github.com/Shopify/shopify-cli/pull/2292): Add support for App Bridge create/details URLs for scripts

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -139,14 +139,14 @@ module Theme
           syncer: {
             forms: {
               apply_to_all: {
-                title: "Would like apply this to all the other %s files?",
+                title: "Would you like to apply this to all the other %s files?",
                 yes: "Yes",
                 no: "No",
               },
               update_strategy: {
                 title_context: <<~TITLE,
 
-                  The local file {{command:%s}} is different from the remote version in the development theme."
+                  The local file {{command:%s}} is different from the remote version in the development theme.
                 TITLE
                 title_question: "What would you like to do?",
                 keep_remote: "Keep the remote version",
@@ -154,10 +154,21 @@ module Theme
                 union_merge: "Merge files (it may break the local file)",
                 exit: "Exit",
               },
+              update_remote_deleted_strategy: {
+                title_context: <<~TITLE,
+
+                  The local file {{command:%s}} doesn’t exist in the remote version of the development theme.
+                TITLE
+                title_question: "What would you like to do?",
+                keep_remote: "Keep the remote version (and remove it locally)",
+                keep_local: "Keep the local version (and restore it remotely)",
+                union_merge: "Merge files (it may break the local file)",
+                exit: "Exit",
+              },
               delete_strategy: {
                 title_context: <<~TITLE,
 
-                  The local file {{command:%s}} has been recently removed, but it's present on your remote development theme.",
+                  The local file {{command:%s}} has been recently removed, but it's present on your remote development theme.
                 TITLE
                 title_question: "What would you like to do?",
                 delete: "Delete permanently",

--- a/lib/shopify_cli/theme/syncer/forms/select_update_strategy.rb
+++ b/lib/shopify_cli/theme/syncer/forms/select_update_strategy.rb
@@ -7,7 +7,7 @@ module ShopifyCLI
     class Syncer
       module Forms
         class SelectUpdateStrategy < BaseStrategyForm
-          flag_arguments :file
+          flag_arguments :file, :exists_remotely
 
           def strategies
             %i[
@@ -19,7 +19,7 @@ module ShopifyCLI
           end
 
           def prefix
-            "theme.serve.syncer.forms.update_strategy"
+            "theme.serve.syncer.forms.#{exists_remotely ? "update_strategy" : "update_remote_deleted_strategy"}"
           end
         end
       end

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -74,7 +74,7 @@ module ShopifyCLI
         end
 
         def ask_update_strategy(file)
-          Forms::SelectUpdateStrategy.ask(@ctx, [], file: file).strategy
+          Forms::SelectUpdateStrategy.ask(@ctx, [], file: file, exists_remotely: file_exist_remotely?(file)).strategy
         end
       end
     end

--- a/test/shopify-cli/theme/syncer/json_update_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_update_handler_test.rb
@@ -32,7 +32,7 @@ module ShopifyCLI
           @to_update.each do |file|
             Forms::SelectUpdateStrategy
               .expects(:ask)
-              .with(@ctx, [], file: file)
+              .with(@ctx, [], file: file, exists_remotely: file != @file1)
               .returns(stub(strategy: :keep_remote))
           end
 
@@ -52,7 +52,7 @@ module ShopifyCLI
           @to_update.each do |file|
             Forms::SelectUpdateStrategy
               .expects(:ask)
-              .with(@ctx, [], file: file)
+              .with(@ctx, [], file: file, exists_remotely: file != @file1)
               .returns(stub(strategy: :keep_local))
           end
 
@@ -71,7 +71,7 @@ module ShopifyCLI
           @to_update.each do |file|
             Forms::SelectUpdateStrategy
               .expects(:ask)
-              .with(@ctx, [], file: file)
+              .with(@ctx, [], file: file, exists_remotely: file != @file1)
               .returns(stub(strategy: :union_merge))
           end
 


### PR DESCRIPTION
Improve ``theme serve --theme-editor-sync`` message

### WHY are these changes introduced?

Fixes [#2218](https://github.com/Shopify/shopify-cli/issues/2218)
![Screen Shot 2022-05-19 at 9 31 18 AM](https://user-images.githubusercontent.com/60304332/169305264-fc89ecac-398f-45a4-adfb-46c30150b594.png)


Change the prompt when a file is removed from the remote theme, indicating that the remote version of the file was deleted and that selecting "Keep the remote version" will remove the local version of the file, or that "Keep the local version" will restore the deleted remote file.

### How to test your changes?

Test Cases:
- Try deleting files on remote theme and then running ``theme serve --theme-editor-sync``, this should result in the warning message (pictured above) being displayed.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).