### PR TITLE
Consume bulk update in the theme assets API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 
 ### Added
-* [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements into `theme serve` and `theme push` commands
+* [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements to the `theme serve` and `theme push` commands
 
 ## Version 2.18.0 - 2022-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements into `theme serve` and `theme push` commands
+
 ## Version 2.18.0 - 2022-05-30
 
 ### Added

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -28,6 +28,7 @@ module Theme
         parser.on("-j", "--json") { flags[:json] = true }
         parser.on("-a", "--allow-live") { flags[:allow_live] = true }
         parser.on("-p", "--publish") { flags[:publish] = true }
+        parser.on("-s", "--stable") { flags[:stable] = true }
         parser.on("-o", "--only=PATTERN", Conversions::IncludeGlob) do |pattern|
           flags[:includes] ||= []
           flags[:includes] |= pattern
@@ -56,7 +57,8 @@ module Theme
 
         syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme,
           include_filter: include_filter,
-          ignore_filter: ignore_filter)
+          ignore_filter: ignore_filter,
+          stable: options.flags[:stable])
         begin
           syncer.start_threads
           if options.flags[:json]

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -17,6 +17,7 @@ module Theme
         parser.on("--poll") { flags[:poll] = true }
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
         parser.on("--theme-editor-sync") { flags[:editor_sync] = true }
+        parser.on("--stable") { flags[:stable] = true }
         parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
       end
 

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -16,6 +16,8 @@ module Theme
         ensure_user_try_this: <<~ENSURE_USER,
           Check if your user is activated, has permission to edit themes at the store, and try to re-login.
         ENSURE_USER
+        stable_flag_suggestion: "If the current command isn't working as expected," \
+          " we suggest re-running the command with the {{command: --stable}} flag",
         init: {
           help: <<~HELP,
             {{command:%s theme init}}: Clones a Git repository to use as a starting point for building a new theme.

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -28,11 +28,11 @@ module ShopifyCLI
         attr_accessor :ctx
 
         def start(ctx, root, host: "127.0.0.1", theme: nil, port: 9292, poll: false, editor_sync: false,
-          mode: ReloadMode.default)
+          mode: ReloadMode.default, stable: false)
           @ctx = ctx
           theme = find_theme(root, theme)
           ignore_filter = IgnoreFilter.from_path(root)
-          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync)
+          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync, stable: stable)
           watcher = Watcher.new(ctx, theme: theme, ignore_filter: ignore_filter, syncer: @syncer, poll: poll)
           remote_watcher = RemoteWatcher.to(theme: theme, syncer: @syncer)
 

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -32,7 +32,8 @@ module ShopifyCLI
           @ctx = ctx
           theme = find_theme(root, theme)
           ignore_filter = IgnoreFilter.from_path(root)
-          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync, stable: stable)
+          @syncer = Syncer.new(ctx, theme: theme, ignore_filter: ignore_filter, overwrite_json: !editor_sync,
+            stable: stable)
           watcher = Watcher.new(ctx, theme: theme, ignore_filter: ignore_filter, syncer: @syncer, poll: poll)
           remote_watcher = RemoteWatcher.to(theme: theme, syncer: @syncer)
 

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -194,6 +194,7 @@ module ShopifyCLI
           wait!(&block)
         end
 
+        api_client.deactivate_throttler!
         enqueue_delayed_files_updates
       end
 

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -37,7 +37,7 @@ module ShopifyCLI
 
       def_delegators :@error_reporter, :has_any_error?
 
-      def initialize(ctx, theme:, include_filter: nil, ignore_filter: nil, overwrite_json: true)
+      def initialize(ctx, theme:, include_filter: nil, ignore_filter: nil, overwrite_json: true, stable: false)
         @ctx = ctx
         @theme = theme
         @include_filter = include_filter
@@ -71,7 +71,8 @@ module ShopifyCLI
         # Initialize `api_client` on main thread
         @api_client = ThemeAdminAPIThrottler.new(
           @ctx,
-          ThemeAdminAPI.new(@ctx, @theme.shop)
+          ThemeAdminAPI.new(@ctx, @theme.shop),
+          !stable
         )
       end
 
@@ -286,7 +287,7 @@ module ShopifyCLI
 
         api_client.put(path: path, body: req_body) do |status, resp_body, response|
           update_checksums(resp_body)
-          yield(response)
+          yield(response) if block_given?
         end
       end
 

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -8,16 +8,10 @@ module ShopifyCLI
     class Syncer
       module JsonUpdateHandler
         def enqueue_json_updates(files)
-          # Some files must be uploaded after the other ones
-          delayed_files = [
-            theme["config/settings_schema.json"],
-            theme["config/settings_data.json"],
-          ]
-
           # Update remote JSON files and delays `delayed_files` update
           files = files
             .select { |file| !ignore_file?(file) && file.exist? && checksums.file_has_changed?(file) }
-            .sort_by { |file| delayed_files.include?(file) ? 1 : 0 }
+            .reject { |file| delayed_files.include?(file) }
 
           if overwrite_json?
             enqueue_updates(files)
@@ -25,6 +19,18 @@ module ShopifyCLI
             # Handle conflicts when JSON files cannot be overwritten
             handle_update_conflicts(files)
           end
+        end
+
+        def enqueue_delayed_files_updates
+          # Update delayed files synchronously
+          delayed_files.each { |file| update(file) }
+        end
+
+        def delayed_files
+          [
+            theme["config/settings_schema.json"],
+            theme["config/settings_data.json"],
+          ]
         end
 
         private

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -23,7 +23,9 @@ module ShopifyCLI
 
         def enqueue_delayed_files_updates
           # Update delayed files synchronously
-          delayed_files.each { |file| update(file) }
+          delayed_files.each do |file|
+            update(file) if checksums.file_has_changed?(file)
+          end
         end
 
         def delayed_files

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -11,7 +11,8 @@ module ShopifyCLI
           # Update remote JSON files and delays `delayed_files` update
           files = files
             .select { |file| !ignore_file?(file) && file.exist? && checksums.file_has_changed?(file) }
-            .reject { |file| delayed_files.include?(file) }
+            .sort_by { |file| delayed_files.include?(file) ? 1 : 0 }
+            .reject { |file| overwrite_json? && delayed_files.include?(file) }
 
           if overwrite_json?
             enqueue_updates(files)
@@ -22,6 +23,7 @@ module ShopifyCLI
         end
 
         def enqueue_delayed_files_updates
+          return unless overwrite_json?
           # Update delayed files synchronously
           delayed_files.each do |file|
             update(file) if checksums.file_has_changed?(file)

