### PR TITLE
Provide better DX when dealing with empty theme selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 * [#2330](https://github.com/Shopify/shopify-cli/pull/2330): Add remote file deleted warning flow to `theme serve --theme-editor-sync`
 
 ### Fixed
+* [#2352](https://github.com/Shopify/shopify-cli/pull/2352): Provide better DX when dealing with empty theme selection
 * [#2347](https://github.com/Shopify/shopify-cli/pull/2347): Fix #2346 Heroku CLI installation for Apple silicon
 
 ## Version 2.17.0 - 2022-05-12

--- a/lib/project_types/theme/commands/delete.rb
+++ b/lib/project_types/theme/commands/delete.rb
@@ -25,6 +25,7 @@ module Theme
             title: @ctx.message("theme.delete.select"),
             exclude_roles: ["live"],
             include_foreign_developments: options.flags[:show_all],
+            cmd: :delete
           )
           return unless form
           [form.theme]

--- a/lib/project_types/theme/commands/publish.rb
+++ b/lib/project_types/theme/commands/publish.rb
@@ -19,6 +19,7 @@ module Theme
             [],
             title: @ctx.message("theme.publish.select"),
             exclude_roles: ["live", "development", "demo"],
+            cmd: :publish
           )
           return unless form
           form.theme

--- a/lib/project_types/theme/forms/select.rb
+++ b/lib/project_types/theme/forms/select.rb
@@ -6,7 +6,7 @@ module Theme
   module Forms
     class Select < ShopifyCLI::Form
       attr_accessor :theme
-      flag_arguments :root, :title, :exclude_roles, :include_foreign_developments
+      flag_arguments :root, :title, :exclude_roles, :include_foreign_developments, :cmd
 
       def ask
         self.theme = CLI::UI::Prompt.ask(title, allow_empty: false) do |handler|
@@ -17,6 +17,9 @@ module Theme
             next if !include_foreign_developments && theme.foreign_development?
 
             handler.option(presenter.to_s(:short)) { theme }
+          end
+          if handler.options.empty? && cmd
+            @ctx.abort(@ctx.message("theme.#{cmd}.no_themes_error"), @ctx.message("theme.#{cmd}.no_themes_resolution"))
           end
         end
       end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -42,6 +42,8 @@ module Theme
           HELP
           done: "Your theme is now live at %s",
           not_found: "Theme #%s does not exist",
+          no_themes_error: "You don't have any theme to be published.",
+          no_themes_resolution: "Try to create an unpublished theme with {{command:theme push -u -t <theme_name>}}.",
           select: "Select theme to push to",
           confirm: "Are you sure you want to make %s the new live theme on %s?",
         },
@@ -233,6 +235,8 @@ module Theme
           HELP
           select: "Select theme to delete",
           done: "%s theme(s) deleted",
+          no_themes_error: "You don't have any theme to be deleted.",
+          no_themes_resolution: "Try to create an unpublished theme with {{command:theme push -u -t <theme_name>}}.",
           not_found: "{{x}} Theme #%s does not exist",
           live: "{{x}} Theme #%s is your live theme. You can't delete it.",
           confirm: "Are you sure you want to delete %s on %s?",

--- a/test/project_types/theme/commands/delete_test.rb
+++ b/test/project_types/theme/commands/delete_test.rb
@@ -116,6 +116,16 @@ module Theme
         @command.options.flags[:force] = true
         @command.call([], "delete")
       end
+
+      def test_delete_when_no_valid_themes_to_select_from
+        CLI::UI::Prompt.expects(:ask).raises(ShopifyCLI::Abort)
+
+        @theme.expects(:delete).never
+        @ctx.expects(:done).never
+        @ctx.expects(:puts)
+
+        @command.call([], "delete")
+      end
     end
   end
 end

--- a/test/project_types/theme/commands/publish_test.rb
+++ b/test/project_types/theme/commands/publish_test.rb
@@ -78,6 +78,16 @@ module Theme
 
         @command.call([])
       end
+
+      def test_publish_when_no_valid_themes_to_select_from
+        CLI::UI::Prompt.expects(:ask).raises(ShopifyCLI::Abort)
+
+        @theme.expects(:publish).never
+        @ctx.expects(:done).never
+        @ctx.expects(:puts)
+
+        @command.call([])
+      end
     end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#2327](https://github.com/Shopify/shopify-cli/issues/2327)

Fixes known cases where developers would go to select a theme from a dropdown and a nasty error was thrown. 
Known cases:
1. When running `theme publish` on a store with no unpublished themes.
2. When running `theme delete` on a store with no other non-live themes.

### WHAT is this pull request doing?

See the linked issue for the before error.
Now, the user sees: 
![screen_shot_2022-05-25_at_12 45 41_pm](https://user-images.githubusercontent.com/60304332/170324145-82b299bb-1938-4d90-a0b3-d0c56b39f909.png)
### How to test your changes?

1. Run `shopify theme publish` on a store with no unpublished themes.
2. Run `shopify theme delete` on a store with no other non-live themes.
### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).