### PR TITLE
updated pixel runtime values from sandbox/unsandbox to strict/lax

### DIFF
--- a/test/project_types/extension/models/specification_handlers/web_pixel_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/web_pixel_extension_test.rb
@@ -7,7 +7,7 @@ module Extension
       class WebPixelExtensionTest < MiniTest::Test
         include ExtensionTestHelpers
         CONFIG_CONTENTS = <<~EOS
-          runtime_context: sandbox
+          runtime_context: strict
           version: "1"
           configuration:
             type: object
@@ -67,7 +67,7 @@ module Extension
         def test_config_implementation
           create(@context, "0", CONFIG_CONTENTS)
           payload = @web_pixel_extension.config(@context)
-          assert_equal("sandbox", payload[:runtime_context])
+          assert_equal("strict", payload[:runtime_context])
           assert_equal("MA==", payload[:serialized_script])
           assert_equal("1", payload[:config_version])
           config = JSON.parse(payload[:runtime_configuration_definition])

--- a/test/project_types/extension/models/specification_handlers/web_pixel_extension_utils/script_config_repository_test.rb
+++ b/test/project_types/extension/models/specification_handlers/web_pixel_extension_utils/script_config_repository_test.rb
@@ -23,14 +23,14 @@ module Extension
             File.open("#{@context.root}/extension.config.yml", "w") do |f|
               f.write(
                 <<-eos
-              runtime_context: sandbox
+              runtime_context: strict
               version: "2"
               eos
 
               )
             end
             yml_content = ScriptConfigYmlRepository.new(ctx: @context).get!.content
-            assert_equal({ "runtime_context" => "sandbox", "version" => "2" }, yml_content)
+            assert_equal({ "runtime_context" => "strict", "version" => "2" }, yml_content)
           end
 
           def test_script_config_yml_repo_raises_error_if_file_is_not_present

--- a/test/project_types/extension/models/specification_handlers/web_pixel_extension_utils/script_config_test.rb
+++ b/test/project_types/extension/models/specification_handlers/web_pixel_extension_utils/script_config_test.rb
@@ -20,7 +20,7 @@ module Extension
 
           def test_script_config_parses_valid_content
             content = {
-              "runtime_context" => "sandbox",
+              "runtime_context" => "strict",
               "version" => 2,
               "configuration" => {
 
@@ -31,7 +31,7 @@ module Extension
               content: content, filename: "some-file-name.yml"
             )
             assert_equal({
-              "runtime_context" => "sandbox",
+              "runtime_context" => "strict",
               "version" => 2,
               "configuration" => {
 
@@ -43,7 +43,7 @@ module Extension
 
           def test_script_config_raises_error_if_expected_field_is_missing
             content = {
-              "runtime_context" => "sandbox",
+              "runtime_context" => "strict",
               "configuration" => {
 
               },


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

EPIC: https://github.com/Shopify/ce-customer-behaviour/issues/984

the values for pixel runtime context should be 'strict' and 'lax'


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

updates references to web pixel runtime context values from sandbox/unsandbox to strict/lax

### How to test your changes?

Changes are only in test files, so ran tests.

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).