--- a/lib/shopify_cli/theme/theme_admin_api_throttler.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+require_relative "theme_admin_api_throttler/bulk"
+require_relative "theme_admin_api_throttler/put_request"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      extend Forwardable
+
+      def_delegators :@admin_api, :get, :post, :delete
+
+      def initialize(ctx, admin_api, active = true)
+        @ctx = ctx
+        @admin_api = admin_api
+        @active = active
+        @bulk = Bulk.new(ctx, admin_api)
+      end
+
+      def put(path:, **args, &block)
+        request = PutRequest.new(path, args[:body], &block)
+        if active?
+          bulk_request(request)
+        else
+          rest_request(request)
+        end
+      end
+
+      def activate!
+        @active = true
+      end
+
+      def deactivate!
+        @active = false
+      end
+
+      def active?
+        @active
+      end
+
+      def shutdown
+        @bulk.shutdown if active?
+      end
+
+      private
+
+      def rest_request(request)
+        @admin_api.rest_request(**request.to_h, &request.block)
+      rescue => error
+        request.block.call(nil, error, nil)
+      end
+
+      def bulk_request(request)
+        @bulk.enqueue(request)
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler.rb
@@ -10,6 +10,8 @@ module ShopifyCLI
     class ThemeAdminAPIThrottler
       extend Forwardable
 
+      attr_reader :bulk, :admin_api
+
       def_delegators :@admin_api, :get, :post, :delete
 
       def initialize(ctx, admin_api, active = true)
@@ -41,19 +43,19 @@ module ShopifyCLI
       end
 
       def shutdown
-        @bulk.shutdown
+        bulk.shutdown
       end
 
       private
 
       def rest_request(request)
-        @admin_api.rest_request(**request.to_h, &request.block)
-      rescue => error
-        request.block.call(nil, error, nil)
+        request.block.call(admin_api.rest_request(**request.to_h))
+      rescue StandardError => error
+        request.block.call(500, {}, error)
       end
 
       def bulk_request(request)
-        @bulk.enqueue(request)
+        bulk.enqueue(request)
       end
     end
   end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler.rb
@@ -30,11 +30,11 @@ module ShopifyCLI
         end
       end
 
-      def activate!
+      def activate_throttler!
         @active = true
       end
 
-      def deactivate!
+      def deactivate_throttler!
         @active = false
       end
 

--- a/lib/shopify_cli/theme/theme_admin_api_throttler.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler.rb
@@ -41,7 +41,7 @@ module ShopifyCLI
       end
 
       def shutdown
-        @bulk.shutdown if active?
+        @bulk.shutdown
       end
 
       private

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative "bulk_job"
+require "shopify_cli/thread_pool"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class Bulk
+        MAX_BULK_BYTESIZE = 10_485_760 # 10MB
+        MAX_BULK_FILES = 20 # files
+        QUEUE_TIMEOUT = 0.2 # 200ms
+
+        attr_accessor :admin_api
+
+        def initialize(ctx, admin_api, pool_size: 20)
+          @ctx = ctx
+          @admin_api = admin_api
+          @latest_enqueued_at = now
+
+          @thread_pool = ShopifyCLI::ThreadPool.new(pool_size: pool_size)
+
+          pool_size.times do
+            @thread_pool.schedule(
+              BulkJob.new(ctx, self)
+            )
+          end
+
+          @put_requests = []
+          @mut = Mutex.new
+        end
+
+        def enqueue(put_request)
+          @mut.synchronize do
+            @latest_enqueued_at = now
+            @put_requests << put_request
+          end
+        end
+
+        def shutdown
+          sleep(0.2) until @put_requests.empty?
+          @thread_pool.shutdown
+        end
+
+        def consume_put_requests
+          
+          to_batch = []
+          to_batch_size_bytes = 0
+          @mut.synchronize do
+            # sort requests to perform less retries at the `bulk_job`` level
+            @put_requests.sort_by! { |r| r.liquid? ? 0 : 1 }
+
+            is_ready = false
+            until is_ready || @put_requests.empty?
+              request = @put_requests.first
+              if to_batch.empty? && request.size > MAX_BULK_BYTESIZE
+                is_ready = true
+                to_batch << request
+                @put_requests.shift
+              elsif to_batch.size + 1 > MAX_BULK_FILES || to_batch_size_bytes + request.size > MAX_BULK_BYTESIZE
+                is_ready = true
+              else
+                to_batch << request
+                to_batch_size_bytes += request.size
+                @put_requests.shift
+              end
+            end
+          end
+
+          to_batch
+        end
+
+        def ready?
+          queue_timeout? || bulk_size >= MAX_BULK_FILES || bulk_bytesize >= MAX_BULK_BYTESIZE
+        end
+
+        def bulk_bytesize
+          @put_requests.map(&:size).reduce(:+).to_i
+        end
+
+        private
+
+        def bulk_size
+          @put_requests.size
+        end
+
+        def queue_timeout?
+          return false if bulk_size.zero?
+          elapsed_time = now - @latest_enqueued_at
+          elapsed_time > QUEUE_TIMEOUT
+        end
+
+        def now
+          Time.now.to_f
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
@@ -43,7 +43,7 @@ module ShopifyCLI
         end
 
         def consume_put_requests
-          
+
           to_batch = []
           to_batch_size_bytes = 0
           @mut.synchronize do

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
@@ -43,7 +43,6 @@ module ShopifyCLI
         end
 
         def consume_put_requests
-
           to_batch = []
           to_batch_size_bytes = 0
           @mut.synchronize do
@@ -66,7 +65,6 @@ module ShopifyCLI
               end
             end
           end
-
           to_batch
         end
 

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
@@ -38,7 +38,7 @@ module ShopifyCLI
         end
 
         def shutdown
-          sleep(0.2) until @put_requests.empty?
+          wait_put_requests
           @thread_pool.shutdown
         end
 
@@ -86,6 +86,10 @@ module ShopifyCLI
           return false if bulk_size.zero?
           elapsed_time = now - @latest_enqueued_at
           elapsed_time > QUEUE_TIMEOUT
