### PR TITLE
Bulk API Integration: CI and Error Handling Patches

### DIFF
--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk.rb
@@ -46,7 +46,7 @@ module ShopifyCLI
           to_batch = []
           to_batch_size_bytes = 0
           @mut.synchronize do
-            # sort requests to perform less retries at the `bulk_job`` level
+            # sort requests to perform less retries at the `bulk_job` level
             @put_requests.sort_by! { |r| r.liquid? ? 0 : 1 }
 
             is_ready = false
@@ -55,6 +55,7 @@ module ShopifyCLI
               if to_batch.empty? && request.size > MAX_BULK_BYTESIZE
                 is_ready = true
                 to_batch << request
+                to_batch_size_bytes += request.size
                 @put_requests.shift
               elsif to_batch.size + 1 > MAX_BULK_FILES || to_batch_size_bytes + request.size > MAX_BULK_BYTESIZE
                 is_ready = true
@@ -65,7 +66,7 @@ module ShopifyCLI
               end
             end
           end
-          to_batch
+          [to_batch, to_batch_size_bytes]
         end
 
         def ready?

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
@@ -24,8 +24,10 @@ module ShopifyCLI
 
         def perform!
           return unless bulk.ready?
-          put_requests = bulk.consume_put_requests
+          put_requests, bulk_size = bulk.consume_put_requests
+          return if put_requests.empty?
 
+          @ctx.debug("[BulkJob] size: #{put_requests.size}, bytesize: #{bulk_size}")
           bulk_status, bulk_body, response = rest_request(put_requests)
 
           if bulk_status == 207

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/errors.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/errors.rb
@@ -1,0 +1,7 @@
+module ShopifyCLI
+  module Theme
+    class ThemeAdminAPIThrottler
+      class AssetUploadError < ShopifyCLI::API::APIRequestError; end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -64,7 +64,6 @@ module ShopifyCLI
         end
 
         def test_uploads_files_on_boot
-          skip
           start_server_and_wait_sync_files
 
           # Should upload all theme files except the ignored files


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the occasional CI errors in `bulk_test.rb`, as well as handles potential asset errors within the `theme serve` and `theme push` commands.

### WHAT is this pull request doing?

This PR changes the way we are testing `Bulk#consume_put_request` calls in a multi-threaded context, by making sure only valid `PutRequest` batches are making it to the API request to Core. It also handles asset upload errors in `theme sync` and `theme push` commands.

### How to test your changes?

CI Fixes: 
1. Run `ruby -I test test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb` multiple times, note no errors

Error Handling Fixes: 
1. Edit a local theme file to an invalid state (invalid css opacity property, etc).
2. Run `main` version of `theme serve/push` and note no individual asset error handling.
3. Checkout `fix/fix-bulk-test-ci-issue` and run `theme serve/push` and note the individual asset error handling.

### Update checklist

- [] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [] I've included any post-release steps in the section above (if needed).