### PR TITLE
Adds support for git branches to git clone

### DIFF
--- a/lib/shopify_cli/git.rb
+++ b/lib/shopify_cli/git.rb
@@ -67,9 +67,14 @@ module ShopifyCLI
         if Dir.exist?(dest)
           ctx.abort(ctx.message("core.git.error.directory_exists"))
         else
+          repo, branch = repository.split("#")
           success_message = ctx.message("core.git.cloned", dest)
-          CLI::UI::Frame.open(ctx.message("core.git.cloning", repository, dest), success_text: success_message) do
-            clone_progress("clone", "--single-branch", repository, dest, ctx: ctx)
+          CLI::UI::Frame.open(ctx.message("core.git.cloning", repo, dest), success_text: success_message) do
+            if branch
+              clone_progress("clone", "--single-branch", "--branch", branch, repo, dest, ctx: ctx)
+            else
+              clone_progress("clone", "--single-branch", repo, dest, ctx: ctx)
+            end
           end
         end
       end

--- a/test/shopify-cli/git_test.rb
+++ b/test/shopify-cli/git_test.rb
@@ -160,6 +160,22 @@ module ShopifyCLI
       end
     end
 
+    def test_clones_git_repo_with_branch
+      Open3.expects(:popen3).with(
+        "git",
+        "clone",
+        "--single-branch",
+        "--branch",
+        "cli_test_branch",
+        "git@github.com:shopify/test.git",
+        "test-app",
+        "--progress"
+      ).returns(mock(success?: true))
+      capture_io do
+        ShopifyCLI::Git.clone("git@github.com:shopify/test.git#cli_test_branch", "test-app", ctx: @context)
+      end
+    end
+
     def test_clone_failure
       assert_raises(ShopifyCLI::Abort) do
         Open3.expects(:popen3).with(


### PR DESCRIPTION
### WHY are these changes introduced?

This support is needed in order to use `cli_two` branches in app templates repositories for backwards compatibility.

### WHAT is this pull request doing?

If a `#branch_name` is added to the repository url passed into `ShopifyCLI::Git.clone`, the url will be split into `repo` and `branch` and that `branch` will be cloned instead of the default.

### How to test your changes?

Unit test added to confirm functionality.

### Post-release steps

n/a

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing) - n/a internal only
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).