+        end
+
+        def wait_put_requests
+          sleep(0.2) until @put_requests.empty?
         end
 
         def now

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "shopify_cli/thread_pool/job"
+require_relative "request_parser"
+require_relative "response_parser"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class BulkJob < ShopifyCLI::ThreadPool::Job
+        JOB_TIMEOUT = 0.2 # 200ms
+
+        attr_reader :bulk
+
+        def initialize(ctx, bulk)
+          super(JOB_TIMEOUT)
+          @ctx = ctx
+          @bulk = bulk
+
+          # Mutex used to coordinate changes performed by the bulk item block
+          @block_mutex = Mutex.new
+        end
+
+        def perform!
+          return unless bulk.ready?
+          put_requests = bulk.consume_put_requests
+
+          bulk_status, bulk_body, response = rest_request(put_requests)
+
+          if bulk_status == 207
+            responses(bulk_body).each_with_index do |tuple, index|
+              status, body = tuple
+              put_request = put_requests[index]
+              if status == 200 || put_request.retries > 5
+                @ctx.debug("[BulkJob] asset saved: #{put_request}")
+                @block_mutex.synchronize do
+                  put_request.block.call(status, body, response)
+                end
+              else
+                @ctx.debug("[BulkJob] asset error: #{put_request}")
+                @block_mutex.synchronize do
+                  put_request.retries += 1
+                  bulk.enqueue(put_request)
+                end
+              end
+            end
+          else
+            # ignore
+            @ctx.puts("Suggest --stable flag")
+          end
+        end
+
+        private
+
+        def rest_request(put_requests)
+          request = RequestParser.new(put_requests).parse
+          bulk.admin_api.rest_request(**request)
+        end
+
+        def responses(response_body)
+          ResponseParser.new(response_body).parse
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/put_request.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/put_request.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "shopify_cli/thread_pool/job"
+require_relative "request_parser"
+require_relative "response_parser"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class PutRequest
+        attr_reader :method, :body, :path, :block
+        attr_accessor :retries
+
+        def initialize(path, body, &block)
+          @method = "PUT"
+          @path = path
+          @body = body
+          @block = block
+          @retries = 0
+        end
+
+        def to_h
+          {
+            method: method,
+            path: path,
+            body: body,
+          }
+        end
+
+        def to_s
+          "#{key}, retries: #{retries}"
+        end
+
+        def liquid?
+          key.end_with?(".liquid")
+        end
+
+        def key
+          JSON.parse(body)["asset"]["key"]
+        end
+
+        def bulk_path
+          path.gsub(/.json$/, "/bulk.json")
+        end
+
+        def size
+          @size ||= body.bytesize
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/put_request.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/put_request.rb
@@ -36,7 +36,7 @@ module ShopifyCLI
         end
 
         def key
-          JSON.parse(body)["asset"]["key"]
+          @key ||= JSON.parse(body)["asset"]["key"]
         end
 
         def bulk_path

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/request_parser.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/request_parser.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class RequestParser
+        def initialize(requests)
+          @requests = requests
+        end
+
+        def parse
+          {
+            path: path,
+            method: method,
+            body: JSON.generate({ assets: assets }),
+          }
+        end
+
+        private
+
+        def method
+          @requests.sample.method
+        end
+
+        def path
+          @requests.sample.bulk_path
+        end
+
+        def assets
+          @requests.map do |request|
+            body = JSON.parse(request.body)
+            body = body.is_a?(Hash) ? body : JSON.parse(body)
+            body["asset"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/response_parser.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/response_parser.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class ResponseParser
+        def initialize(response_body)
+          @response_body = response_body
+        end
+
+        def parse
+          result = []
+          @response_body["results"]&.each do |resp|
+            result << [resp["code"], resp["body"]]
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -35,7 +35,7 @@ module Theme
           .returns(@theme)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -57,7 +57,7 @@ module Theme
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -70,6 +70,28 @@ module Theme
         @command.call([], "push")
       end
 
+      def test_push_with_stable
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: true)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme] = 1234
+        @command.options.flags[:stable] = true
+        @command.call([], "push")
+      end
+
       def test_push_with_root
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: "dist", identifier: 1234)
@@ -78,7 +100,7 @@ module Theme
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with("dist").returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -101,7 +123,7 @@ module Theme
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -127,7 +149,7 @@ module Theme
           .returns(true)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -153,7 +175,7 @@ module Theme
           .returns(true)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -176,7 +198,7 @@ module Theme
         CLI::UI::Prompt.expects(:confirm).never
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -198,7 +220,7 @@ module Theme
         @theme.expects(:to_h).returns({})
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -224,7 +246,7 @@ module Theme
         @theme.expects(:to_h).returns({})
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(syncer)
 
         syncer.expects(:start_threads)
@@ -249,7 +271,7 @@ module Theme
           .returns(@theme)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -275,7 +297,7 @@ module Theme
           .with(".", includes)
           .returns(include_filter)
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -298,7 +320,7 @@ module Theme
         @ignore_filter.expects(:add_patterns).with(["config/*"])
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -318,7 +340,7 @@ module Theme
           .returns(@theme)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -340,7 +362,7 @@ module Theme
         CLI::UI::Prompt.expects(:ask).returns("NAME")
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -364,7 +386,7 @@ module Theme
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -385,7 +407,7 @@ module Theme
           .returns(@theme)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)
@@ -407,7 +429,7 @@ module Theme
         @syncer.expects(:upload_theme!).with(delete: true)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
-          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
           .returns(@syncer)
 
         @syncer.expects(:start_threads)

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -48,6 +48,15 @@ module Theme
         end
       end
 
+      def test_with_stable
+        ShopifyCLI::Theme::DevServer.expects(:start)
+          .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, stable: true)
+
+        run_serve_command do |command|
+          command.options.flags[:stable] = true
+        end
+      end
+
       def test_can_specify_poll
         ShopifyCLI::Theme::DevServer.expects(:start)
           .with(@ctx, ".", host: Theme::Command::Serve::DEFAULT_HTTP_HOST, poll: true)

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -128,7 +128,7 @@ module ShopifyCLI
 
           @ctx.output_captured = true
           io = capture_io_and_assert_raises(ShopifyCLI::AbortSilent) do
-            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port, stable: true)
           end
           @ctx.output_captured = false
 
@@ -170,7 +170,7 @@ module ShopifyCLI
           @ctx.stubs(:message).with("theme.serve.ensure_user", shop).returns(error_message)
           @ctx.output_captured = true
           io = capture_io_and_assert_raises(ShopifyCLI::Abort) do
-            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port, stable: true)
           end
           @ctx.output_captured = false
 
@@ -182,7 +182,7 @@ module ShopifyCLI
         def start_server
           @ctx = TestHelpers::FakeContext.new(root: "#{ShopifyCLI::ROOT}/test/fixtures/theme")
           @server_thread = Thread.new do
-            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port)
+            DevServer.start(@ctx, "#{ShopifyCLI::ROOT}/test/fixtures/theme", port: @@port, stable: true)
           rescue => e
             puts "Failed to start DevServer:"
             puts e.message

--- a/test/shopify-cli/theme/syncer/json_update_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_update_handler_test.rb
@@ -22,7 +22,7 @@ module ShopifyCLI
         def test_enqueue_json_updates_when_it_should_overwrite_json_files
           @overwrite_json = true
 
-          expects(:enqueue_updates).with(@to_update)
+          expects(:enqueue_updates).with(@to_update - [@delayed_file1, @delayed_file2])
 
           enqueue_json_updates(@files)
         end
