### PR TITLE
Feature/detect outdated postpurchase subscription

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -216,6 +216,22 @@ module Extension
             * Add a develop script: shopify-cli-extensions develop
             * Change the build script to: shopify-cli-extensions build
           TEXT
+          product_subscription: <<~TEXT.strip,
+            Please update your package.json as follows:
+            * Replace the development dependency @shopify/admin-ui-extensions-run
+              with @shopify/shopify-cli-extensions
+            * Remove the start and server script
+            * Add a develop script: shopify-cli-extensions develop
+            * Change the build script to: shopify-cli-extensions build
+          TEXT
+          checkout_post_purchase: <<~TEXT.strip,
+            Please update your package.json as follows:
+            * Replace the development dependency @shopify/checkout-ui-extensions-run
+              with @shopify/shopify-cli-extensions
+            * Remove the start and server script
+            * Add a develop script: shopify-cli-extensions develop
+            * Change the build script to: shopify-cli-extensions build
+          TEXT
         },
       },
       warnings: {

--- a/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
+++ b/lib/project_types/extension/tasks/execute_commands/outdated_extension_detection.rb
@@ -20,6 +20,10 @@ module Extension
             case type
             when "checkout_ui_extension"
               context.message("errors.outdated_extensions.checkout_ui_extension")
+            when "product_subscription"
+              context.message("errors.outdated_extensions.product_subscription")
+            when "checkout_post_purchase"
+              context.message("errors.outdated_extensions.checkout_post_purchase")
             else
               context.message("errors.outdated_extensions.unknown")
             end
@@ -33,7 +37,7 @@ module Extension
 
           def valid?(package)
             case type
-            when "checkout_ui_extension"
+            when "checkout_ui_extension", "product_subscription", "checkout_post_purchase"
               package.dev_dependency?("@shopify/shopify-cli-extensions") &&
                 package.script?("build") &&
                 package.script?("develop")


### PR DESCRIPTION
### WHY are these changes introduced?

Preparation for unblocking new Argo flows for `product_subscription` and `checkout_post_purchase`. To prevent the CLI from crashing when running `shopify extensions {build|serve}` with the new extensions server without migrating the extension. Instead of crashing, the CLI will now emit an error message with detailed instructions.

### WHAT is this pull request doing?

- OutdatedExtensionCheck for `product_subscription` and `checkout_post_purchase`

### How to test your changes?

1. Ensure that the "legacy" flow is enabled for `product_subscription` and `checkout_post_purchase` by running `shopify config feature extension_server_beta --disable`.
2. Create two "legacy" flow extensions, one for `product_subscription` and one for `checkout_post_purchase` by running `shopify extension create` and supplying the requisite information.
3. Re-enable the Argo flows for `product_subscription` and `checkout_post_purchase` by running `shopify config feature extension_server_beta --enable`.
4. `cd` into each of the extension directories and run `shopify extension serve` answering the prompts.
5. Observe the error messages for each.

Post Purchase:
<img width="536" alt="Screen Shot 2022-05-25 at 4 28 46 PM" src="https://user-images.githubusercontent.com/4490738/170361442-10ffb8c5-5d4c-4782-9391-4455edc35115.png">

Subscription:
<img width="516" alt="Screen Shot 2022-05-25 at 4 29 25 PM" src="https://user-images.githubusercontent.com/4490738/170361530-e6173e18-0f6a-4291-8f86-c8b112c98396.png">

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).
