### PR TITLE
Bump theme-check version to 1.10.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     shopify-cli (2.18.1)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
-      theme-check (~> 1.10.1)
+      theme-check (~> 1.10.3)
 
 GEM
   remote: https://rubygems.org/
@@ -108,7 +108,7 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.21.0)
-    parser (3.1.1.0)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -150,7 +150,7 @@ GEM
       faraday (> 0.8, < 2.0)
     sys-uname (1.2.2)
       ffi (~> 1.1)
-    theme-check (1.10.2)
+    theme-check (1.10.3)
       liquid (>= 5.1.0)
       nokogiri (>= 1.12)
       parser (~> 3)

--- a/shopify-cli.gemspec
+++ b/shopify-cli.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   # Whereas if we were to have "~> 1.9", that version would still be satisfied and thus not upgraded.
   # Both shopify-cli and theme-check gems are owned and developed by Shopify.
   # These gems are currently being actively developed and it's easiest to update them together.
-  spec.add_dependency("theme-check", "~> 1.10.1")
+  spec.add_dependency("theme-check", "~> 1.10.3")
 
   spec.extensions = ["ext/shopify-extensions/extconf.rb"]
 end


### PR DESCRIPTION
Released v1.10.3 to support theme app extensions and bug fixes. Changelog can be found [here](https://github.com/Shopify/theme-check/releases/tag/v1.10.3)