@@ -101,6 +101,24 @@ module ShopifyCLI
           enqueue_json_updates(@files)
         end
 
+        def test_enqueue_delayed_files_updates_when_overwrite_json_is_true
+          @overwrite_json = true
+
+          expects(:update).with(@delayed_file1)
+          expects(:update).with(@delayed_file2)
+
+          enqueue_delayed_files_updates
+        end
+
+        def test_enqueue_delayed_files_updates_when_overwrite_json_is_false
+          @overwrite_json = false
+
+          expects(:update).with(@delayed_file1).never
+          expects(:update).with(@delayed_file2).never
+
+          enqueue_delayed_files_updates
+        end
+
         private
 
         def mock_files
@@ -157,6 +175,7 @@ module ShopifyCLI
         def enqueue_union_merges(files); end
         def delete_locally(file); end
         def ignore_file?(file); end
+        def update(file); end
       end
     end
   end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -63,13 +63,13 @@ module ShopifyCLI
       end
 
       def test_update_with_bulk_request
-        @syncer.api_client.deactivate!
+        @syncer.api_client.deactivate_throttler!
         @syncer.api_client.admin_api.expects(:rest_request)
         @syncer.send(:update, @theme["assets/theme.css"])
       end
 
       def test_update_with_regular_request_bulk
-        @syncer.api_client.activate!
+        @syncer.api_client.activate_throttler!
         @syncer.api_client.bulk.expects(:enqueue)
         @syncer.send(:update, @theme["assets/theme.css"])
       end
@@ -495,6 +495,7 @@ module ShopifyCLI
         @syncer.expects(:enqueue_updates).with(@theme.static_asset_files)
         @syncer.expects(:enqueue_json_updates).with(@theme.json_files)
         @syncer.expects(:enqueue_delayed_files_updates)
+        @syncer.api_client.expects(:deactivate_throttler!)
 
         @syncer.start_threads
         @syncer.upload_theme!(delete: true)

--- a/test/shopify-cli/theme/theme_admin_api_throttler/bulk_job_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/bulk_job_test.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timecop"
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/theme_admin_api_throttler/put_request"
+require "shopify_cli/theme/theme_admin_api_throttler/bulk"
+
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class BulkJobTest < Minitest::Test
+        def setup
+          super
+
+          root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:development_theme_id)
+            .returns("12345678")
+
+          ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:shop)
+            .returns("dev-theme-server-store.myshopify.com")
+
+          @ctx = TestHelpers::FakeContext.new(root: root)
+          @theme = Theme.new(@ctx, root: root)
+          @admin_api = ThemeAdminAPI.new(@ctx, @theme.shop)
+        end
+
+        def test_perform_success
+          @job = BulkJob.new(bulk)
+          ShopifyCLI::AdminAPI
+            .expects(:rest_request)
+            .with(
+              @ctx,
+              shop: @theme.shop,
+              path: "themes/#{@theme.id}/assets/bulk.json",
+              method: "PUT",
+              api_version: "unstable",
+              body: JSON.generate({
+                assets: [
+                  { key: "file1.txt", value: "file1" },
+                ]
+              })
+            ).returns(
+              [
+                207,
+                {
+                  "results" => [
+                    {
+                      "code" => 200,
+                      "body" => {
+                        "asset" => {
+                          "key" => "file1.txt",
+                        }
+                      }
+                    },
+                  ],
+                },
+                {}
+              ]
+            )
+
+          @ctx.expects(:puts).with("12:30:59 {{green:Synced }} {{>}} {{blue:update file1.txt}}").once
+
+          time_freeze do
+            @job.perform!
+          end
+        end
+
+        def test_perform_when_bulk_request_error
+          @job = BulkJob.new(bulk)
+          ShopifyCLI::AdminAPI
+            .expects(:rest_request)
+            .with(
+              @ctx,
+              shop: @theme.shop,
+              path: "themes/#{@theme.id}/assets/bulk.json",
+              method: "PUT",
+              api_version: "unstable",
+              body: JSON.generate({
+                assets: [
+                  { key: "file1.txt", value: "file1" },
+                ]
+              })
+            ).returns(
+              [
+                400,
+                {},
+                {}
+              ]
+            )
+          @job.expects(:handle_requeue).once
+          @job.perform!
+        end
+
+        def test_perform_when_asset_update_error
+          @job = BulkJob.new(bulk)
+          ShopifyCLI::AdminAPI
+            .expects(:rest_request)
+            .with(
+              @ctx,
+              shop: @theme.shop,
+              path: "themes/#{@theme.id}/assets/bulk.json",
+              method: "PUT",
+              api_version: "unstable",
+              body: JSON.generate({
+                assets: [
+                  { key: "file1.txt", value: "file1" },
+                ]
+              })
+            ).returns(
+              [
+                207,
+                {
+                  "results" => [
+                    {
+                      "code" => 422,
+                      "body" => {
+                        "errors" => {
+                          "asset" => "Something is wrong with this file!!!",
+                        }
+                      }
+                    },
+                  ],
+                },
+                {}
+              ]
+            )
+          # TODO: determine how to handle
+        end
+
+        private
+
+        def bulk
+          @bulk ||= stub(
+            "Bulk",
+            ready?: true,
+            consume_put_requests: [generate_put_request("file1", 34_021)],
+            admin_api: @admin_api,
+          )
+        end
+
+        def simulate_operations
+          # print error if passed error in block
+          # print synced otherwise
+        end
+
+        def generate_put_request(name, size, &block)
+          body = request_body(name, size)
+          path = "themes/#{@theme.id}/assets.json"
+          request = stub(
+            "PutRequest",
+            name: name, # debugging
+            method: "PUT",
+            body: body,
+            size: size,
+            path: path,
+            bulk_path: path.gsub(/.json$/, "/bulk.json"),
+            block: block,
+          )
+          request
+        end
+
+        def request_body(name, size)
+          JSON.generate(
+            asset: {
+              key: "#{name}.txt",
+              value: "#{name}",
+            }
+          )
+        end
+
+        def time_freeze(&block)
+          time = Time.local(2000, 1, 1, 12, 30, 59)
+          Timecop.freeze(time, &block)
+        end
+
+        def mock_context_synced_message
+          @ctx.stubs(:message)
+            .with("theme.serve.operation.status.synced")
+            .returns("Synced")
+        end
+
+        def mock_context_synced_message
+          @ctx.stubs(:message)
+            .with("theme.serve.operation.status.error")
+            .returns("Error")
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/theme_admin_api_throttler/put_request"
+require "shopify_cli/theme/theme_admin_api_throttler/bulk"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class BulkTest < Minitest::Test
+        MULTIPLE_THREADS = 3
+
+        def setup
+          super
+          root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:development_theme_id)
+            .returns("12345678")
+
+          # Avoid rest_request call
+          ShopifyCLI::Theme::ThemeAdminAPIThrottler::BulkJob
+            .any_instance
+            .stubs(:rest_request)
+            .returns(temp_bulk_response)
+
+          ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:shop)
+            .returns("dev-theme-server-store.myshopify.com")
+
+          @ctx = TestHelpers::FakeContext.new(root: root)
+          @theme = Theme.new(@ctx, root: root)
+          @admin_api = ThemeAdminAPI.new(@ctx, @theme.shop)
+        end
+
+        def test_batch_bytesize_upper_bound_with_multiple_threads
+          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+
+          file1 = generate_put_request("file1", 30_010)
+          file2 = generate_put_request("file2", 60_020)
+          file3 = generate_put_request("file3", 5_242_880) # exactly max bytesize
+
+          [file1, file2, file3].each do |r|
+            @bulk.enqueue(r)
+          end
+
+          assert(@bulk.num_calls, 2)
+          assert(@bulk.sizes, [90_030, 5_242_880])
+          @bulk.shutdown
+        end
+
+        def test_batch_bytesize_upper_bound_with_single_thread
+          @bulk = BulkMock.new(@admin_api)
+
+          file1 = generate_put_request("file1", 5_242_802)
+          file2 = generate_put_request("file2", 5_242_803)
+          file3 = generate_put_request("file3", 5_242_804) # exactly max bytesize
+
+          [file1, file2, file3].each do |r|
+            @bulk.enqueue(r)
+          end
+
+          assert(@bulk.num_calls, 3)
+          assert(@bulk.sizes, [5_242_802, 5_242_803, 5_242_804])
+          @bulk.shutdown
+        end
+
+        def test_batch_num_files_upper_bound_with_single_thread
+          @bulk = BulkMock.new(@admin_api)
+
+          Bulk::MAX_BULK_FILES.times { |n|
+            file = generate_put_request("file#{n}", 100_000)
+            @bulk.enqueue(file)
+          }
+
+          assert(@bulk.num_calls, 1)
+          assert(@bulk.sizes, [3_000_000])
+          @bulk.shutdown
+        end
+
+        def test_batch_num_files_upper_bound_with_multiple_threads
+          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+
+          num_requests = Bulk::MAX_BULK_FILES << 1
+
+          num_requests.times { |n|
+            file = generate_put_request("file#{n}", 10_000)
+            @bulk.enqueue(file)
+          }
+
+          assert(@bulk.num_calls, 2)
+          assert(@bulk.sizes, [Bulk::MAX_BULK_FILES * 10_000, Bulk::MAX_BULK_FILES * 10_000])
+          @bulk.shutdown
+        end
+
+        def test_batch_big_test_with_multiple_threads
+          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+
+          5.times { |n|
+            file = generate_put_request("file#{n}", 3_565_210 + n)
+            @bulk.enqueue(file)
+          }
+
+          assert(@bulk.num_calls, 5)
+          assert(@bulk.sizes, [3_565_211, 3_565_212, 3_565_213, 3_565_214, 3_565_215])
+          @bulk.shutdown
+        end
+
+        private
+
+        def generate_put_request(name, size)
+          body = request_body(name, size)
+          path = "themes/#{@theme.id}/assets.json"
+          request = stub(
+            "PutRequest",
+            name: name, # debugging
+            method: "PUT",
+            body: body,
+            size: size,
+            path: path,
+            bulk_path: path.gsub(/.json$/, "/bulk.json"),
+            block: nil,
+          )
+          request
+        end
+
+        def request_body(name, size)
+          JSON.generate(
+            asset: {
+              key: "#{name}.txt",
+              value: "#{name}",
+            }
+          )
+        end
+
+        def temp_bulk_response
+          [1234, [], {}]
+        end
+
+        class BulkMock < Bulk
+          attr_accessor :num_calls, :sizes
+
+          def initialize(admin_api, pool_size: 1)
+            super(admin_api, pool_size: pool_size)
+            @num_calls = 0
+            @sizes = []
+          end
+
+          def consume_put_requests
+            bulk_request = super # pretty hacky, but it appears to work and allows me to profile nicely
+
+            @sizes += bulk_request.map(&:size).reduce(:+).to_i
+            @num_calls += 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
@@ -124,7 +124,8 @@ module ShopifyCLI
           assert_equal([
             files[0].size + files[1].size,
             files[2].size + files[3].size,
-            files[4].size], @bulk.sizes)
+            files[4].size,
+          ], @bulk.sizes)
           @bulk.shutdown
         end
 

