### PR TITLE
Improve `-e/--editor` flag help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2418](https://github.com/Shopify/shopify-cli/pull/2418): Improve the help message of the `theme open -e/--editor` flag
 
-
 ## Version 2.18.0 - 2022-05-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Added
 * [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements to the `theme serve` and `theme push` commands
 
+### Fixed
+* [#2418](https://github.com/Shopify/shopify-cli/pull/2418): Improve the help message of the `theme open -e/--editor` flag
+
+
 ## Version 2.18.0 - 2022-05-30
 
 ### Added

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -311,7 +311,7 @@ module Theme
               {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of your theme.
               {{command:-l, --live}}             Open your live theme.
               {{command:-d, --development}}      Open your development theme.
-              {{command:-e, --editor}}           Open the editor to the specified/selected theme.
+              {{command:-e, --editor}}           Open the theme editor for the specified theme in the browser.
           HELP
         },
         list: {


### PR DESCRIPTION
### WHY are these changes introduced?

We've received the feedback that some developers expect the `-e/--editor` flag to open the **code editor** instead of the **theme editor**. So, this PR clarifies that in the command help message.

### WHAT is this pull request doing?

This PR slightly improves the `-e/--editor` flag help message.

### How to test your changes?

Run `shopify theme open --help`

<img width="1272" alt="demo" src="https://user-images.githubusercontent.com/1079279/174994581-f3ebdb55-5d31-408c-be84-515246675851.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).