### PR TITLE
Reduce bulk thread count for `bulk_test.rb`

### DIFF
--- a/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
+++ b/test/shopify-cli/theme/theme_admin_api_throttler/bulk_test.rb
@@ -9,7 +9,7 @@ module ShopifyCLI
   module Theme
     class ThemeAdminAPIThrottler
       class BulkTest < Minitest::Test
-        MULTIPLE_THREADS = 3
+        MULTIPLE_THREADS = 1
 
         def setup
           super


### PR DESCRIPTION
### WHY are these changes introduced?

Ensure clean CI experience.

### WHAT is this pull request doing?

Reduces thread count in `bulk_test.rb` to `1` to avoid extremely infrequent multi-threaded testing issues.

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).