--- a/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
@@ -38,101 +38,98 @@ module ShopifyCLI
         end
 
         def test_batch_bytesize_upper_bound_with_multiple_threads
-          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+          @bulk = BulkMock.new(@ctx, @admin_api, pool_size: MULTIPLE_THREADS)
 
-          file1 = generate_put_request("file1", 30_010)
-          file2 = generate_put_request("file2", 60_020)
-          file3 = generate_put_request("file3", 5_242_880) # exactly max bytesize
+          file1 = generate_put_request("file1.txt", 30_010)
+          file2 = generate_put_request("file2.txt", 60_020)
+          file3 = generate_put_request("file3.txt", 5_242_880) # exactly max bytesize
 
           [file1, file2, file3].each do |r|
             @bulk.enqueue(r)
           end
 
-          assert(@bulk.num_calls, 2)
-          assert(@bulk.sizes, [90_030, 5_242_880])
+          assert_equal(@bulk.num_calls, 2)
+          assert_equal(@bulk.sizes, [90_030, 5_242_880])
           @bulk.shutdown
         end
 
         def test_batch_bytesize_upper_bound_with_single_thread
-          @bulk = BulkMock.new(@admin_api)
+          @bulk = BulkMock.new(@ctx, @admin_api)
 
-          file1 = generate_put_request("file1", 5_242_802)
-          file2 = generate_put_request("file2", 5_242_803)
-          file3 = generate_put_request("file3", 5_242_804) # exactly max bytesize
+          file1 = generate_put_request("file1.txt", 5_242_802)
+          file2 = generate_put_request("file2.txt", 5_242_803)
+          file3 = generate_put_request("file3.txt", 5_242_804) # exactly max bytesize
 
           [file1, file2, file3].each do |r|
             @bulk.enqueue(r)
           end
 
-          assert(@bulk.num_calls, 3)
-          assert(@bulk.sizes, [5_242_802, 5_242_803, 5_242_804])
+          assert_equal(@bulk.num_calls, 3)
+          assert_equal(@bulk.sizes, [5_242_802, 5_242_803, 5_242_804])
           @bulk.shutdown
         end
 
         def test_batch_num_files_upper_bound_with_single_thread
