### PR TITLE
Require App Bridge paths + populate them on script create

### DIFF
--- a/lib/project_types/script/layers/infrastructure/script_project_repository.rb
+++ b/lib/project_types/script/layers/infrastructure/script_project_repository.rb
@@ -37,7 +37,9 @@ module Script
             extension_point_type: extension_point_type,
             title: title,
             description: nil,
-            language: language
+            language: language,
+            app_bridge_create_path: "/",
+            app_bridge_details_path: "/",
           )
 
           build_script_project(script_config: nil)
@@ -124,8 +126,8 @@ module Script
         end
 
         def app_bridge
-          create_path = project_config_value("app_bridge_create_path") || "/"
-          details_path = project_config_value("app_bridge_details_path") || "/"
+          create_path = project_config_value!("app_bridge_create_path")
+          details_path = project_config_value!("app_bridge_details_path")
 
           Domain::AppBridge.new(
             create_path: create_path,

--- a/lib/project_types/script/messages/messages.rb
+++ b/lib/project_types/script/messages/messages.rb
@@ -24,7 +24,7 @@ module Script
           oauth_help: "Wait a few minutes and try again.",
 
           invalid_context_cause: "Your .shopify-cli.yml is formatted incorrectly. It's missing values for "\
-                                 "extension_point_type or title.",
+                                 "extension_point_type, title, app_bridge_create_path or app_bridge_details_path.",
           invalid_context_help: "Add these values.",
 
           invalid_script_title_cause: "Script title contains unsupported characters.",

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -76,6 +76,14 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         assert_equal extension_point_type, subject.extension_point_type
         assert_equal language, subject.language
       end
+
+      it "stores default app bridge values to project config" do
+        capture_io { subject }
+        project = ShopifyCLI::Project.current(force_reload: true)
+
+        assert_equal "/", project.config["app_bridge_create_path"]
+        assert_equal "/", project.config["app_bridge_details_path"]
+      end
     end
   end
 
@@ -106,18 +114,21 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
       }
     end
     let(:valid_config) do
-      {
+      config = {
         "extension_point_type" => "payment_methods",
         "title" => title,
         "description" => description,
         "script_config" => script_config,
-        "app_bridge_create_path" => app_bridge_create_path,
-        "app_bridge_details_path" => app_bridge_details_path,
       }
+
+      config["app_bridge_create_path"] = app_bridge_create_path if app_bridge_create_path
+      config["app_bridge_details_path"] = app_bridge_details_path if app_bridge_details_path
+
+      config
     end
     let(:actual_config) { valid_config }
-    let(:app_bridge_create_path) { nil }
-    let(:app_bridge_details_path) { nil }
+    let(:app_bridge_create_path) { "/" }
+    let(:app_bridge_details_path) { "/" }
     let(:current_project) do
       TestHelpers::FakeProject.new(directory: File.join(ctx.root, title), config: actual_config)
     end
@@ -241,10 +252,8 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
         let(:app_bridge_create_path) { nil }
         let(:app_bridge_details_path) { nil }
 
-        it "should default to /" do
-          assert subject
-          assert "/", subject.app_bridge.create_path
-          assert "/", subject.app_bridge.details_path
+        it "should raise error" do
+          assert_raises(Script::Layers::Infrastructure::Errors::InvalidContextError) { subject }
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/script-service/issues/4712

### WHAT is this pull request doing?

This PR requires that App Bridge paths are present when pushing a script. It also populates default App Bridge paths when creating a script.

### How to test your changes?

- Create a new script and see that the App Bridge paths are present
- Push a script with App Bridge paths and see they are sent
- Push a script without App Bridge paths and see there is an error

### Update checklist

- [x] ~I've added a CHANGELOG entry for this PR (if the change is public-facing)~
- [x] ~I've considered possible cross-platform impacts (Mac, Linux, Windows).~
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] ~I've included any post-release steps in the section above (if needed).~