### PR TITLE
Allow shipping_methods and payment_customizations to pull rust script examples

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -15,6 +15,8 @@ payment_customization:
   libraries:
     wasm:
       repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
 shipping_methods:
   domain: 'checkout'
   libraries:
@@ -23,6 +25,8 @@ shipping_methods:
       package: "@shopify/scripts-checkout-apis"
       repo: "https://github.com/Shopify/scripts-apis-examples"
     wasm:
+      repo: "https://github.com/Shopify/scripts-apis-examples"
+    rust:
       repo: "https://github.com/Shopify/scripts-apis-examples"
 product_discounts:
   beta: true


### PR DESCRIPTION
This allows us to do `shopify script create --language=rust` and select `payment_customization` and `shipping_methods`

We have default rust scripts for them here https://github.com/Shopify/scripts-apis-examples/tree/master/checkout/rust