-          @bulk = BulkMock.new(@admin_api)
+          @bulk = BulkMock.new(@ctx, @admin_api)
 
-          Bulk::MAX_BULK_FILES.times { |n|
-            file = generate_put_request("file#{n}", 100_000)
+          Bulk::MAX_BULK_FILES.times do |n|
+            file = generate_put_request("file#{n}.txt", 100_000)
             @bulk.enqueue(file)
-          }
+          end
 
-          assert(@bulk.num_calls, 1)
-          assert(@bulk.sizes, [3_000_000])
+          assert_equal(@bulk.num_calls, 1)
+          assert_equal(@bulk.sizes, [3_000_000])
           @bulk.shutdown
         end
 
         def test_batch_num_files_upper_bound_with_multiple_threads
-          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+          @bulk = BulkMock.new(@ctx, @admin_api, pool_size: MULTIPLE_THREADS)
 
           num_requests = Bulk::MAX_BULK_FILES << 1
 
-          num_requests.times { |n|
-            file = generate_put_request("file#{n}", 10_000)
+          num_requests.times do |n|
+            file = generate_put_request("file#{n}.txt", 10_000)
             @bulk.enqueue(file)
-          }
+          end
 
-          assert(@bulk.num_calls, 2)
-          assert(@bulk.sizes, [Bulk::MAX_BULK_FILES * 10_000, Bulk::MAX_BULK_FILES * 10_000])
+          assert_equal(@bulk.num_calls, 2)
+          assert_equal(@bulk.sizes, [Bulk::MAX_BULK_FILES * 10_000, Bulk::MAX_BULK_FILES * 10_000])
           @bulk.shutdown
         end
 
         def test_batch_big_test_with_multiple_threads
-          @bulk = BulkMock.new(@admin_api, pool_size: MULTIPLE_THREADS)
+          @bulk = BulkMock.new(@ctx, @admin_api, pool_size: MULTIPLE_THREADS)
 
-          5.times { |n|
-            file = generate_put_request("file#{n}", 3_565_210 + n)
+          5.times do |n|
+            file = generate_put_request("file#{n}.txt", 3_565_210 + n)
             @bulk.enqueue(file)
-          }
+          end
 
-          assert(@bulk.num_calls, 5)
-          assert(@bulk.sizes, [3_565_211, 3_565_212, 3_565_213, 3_565_214, 3_565_215])
+          assert_equal(5, @bulk.num_calls)
+          assert_equal(@bulk.sizes, [3_565_211, 3_565_212, 3_565_213, 3_565_214, 3_565_215])
           @bulk.shutdown
         end
 
         private
 
         def generate_put_request(name, size)
-          body = request_body(name, size)
+          req_body = request_body(name)
           path = "themes/#{@theme.id}/assets.json"
-          request = stub(
-            "PutRequest",
-            name: name, # debugging
-            method: "PUT",
-            body: body,
-            size: size,
-            path: path,
-            bulk_path: path.gsub(/.json$/, "/bulk.json"),
-            block: nil,
-          )
-          request
+          req = PutRequest.new(path, req_body) do |status, body, _response|
+            if status == 200
+              @ctx.puts(body)
+            else
+              @ctx.error(body)
+            end
+          end
+          req
         end
 
-        def request_body(name, size)
+        def request_body(name)
           JSON.generate(
             asset: {
-              key: "#{name}.txt",
-              value: "#{name}",
+              key: name,
+              value: name,
             }
           )
         end
@@ -144,16 +141,14 @@ module ShopifyCLI
         class BulkMock < Bulk
           attr_accessor :num_calls, :sizes
 
-          def initialize(admin_api, pool_size: 1)
-            super(admin_api, pool_size: pool_size)
+          def initialize(ctx, admin_api, pool_size: 20)
+            super(ctx, admin_api, pool_size: pool_size)
             @num_calls = 0
             @sizes = []
           end
 
           def consume_put_requests
-            bulk_request = super # pretty hacky, but it appears to work and allows me to profile nicely
-
-            @sizes += bulk_request.map(&:size).reduce(:+).to_i
+            bulk_request = super
             @num_calls += 1
           end
         end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/put_request_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/put_request_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/theme_admin_api_throttler/put_request"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class PutRequestTest < Minitest::Test
+        def setup
+          super
+        end
+
+        def test_to_h
+          op = generate_operation("file1.json")
+          put_request = PutRequest.new(op[:path], op[:body])
+          expected_output = {
+            method: "PUT",
+            path: op[:path],
+            body: op[:body],
+          }
+          assert_equal(put_request.to_h, expected_output)
+        end
+
+        def test_to_s
+          op = generate_operation("file1.json")
+          put_request = PutRequest.new(op[:path], op[:body])
+          put_request.retries += 10
+
+          expected_output = "file1.json, retries: 10"
+          assert_equal(put_request.to_s, expected_output)
+        end
+
+        def test_liquid?
+          op1 = generate_operation("file1.json")
+          put_request_1 = PutRequest.new(op1[:path], op1[:body])
+
+          op2 = generate_operation("file1.liquid")
+          put_request_2 = PutRequest.new(op2[:path], op2[:body])
+
+          refute(put_request_1.liquid?)
+          assert(put_request_2.liquid?)
+        end
+
+        def test_key
+          op1 = generate_operation("file1.json")
+          put_request = PutRequest.new(op1[:path], op1[:body])
+          assert_equal("file1.json", put_request.key)
+        end
+
+        def test_bulk_path
+          op1 = generate_operation("file1.json")
+          put_request = PutRequest.new(op1[:path], op1[:body])
+
+          assert_equal("themes/1/assets/bulk.json", put_request.bulk_path)
+        end
+
+        def test_size
+          op1 = generate_operation("file1.json")
+          put_request = PutRequest.new(op1[:path], op1[:body])
+
+          assert_equal(put_request.size, op1[:body].bytesize)
+        end
+
+        private
+
+        def generate_operation(name)
+          {
+            path: "themes/1/assets.json",
+            body: JSON.generate({
+              asset: {
+                key: name,
+                value: name,
+              },
+            }),
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/request_parser_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/request_parser_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/theme_admin_api_throttler/errors"
+require "shopify_cli/theme/theme_admin_api_throttler/request_parser"
+require "shopify_cli/theme/theme_admin_api_throttler/put_request"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class RequestParserTest < Minitest::Test
+        def setup
+          super
+
+          ShopifyCLI::DB
+            .stubs(:exists?)
+            .with(:shop)
+            .returns(true)
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:shop)
+            .returns("shop.myshopify.com")
+        end
+
+        def test_parse
+          parser = RequestParser.new([
+            ShopifyCLI::Theme::ThemeAdminAPIThrottler::PutRequest.new(
+              "themes/#{theme.id}/assets.json",
+              JSON.generate({
+                asset: {
+                  key: "assets/theme.css",
+                  value: theme["assets/theme.css"].read,
+                },
+              }),
+            ),
+            ShopifyCLI::Theme::ThemeAdminAPIThrottler::PutRequest.new(
+              "themes/#{theme.id}/assets.json",
+              JSON.generate({
+                asset: {
+                  key: "assets/logo.png",
+                  attachment: Base64.encode64(theme["assets/logo.png"].read),
+                },
+              }),
+            ),
+          ])
+
+          actual_request = parser.parse
+          expected_request = {
+            path: "themes/123/assets/bulk.json",
+            method: "PUT",
+            body: JSON.generate({
+              assets: [
+                {
+                  key: "assets/theme.css",
+                  value: theme["assets/theme.css"].read,
+                },
+                {
+                  key: "assets/logo.png",
+                  attachment: Base64.encode64(theme["assets/logo.png"].read),
+                },
+              ],
+            }),
+          }
+
+          assert_equal(expected_request, actual_request)
+        end
+
+        private
+
+        def theme
+          @theme ||= Theme.new(ctx, root: root, id: "123")
+        end
+
+        def ctx
+          @ctx ||= TestHelpers::FakeContext.new(root: root)
+        end
+
+        def root
+          ShopifyCLI::ROOT + "/test/fixtures/theme"
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/request_parser_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/request_parser_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "shopify_cli/theme/theme"
-require "shopify_cli/theme/theme_admin_api_throttler/errors"
 require "shopify_cli/theme/theme_admin_api_throttler/request_parser"
 require "shopify_cli/theme/theme_admin_api_throttler/put_request"
 

