### PR TITLE
Remove old discounts EPs

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -24,26 +24,6 @@ shipping_methods:
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
-merchandise_discount_types:
-  beta: true
-  domain: 'discounts'
-  libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-discounts-apis"
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-    wasm:
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-delivery_discount_types:
-  beta: true
-  domain: 'discounts'
-  libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-discounts-apis"
-      repo: "https://github.com/Shopify/scripts-apis-examples"
-    wasm:
-      repo: "https://github.com/Shopify/scripts-apis-examples"
 product_discounts:
   beta: true
   domain: 'discounts'


### PR DESCRIPTION
### WHY are these changes introduced?

Deprecated discounts APIs:

- `merchandise_discount_types`
- `delivery_discount_types`

### WHAT is this pull request doing?

Removes old script extension points so scripts can't be created for deprecated discounts APIs

### How to test your changes?

```
shopify-dev script create
```

`merchandise_discount_types` and `delivery_discount_types` should not appear as API options

### Update checklist

- [ ] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] ~I've included any post-release steps in the section above (if needed).~