### PR TITLE
Changes php app repo to shopify-app-template-php

### DIFF
--- a/lib/shopify_cli/services/app/create/php_service.rb
+++ b/lib/shopify_cli/services/app/create/php_service.rb
@@ -74,7 +74,7 @@ module ShopifyCLI
           end
 
           def build(form)
-            ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-php.git", form.name)
+            ShopifyCLI::Git.clone("https://github.com/Shopify/shopify-app-template-php.git#cli_two", form.name)
 
             context.root = File.join(context.root, form.name)
             context.chdir(context.root)

--- a/test/shopify-cli/services/app/create/php_service_test.rb
+++ b/test/shopify-cli/services/app/create/php_service_test.rb
@@ -68,7 +68,10 @@ module ShopifyCLI
               ["https://registry.yarnpkg.com", nil]
             )
 
-            ShopifyCLI::Git.expects(:clone).with("https://github.com/Shopify/shopify-app-php.git", "test-app")
+            ShopifyCLI::Git.expects(:clone).with(
+              "https://github.com/Shopify/shopify-app-template-php.git#cli_two",
+              "test-app"
+            )
             ShopifyCLI::PHPDeps.expects(:install)
             ShopifyCLI::JsDeps.expects(:install)
             @context.expects(:system).with("php", "artisan", "key:generate")


### PR DESCRIPTION
### WHY are these changes introduced?

In preparation to launch new PHP app template, the repo name is being changed from `shopify-app-php` to `shopify-app-template-php`

Prerequisites before merging:
- repo rename to occur
- https://github.com/Shopify/shopify-cli/pull/2376 to be merged

Closes https://github.com/Shopify/first-party-library-planning/issues/306

### WHAT is this pull request doing?

☝🏻 See above!

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing) - not applicable
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).