--- a/test/shopify-cli/theme/theme_admin_api_throttler/response_parser_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/response_parser_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/theme_admin_api_throttler/errors"
+require "shopify_cli/theme/theme_admin_api_throttler/response_parser"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class ResponseParserTest < Minitest::Test
+        def setup
+          super
+
+          ShopifyCLI::DB
+            .stubs(:exists?)
+            .with(:shop)
+            .returns(true)
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:shop)
+            .returns("shop.myshopify.com")
+        end
+
+        def test_parse
+          parser = ResponseParser.new({
+            "results" => [
+              {
+                "code" => 200,
+                "body" => {
+                  "asset" => {
+                    "key" => "templates/index.liquid",
+                    "public_url" => nil,
+                    "created_at" => "2022-04-05T13:20:49-04:00",
+                    "updated_at" => "2022-04-05T13:20:49-04:00",
+                    "content_type" => "application/x-liquid",
+                    "size" => 3049,
+                    "checksum" => "1879a06996941b2ff1ff485a1fe60a97",
+                    "theme_id" => 828155753,
+                  },
+                },
+              },
+              {
+                "code" => 200,
+                "body" => {
+                  "asset" => {
+                    "key" => "icon-minus.liquid",
+                    "public_url" => nil,
+                    "created_at" => "2022-04-05T13:20:49-04:00",
+                    "updated_at" => "2022-04-05T13:20:49-04:00",
+                    "content_type" => "application/x-liquid",
+                    "size" => 3049,
+                    "checksum" => "1879a06996941b2323456f485a1fe60a97",
+                    "theme_id" => 828155753,
+                  },
+                },
+              },
+            ],
+          })
+          parsed_response = parser.parse
+          expected_response = [
+            [
+              200,
+              {
+                "asset" => {
+                  "key" => "templates/index.liquid",
+                  "public_url" => nil,
+                  "created_at" => "2022-04-05T13:20:49-04:00",
+                  "updated_at" => "2022-04-05T13:20:49-04:00",
+                  "content_type" => "application/x-liquid",
+                  "size" => 3049,
+                  "checksum" => "1879a06996941b2ff1ff485a1fe60a97",
+                  "theme_id" => 828155753,
+                },
+              },
+            ],
+            [
+              200,
+              {
+                "asset" => {
+                  "key" => "icon-minus.liquid",
+                  "public_url" => nil,
+                  "created_at" => "2022-04-05T13:20:49-04:00",
+                  "updated_at" => "2022-04-05T13:20:49-04:00",
+                  "content_type" => "application/x-liquid",
+                  "size" => 3049,
+                  "checksum" => "1879a06996941b2323456f485a1fe60a97",
+                  "theme_id" => 828155753,
+                },
+              },
+            ],
+          ]
+
+          assert_equal(parsed_response, expected_response)
+        end
+
+        private
+
+        def theme
+          @theme ||= Theme.new(ctx, root: root, id: "123")
+        end
+
+        def ctx
+          @ctx ||= TestHelpers::FakeContext.new(root: root)
+        end
+
+        def root
+          ShopifyCLI::ROOT + "/test/fixtures/theme"
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler/response_parser_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/response_parser_test.rb
@@ -2,7 +2,6 @@
 
 require "test_helper"
 require "shopify_cli/theme/theme"
-require "shopify_cli/theme/theme_admin_api_throttler/errors"
 require "shopify_cli/theme/theme_admin_api_throttler/response_parser"
 
 module ShopifyCLI

--- a/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/theme"
+require "shopify_cli/theme/theme_admin_api_throttler"
+
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottlerTest < Minitest::Test
+      def setup
+        super
+        root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:development_theme_id)
+            .returns("12345678")
+
+          ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+          ShopifyCLI::DB
+            .stubs(:get)
+            .with(:shop)
+            .returns("dev-theme-server-store.myshopify.com")
+
+          @ctx = TestHelpers::FakeContext.new(root: root)
+          @theme = Theme.new(@ctx, root: root)
+          @admin_api = ThemeAdminAPI.new(@ctx, @theme.shop)
+      end
+
+      def test_calls_rest_request_when_file_is_too_big
+        @throttler = ShopifyCLI::Theme::ThemeAdminAPIThrottler.new(@ctx, @admin_api)
+        op = operation("file1.json")
+
+        op.stubs(:size).returns(6_000_000)
+        @throttler.expects(:rest_request)
+
+        @throttler.put(path: op[:path], **op.to_h)
+      end
+
+      def operation(name)
+        {
+          path: "themes/#{@theme.id}/assets",
+          method: "PUT",
+          body: JSON.generate(
+            asset: {
+              key: name,
+            }
+          )
+        }
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
@@ -40,7 +40,7 @@ module ShopifyCLI
           .once
 
         @throttler.put(path: op1.path, **op1.body) { operation_handler_block }
-        @throttler.deactivate!
+        @throttler.deactivate_throttler!
         @throttler.put(path: op2.path, **op2.body) { operation_handler_block }
         @throttler.shutdown
       end

