### PR TITLE
Honor dev server beta flag without special casing checkout_ui_extensions

### DIFF
--- a/lib/project_types/extension/models/development_server_requirements.rb
+++ b/lib/project_types/extension/models/development_server_requirements.rb
@@ -15,7 +15,7 @@ module Extension
 
       class << self
         def supported?(type)
-          if type_supported?(type) && type_enabled?(type)
+          if type_supported?(type) && beta_enabled?
             return true if binary_installed?
             warn_about_missing_binary
           end
@@ -29,11 +29,6 @@ module Extension
 
         def type_supported?(type)
           SUPPORTED_EXTENSION_TYPES.include?(type.downcase)
-        end
-
-        # Some types are enabled unconditionally; others require beta_enabled
-        def type_enabled?(type)
-          beta_enabled? || "checkout_ui_extension" == type.downcase
         end
 
         private

--- a/test/project_types/extension/models/development_server_requirements_test.rb
+++ b/test/project_types/extension/models/development_server_requirements_test.rb
@@ -3,11 +3,9 @@ require "test_helper"
 module Extension
   module Models
     class DevelopmentServerRequirementsTest < MiniTest::Test
-      UNCONDITIONALLY_SUPPORTED_TYPES = [
-        "checkout_ui_extension",
-      ]
       CONDITIONALLY_SUPPORTED_TYPES = [
         "checkout_post_purchase",
+        "checkout_ui_extension",
         "product_subscription",
         "web_pixel_extension",
         "pos_ui_extension",
@@ -16,33 +14,6 @@ module Extension
       def setup
         ShopifyCLI::ProjectType.load_type(:extension)
         super
-      end
-
-      def test_unconditionally_supported_types_beta_enabled
-        Extension::Models::DevelopmentServerRequirements.stubs(:binary_installed?).returns(true)
-        Extension::Models::DevelopmentServerRequirements.stubs(:beta_enabled?).returns(true)
-
-        UNCONDITIONALLY_SUPPORTED_TYPES.each do |type|
-          assert Extension::Models::DevelopmentServerRequirements.supported?(type)
-        end
-      end
-
-      def test_unconditionally_supported_types_beta_disabled
-        Extension::Models::DevelopmentServerRequirements.stubs(:binary_installed?).returns(true)
-        Extension::Models::DevelopmentServerRequirements.stubs(:beta_enabled?).returns(false)
-
-        UNCONDITIONALLY_SUPPORTED_TYPES.each do |type|
-          assert Extension::Models::DevelopmentServerRequirements.supported?(type)
-        end
-      end
-
-      def test_unconditionally_supported_types_beta_enabled_binary_missing
-        Extension::Models::DevelopmentServerRequirements.stubs(:binary_installed?).returns(false)
-        Extension::Models::DevelopmentServerRequirements.stubs(:beta_enabled?).returns(true)
-
-        UNCONDITIONALLY_SUPPORTED_TYPES.each do |type|
-          refute Extension::Models::DevelopmentServerRequirements.supported?(type)
-        end
       end
 
       def test_conditionally_supported_types_beta_enabled


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This addresses part of https://github.com/Shopify/checkout-web/issues/11018

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The [shopify-cli-extensions](https://github.com/Shopify/shopify-cli-extensions) server will not be enabled by default. A developer would have to explicitly enable the beta flag after this PR.

Why? The public beta of Checkout UI Extensions will use [CLI 3.0](https://github.com/Shopify/shopify-cli-next/).

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
I just used the unit tests

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).