### PR TITLE
Add permitted key :configuration_schema to CheckoutUiExtension

### DIFF
--- a/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/checkout_ui_extension.rb
@@ -15,7 +15,7 @@ module Extension
            (?<region>[a-zA-Z]{2}) # Optional region subtag
           )?
           \z}x
-        PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name, :capabilities]
+        PERMITTED_CONFIG_KEYS = [:extension_points, :metafields, :name, :capabilities, :configuration_schema]
 
         def config(context)
           {

--- a/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/checkout_ui_extension_test.rb
@@ -92,7 +92,7 @@ module Extension
           Features::Argo.any_instance.stubs(:config).returns({})
           Features::ArgoConfig
             .expects(:parse_yaml)
-            .with(@context, [:extension_points, :metafields, :name, :capabilities])
+            .with(@context, [:extension_points, :metafields, :name, :capabilities, :configuration_schema])
             .once
             .returns({})
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [internal issue](https://github.com/Shopify/checkout-web/issues/10858)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Simply adding `configuration_schema` to the `PERMITTED_CONFIG_KEYS` of the `CheckoutUiExtension` specification handler.

This means that partners will be allowed to configure an attribute called `configuration_schema` in their `extension.config.yml` for checkout extensions. They will then be able to push these values when running the `extension push` command.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Use the instructions written in [this other pull request](https://github.com/Shopify/shopify/pull/353301).

#### Before this change
<img width="459" alt="Screen Shot 2022-05-26 at 12 02 44 PM" src="https://user-images.githubusercontent.com/3000613/170551377-4d12a3aa-8f6e-4864-8d5f-3f5d7d56cc43.png">

#### After this change (validation error)
<img width="599" alt="Screen Shot 2022-05-26 at 12 07 00 PM" src="https://user-images.githubusercontent.com/3000613/170551465-6e85ad63-a840-4d71-b1d1-48d7dccfd7c5.png">

#### After this change (valid)
<img width="573" alt="Screen Shot 2022-05-26 at 12 08 49 PM" src="https://user-images.githubusercontent.com/3000613/170551485-5d7597a5-8ae7-402b-84a7-167cfd84aea9.png">

Note: The reason for the message `base: Unexpected keys were found` is because the `configuration_schema` attribute is not yet added to the underlying UiExtension model in the backend. In this situation, pushing code to a draft version will work (with this warning) but publishing a version containing a configuration schema will be blocked.


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
n/a

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
  - I will add this once approvals are in since this file changes quickly.
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).