### PR TITLE
Fix #2346 - Error received when deploying to Heroku

### DIFF
--- a/lib/shopify_cli/heroku.rb
+++ b/lib/shopify_cli/heroku.rb
@@ -4,6 +4,7 @@ module ShopifyCLI
       linux: "https://cli-assets.heroku.com/heroku-linux-x64.tar.gz",
       mac: "https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz",
       windows: "https://cli-assets.heroku.com/heroku-x64.exe",
+      mac_m1: "https://cli-assets.heroku.com/heroku-darwin-x64.tar.gz",
     }
 
     def initialize(ctx)
@@ -97,15 +98,16 @@ module ShopifyCLI
       if File.exist?(local_path)
         local_path
       elsif @ctx.windows?
-        # Check if Heroku exists in the Windows registry and run it from there
-        require "win32/registry"
         begin
+          # Check if Heroku exists in the Windows registry and run it from there
+          require "win32/registry"
+
           windows_path = Win32::Registry::HKEY_CURRENT_USER.open('SOFTWARE\heroku') do |reg|
             reg[""] # This reads the 'Default' registry key
           end
 
           File.join(windows_path, "bin", "heroku").to_s
-        rescue
+        rescue StandardError, LoadError
           "heroku"
         end
       else

--- a/test/shopify-cli/heroku_test.rb
+++ b/test/shopify-cli/heroku_test.rb
@@ -105,14 +105,18 @@ module ShopifyCLI
       assert_nil(heroku_service.download)
     end
 
-    def test_download_downloads_heroku_cli_if_it_is_not_installed
-      expects_heroku_installed(status: false)
-      expects_heroku_download(status: true)
-      expects_heroku_download_exists(status: true)
-
-      heroku_service = ShopifyCLI::Heroku.new(@context)
-
-      assert_nil(heroku_service.download)
+    [:linux, :mac, :mac_m1, :windows].each do |os|
+      define_method("test_download_downloads_heroku_cli_if_it_is_not_installed_for_#{os}") do
+        ShopifyCLI::Context.any_instance.stubs(:os).returns(os)
+        
+        expects_heroku_installed(status: false)
+        expects_heroku_download(status: true, os: os)
+        expects_heroku_download_exists(status: true, os: os)
+        
+        heroku_service = ShopifyCLI::Heroku.new(@context)
+        
+        assert_nil(heroku_service.download)
+      end
     end
 
     def test_download_raises_if_heroku_cli_download_fails

--- a/test/test_helpers/heroku.rb
+++ b/test/test_helpers/heroku.rb
@@ -187,23 +187,23 @@ module TestHelpers
         .returns([db, status_mock[:"#{status}"]])
     end
 
-    def expects_heroku_download_exists(status:)
+    def expects_heroku_download_exists(status:, os: :mac)
       File.expects(:exist?)
-        .with(download_path)
+        .with(download_path(os))
         .returns(status)
     end
 
-    def expects_heroku_download(status:)
+    def expects_heroku_download(status:, os: :mac)
       if status.nil?
         @context.expects(:system)
-          .with("curl", "-o", download_path,
-            ShopifyCLI::Heroku::DOWNLOAD_URLS[:mac],
+          .with("curl", "-o", download_path(os),
+            ShopifyCLI::Heroku::DOWNLOAD_URLS[os],
             chdir: ShopifyCLI.cache_dir)
           .never
       else
         @context.expects(:system)
-          .with("curl", "-o", download_path,
-            ShopifyCLI::Heroku::DOWNLOAD_URLS[:mac],
+          .with("curl", "-o", download_path(os),
+            ShopifyCLI::Heroku::DOWNLOAD_URLS[os],
             chdir: ShopifyCLI.cache_dir)
           .returns(status_mock[:"#{status}"])
       end
@@ -298,12 +298,12 @@ module TestHelpers
 
     private
 
-    def download_filename
-      "heroku-darwin-x64.tar.gz"
+    def download_filename(os)
+      URI.parse(ShopifyCLI::Heroku::DOWNLOAD_URLS[os]).path.split("/").last
     end
 
-    def download_path
-      File.join(ShopifyCLI.cache_dir, download_filename)
+    def download_path(os = :mac)
+      File.join(ShopifyCLI.cache_dir, download_filename(os))
     end
 
     def heroku_command(full_path: false)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2346 - Error received when deploying to Heroku

An error is produced when trying to deploy an app to Heroku using a MacOS M1 platform. More precisely, no URL is set to download Heroku CLI for MacOS M1

### WHAT is this pull request doing?
- Added Heroku CLI download URL por the ```os mac_m1```. It matches the one used for the mac. Tested in a MacOS M1 local environment
- Added testing methods to ensure that each os platform has its own download url

### How to test your changes?
- Installing Shopify CLI in a MacOS M1
- Creating an app of any kind
- Executing ```shopify app deploy heroku```
- The process must finish with succeed

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).