### PR TITLE
Switch to monorail-edge.shopifysvc.com endpoint

### DIFF
--- a/lib/shopify_cli/core/monorail.rb
+++ b/lib/shopify_cli/core/monorail.rb
@@ -6,7 +6,7 @@ require "rbconfig"
 module ShopifyCLI
   module Core
     module Monorail
-      ENDPOINT_URI = URI.parse("https://monorail-edge.shopifycloud.com/v1/produce")
+      ENDPOINT_URI = URI.parse("https://monorail-edge.shopifysvc.com/v1/produce")
       INVOCATIONS_SCHEMA = "app_cli_command/5.0"
 
       # Extra hash of data that will be sent in the payload


### PR DESCRIPTION
Monorail-edge.shopifycloud.com is backed by a single region (us-east), whereas monorail-edge.shopifysvc.com balances traffic between two regions (us-east and us-central) providing a highly available endpoint for monorail producers. Clients of monorail-edge.shopifycloud.com could experience outages and data loss if the us-east cluster went down. The monorail team intends to sunset the monorail-edge.shopifycloud.com domain in the next few weeks.