### PR TITLE
Load changelog only after branch has been switched to main

### DIFF
--- a/lib/shopify_cli/release.rb
+++ b/lib/shopify_cli/release.rb
@@ -8,7 +8,6 @@ module ShopifyCLI
   class Release
     def initialize(new_version, github_access_token)
       @new_version = new_version
-      @changelog = ShopifyCLI::Changelog.new
       @github = Octokit::Client.new(access_token: github_access_token)
     end
 
@@ -32,7 +31,7 @@ module ShopifyCLI
 
     private
 
-    attr_reader :new_version, :changelog, :github
+    attr_reader :new_version, :github
 
     def ensure_updated_main
       # We can't be sure what is the correct action to take if changes have been
@@ -189,6 +188,10 @@ module ShopifyCLI
 
     def system_or_fail(command, action)
       raise "Failed to #{action}!" unless system(command)
+    end
+
+    def changelog
+      @changelog ||= ShopifyCLI::Changelog.new
     end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes the issues seen in [this PR](https://github.com/Shopify/shopify-cli/pull/2322), where the release was initiated from a non-main branch, the changelog was loaded too early, and it was updated based on that branch's changelog which was several changes old. This should have us only load the changelog once we've switched branches to `main`.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Saves loading of the changelog into memory until after the step to switch to updated `main` has completed.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
It'll get tested in the next release.

### Update checklist

All N/A