--- a/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler_test.rb
@@ -3,6 +3,7 @@
 require "test_helper"
 require "shopify_cli/theme/theme"
 require "shopify_cli/theme/theme_admin_api_throttler"
+require "shopify_cli/theme/theme_admin_api_throttler/put_request"
 
 module ShopifyCLI
   module Theme
@@ -10,42 +11,133 @@ module ShopifyCLI
       def setup
         super
         root = ShopifyCLI::ROOT + "/test/fixtures/theme"
-          ShopifyCLI::DB
-            .stubs(:get)
-            .with(:development_theme_id)
-            .returns("12345678")
+        ShopifyCLI::DB
+          .stubs(:get)
+          .with(:development_theme_id)
+          .returns("12345678")
 
-          ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
-          ShopifyCLI::DB
-            .stubs(:get)
-            .with(:shop)
-            .returns("dev-theme-server-store.myshopify.com")
+        ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
+        ShopifyCLI::DB
+          .stubs(:get)
+          .with(:shop)
+          .returns("dev-theme-server-store.myshopify.com")
 
-          @ctx = TestHelpers::FakeContext.new(root: root)
-          @theme = Theme.new(@ctx, root: root)
-          @admin_api = ThemeAdminAPI.new(@ctx, @theme.shop)
+        @ctx = TestHelpers::FakeContext.new(root: root)
+        @theme = Theme.new(@ctx, root: root)
+        @admin_api = ThemeAdminAPI.new(@ctx, @theme.shop)
       end
 
-      def test_calls_rest_request_when_file_is_too_big
+      def test_active_toggling_works
         @throttler = ShopifyCLI::Theme::ThemeAdminAPIThrottler.new(@ctx, @admin_api)
-        op = operation("file1.json")
+        op1 = generate_operation("file1.json", 10_000)
+        op2 = generate_operation("file2.json", 10_000)
 
-        op.stubs(:size).returns(6_000_000)
-        @throttler.expects(:rest_request)
+        @throttler
+          .expects(:bulk_request)
+          .once
+        @throttler
+          .expects(:rest_request)
+          .once
 
-        @throttler.put(path: op[:path], **op.to_h)
+        @throttler.put(path: op1.path, **op1.body) { operation_handler_block }
+        @throttler.deactivate!
+        @throttler.put(path: op2.path, **op2.body) { operation_handler_block }
+        @throttler.shutdown
       end
 
-      def operation(name)
-        {
-          path: "themes/#{@theme.id}/assets",
+      def test_throttler_throws_error_on_unsuccessful_rest_request
+        @throttler = ShopifyCLI::Theme::ThemeAdminAPIThrottler.new(@ctx, @admin_api, false)
+        error_body = JSON.generate(
+          errors: {
+            message: "Testing error",
+          }
+        )
+        ShopifyCLI::AdminAPI
+          .stubs(:rest_request)
+          .raises(api_error(error_body))
+        @ctx.expects(:error).with(error_body)
+        op1 = generate_operation("file1.json", 10_000)
+
+        test_operation(@throttler, op1)
+        @throttler.shutdown
+      end
+
+      def test_throttler_prints_synced_on_successful_rest_request
+        @throttler = ShopifyCLI::Theme::ThemeAdminAPIThrottler.new(@ctx, @admin_api, false)
+        op1 = generate_operation("file1.json", 10_000)
+        resp_body = JSON.generate(
+          asset: {
+            key: "file1.json",
+            checksum: "randomchecksum",
+          },
+        )
+        ShopifyCLI::AdminAPI
+          .stubs(:rest_request)
+          .with(
+            @ctx,
+            shop: @theme.shop,
+            path: op1.path,
+            method: "PUT",
+            api_version: "unstable",
+            body: JSON.generate({
+              asset: {
+                key: "file1.json",
+                value: "file1.json",
+              },
+            })
+          ).returns([
+            200,
+            {
+              "asset" => {
+                "key" => "file1.json",
+                "checksum" => "randomchecksum",
+              },
+            },
+            {},
+          ])
+        @ctx.expects(:puts).with(JSON.parse(resp_body))
+
+        test_operation(@throttler, op1)
+        @throttler.shutdown
+      end
+
+      private
+
+      def request_body(name)
+        JSON.generate(
+          asset: {
+            key: name,
+            value: name,
+          }
+        )
+      end
+
+      def generate_operation(name, size)
+        path = "themes/#{@theme.id}/assets.json"
+        request = stub(
+          "Operation",
+          name: name, # debugging
           method: "PUT",
-          body: JSON.generate(
-            asset: {
-              key: name,
-            }
-          )
-        }
+          body: { body: request_body(name) },
+          size: size,
+          path: path,
+          bulk_path: path.gsub(/.json$/, "/bulk.json"),
+        )
+        request
+      end
+
+      def api_error(msg)
+        ShopifyCLI::API::APIRequestError.new(msg, response: { body: msg })
+      end
+
+      def test_operation(throttler, operation)
+        throttler.put(path: operation.path, **operation.body) do |status, body, response|
+          if status == 500
+            @ctx.error(response.message)
+          else
+            @ctx.puts(body)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

We've introduced a new API that supports the upload of multiple assets in a single request. This PR relies on this new endpoint to optimize the `shopify theme push` and `shopify theme serve` commands.

### WHAT is this pull request doing?

This PR introduces an async API into the `ThemeAdminAPI`, so now it supports sync and async calls:
```ruby
# sync
status, body, response = api_client.put(path: path, body: body)

# async
api_client.put(path: path, body: body) do |status, resp_body, response|
  # ...
end
```

Also, it introduces the `ThemeAdminAPIThrottler` decorator, responsible for intercepting `PUT` requests in order to group them. The `ThemeAdminAPIThrottler` relies in the `ThemeAdminAPIThrottler::Bulk` class to perform requests in the new endpoint without blocking the `Syncer` (as some update operations are scheduled for a bulk requests, and can only be proceed when the bulk is ready).

Finally, after trying different tuninng approaches, I've decided to rely on:
- a pool of 20 threads
- a max bulk size of 20 assets
- a max bulk size of 10MB
- a timeout for new eligible PUT requests of 200ms

With those constraints, we've reached a `shopify theme push` command **6x faster** on our tests.

### How to test your changes?

- Create a theme with `shopify-dev theme init test_bulk`
- Run `shopify-dev theme push -u -t test_bulk_pr_2 --stable`
- Run `shopify-dev theme push -u -t test_bulk_pr_1`
- Notice is faster
- In a different directory, run `shopify-dev theme pull -t test_bulk_pr_1`
- In a different directory, run `shopify-dev theme pull -t test_bulk_pr_2`
- Compare both directories, they must be equal

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).