### PR TITLE
[Feature]: Add ``--theme/-t`` flag support to the ``theme serve`` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 
 ### Added
+* [#2336](https://github.com/Shopify/shopify-cli/pull/2336): Add `--theme/-t` flag support to the `theme serve` command
 * [#2325](https://github.com/Shopify/shopify-cli/pull/2325): Add `-e/--editor` flag to open theme editor in the `theme open` command
 * [#2330](https://github.com/Shopify/shopify-cli/pull/2330): Add remote file deleted warning flow to `theme serve --theme-editor-sync`
 

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -17,6 +17,7 @@ module Theme
         parser.on("--poll") { flags[:poll] = true }
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
         parser.on("--theme-editor-sync") { flags[:editor_sync] = true }
+        parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
       end
 
       def call(_args, name)

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -101,6 +101,7 @@ module Theme
           name: "Theme name",
         },
         serve: {
+          theme_not_found: "Theme \"%s\" doesn't exist",
           help: <<~HELP,
             Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.
 

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -73,6 +73,16 @@ module Theme
         run_serve_command(["dist"])
       end
 
+      def test_can_specify_theme
+        ShopifyCLI::Theme::DevServer
+          .expects(:start)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, theme: 1234)
+
+        run_serve_command do |command|
+          command.options.flags[:theme] = 1234
+        end
+      end
+
       def test_valid_authentication_method_when_storefront_renderer_token_and_password_are_present
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
         ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("SFR token")

--- a/test/shopify-cli/theme/dev_server_test.rb
+++ b/test/shopify-cli/theme/dev_server_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+require "test_helper"
+require "shopify_cli/theme/dev_server"
+
+module ShopifyCLI
+  module Theme
+    class DevServerTest < Minitest::Test
+      def setup
+        super
+        @ctx = ShopifyCLI::Context.new
+        @theme = stub(
+          "Dev Server Testing",
+          root: ".",
+          id: 1234,
+          name: "DevServer Test",
+          shop: "test.myshopify.io",
+          editor_url: "https://test.myshopify.io/editor",
+          preview_url: "https://test.myshopify.io/preview",
+          live?: false,
+        )
+        ShopifyCLI::Theme::DevServer.ctx = @ctx
+      end
+
+      def test_abort_when_invalid_theme
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(@ctx, root: @theme.root, identifier: @theme.id)
+          .returns(nil)
+
+        error = assert_raises CLI::Kit::Abort do
+          simulate_server(@theme.root, @theme.id)
+        end
+        assert_equal("{{x}} Theme \"1234\" doesn't exist", error.message)
+      end
+
+      def test_works_with_valid_theme_id
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(@ctx, root: @theme.root, identifier: @theme.id)
+          .returns(@theme)
+
+        simulate_server(@theme.root, @theme.id)
+      end
+
+      def test_works_with_valid_theme_name
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier)
+          .with(@ctx, root: @theme.root, identifier: @theme.name)
+          .returns(@theme)
+
+        simulate_server(@theme.root, @theme.name)
+      end
+
+      def test_finds_or_creates_a_dev_theme_when_no_theme_specified
+        ShopifyCLI::Theme::Theme
+          .expects(:find_by_identifier).never
+        ShopifyCLI::Theme::DevelopmentTheme
+          .expects(:find_or_create!)
+          .with(@ctx, root: ".").once
+
+        simulate_server
+      end
+
+      private
+
+      def simulate_server(root = ".", identifier = nil)
+        ShopifyCLI::Theme::DevServer
+          .send(:find_theme, root, identifier)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#2334](https://github.com/Shopify/shopify-cli/issues/2334)


### WHAT is this pull request doing?

Before, calling ``theme serve`` would automatically generate a new development theme and use that as a base. This PR adds functionality to serve any theme of your choice.


### How to test your changes?

Test Cases:
- ``theme serve -t {THEME_NAME}`` for live, development, and other themes
- ``theme serve -t {THEME_ID}`` for live, development, and other themes
- ``theme serve -t {THEME_NAME}`` for invalid themes
- ``theme serve -t {THEME_ID}`` for invalid themes
- Default ``theme serve`` flow

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).