### PR TITLE
Add support to the warnings field in the assets API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements to the `theme serve` and `theme push` commands
+* [#2437](https://github.com/Shopify/shopify-cli/pull/2437): Add support to the `warnings` field in the assets API
 
 ### Fixed
 * [#2418](https://github.com/Shopify/shopify-cli/pull/2418): Improve the help message of the `theme open -e/--editor` flag

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -181,6 +181,41 @@ module Theme
                 exit: "Exit",
               },
             },
+            warnings: {
+              unsupported_script: "unsupported script",
+              unsupported_script_text: <<~UNSUPPORTED_SCRIPT,
+
+                {{underline:Unsupported external checkout script}}
+
+                You have a code snippet on your storefront that violates
+                Shopify's Terms of Service. This script removes Shopify's
+                ability to protect your store against fraudulent orders,
+                could steal customer data and may cause customers to be
+                charged the wrong amount.
+
+                %s
+                By proceeding, you're acknowledging that you understand the
+                risks and will not hold Shopify liable for any problems that
+                occur due to the use of an external checkout, including:
+
+                - Discounts
+                - Shipping rules
+                - Multi-currency rules
+                - Variant selection
+                - Orders and fulfillment workflows
+                - Shopify Fraud Protection
+                - Payment settings
+                - Cart
+
+                You also acknowledge that you will not be able to reliably
+                get support for those features from Shopify because you are
+                violating Shopify's terms of service and that your account
+                may become suspended as a result.
+              UNSUPPORTED_SCRIPT
+              line_and_column: <<~LINE_AND_COLUMN,
+                - Line: %s Column: %s
+              LINE_AND_COLUMN
+            },
           },
           error: {
             address_binding_error: "Couldn't bind to localhost."\

--- a/lib/shopify_cli/theme/file.rb
+++ b/lib/shopify_cli/theme/file.rb
@@ -5,6 +5,7 @@ module ShopifyCLI
   module Theme
     class File < Struct.new(:path)
       attr_accessor :remote_checksum
+      attr_writer :warnings
 
       def initialize(path, root)
         super(Pathname.new(path))
@@ -102,6 +103,10 @@ module ShopifyCLI
 
       def relative_path
         @relative_path.to_s
+      end
+
+      def warnings
+        @warnings || []
       end
 
       private

--- a/lib/shopify_cli/theme/syncer/operation.rb
+++ b/lib/shopify_cli/theme/syncer/operation.rb
@@ -9,6 +9,7 @@ module ShopifyCLI
         COLOR_BY_STATUS = {
           error: :red,
           synced: :green,
+          warning: :yellow,
           fixed: :cyan,
         }
 
@@ -26,8 +27,8 @@ module ShopifyCLI
           as_message_with(status: :error)
         end
 
-        def as_synced_message
-          as_message_with(status: :synced)
+        def as_synced_message(color: :green)
+          as_message_with(status: :synced, color: color)
         end
 
         def as_fix_message
@@ -40,11 +41,11 @@ module ShopifyCLI
 
         private
 
-        def as_message_with(status:)
-          status_color = COLOR_BY_STATUS[status]
-          status_text = @ctx.message("theme.serve.operation.status.#{status}").ljust(6)
+        def as_message_with(status:, color: nil)
+          color ||= COLOR_BY_STATUS[status]
+          text = @ctx.message("theme.serve.operation.status.#{status}").ljust(6)
 
-          "#{timestamp} {{#{status_color}:#{status_text}}} {{>}} {{blue:#{self}}}"
+          "#{timestamp} {{#{color}:#{text}}} {{>}} {{blue:#{self}}}"
         end
 
         def timestamp

--- a/lib/shopify_cli/theme/syncer/unsupported_script_warning.rb
+++ b/lib/shopify_cli/theme/syncer/unsupported_script_warning.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class UnsupportedScriptWarning
+        attr_reader :ctx
+
+        def initialize(ctx, file)
+          @ctx = ctx
+          @file = file
+        end
+
+        def to_s
+          "\n\n#{occurrences} #{long_text}"
+        end
+
+        private
+
+        def occurrences
+          warnings.map { |w| occurrence(w) }.join("\n")
+        end
+
+        def occurrence(warning)
+          line_number = "{{blue: #{warning.line} |}}"
+          pointer = pointer_message(warning)
+
+          <<~OCCURRENCE
+            #{line_number} #{warning.line_content}
+            #{pointer}
+          OCCURRENCE
+        end
+
+        def long_text
+          lines_and_columns = warnings.map do |warning|
+            message("line_and_column", warning.line, warning.column)
+          end
+
+          message("unsupported_script_text", lines_and_columns.join)
+            .split("\n")
+            .reduce("") do |text, line|
+              # Add indentation in the long text to improve readability
+              line = " #{line}"
+
+              # Inline yellow (otherwise `CLI::UI::Frame` breaks multiline formatting)
+              line = "{{yellow:#{line}}}"
+
+              "#{text}#{line}\n"
+            end
+        end
+
+        def pointer_message(warning)
+          padding = warning.column + warning.line.to_s.size + 2
+          text = message("unsupported_script")
+
+          "{{yellow:#{" " * padding} ^ {{bold:#{text}}}}}"
+        end
+
+        def message(*args)
+          key = args.shift
+          @ctx.message("theme.serve.syncer.warnings.#{key}", *args)
+        end
+
+        def warnings
+          @warnings ||= @file.warnings.map { |w| Warning.new(@file, w) }
+        end
+
+        class Warning
+          attr_reader :line, :column
+
+          def initialize(file, warning_hash)
+            @file = file
+            @line = warning_hash["line"].to_i
+            @column = warning_hash["column"].to_i
+          end
+
+          def line_content
+            file_lines[line - 1]
+          end
+
+          private
+
+          def file_lines
+            @file_lines ||= @file.read.split("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/file_test.rb
+++ b/test/shopify-cli/theme/file_test.rb
@@ -116,6 +116,21 @@ module ShopifyCLI
         assert_equal(expected_relative_path, actual_relative_path)
       end
 
+      def test_warnings_when_it_is_nil
+        @file.warnings = nil
+
+        assert_empty(@file.warnings)
+      end
+
+      def test_warnings_when_it_is_not_nil
+        expected_warnings = [mock, mock]
+        @file.warnings = expected_warnings
+
+        actual_warnings = @file.warnings
+
+        assert_equal(expected_warnings, actual_warnings)
+      end
+
       private
 
       def fixture_file(file_path)

--- a/test/shopify-cli/theme/syncer/operation_test.rb
+++ b/test/shopify-cli/theme/syncer/operation_test.rb
@@ -33,6 +33,15 @@ module ShopifyCLI
           end
         end
 
+        def test_as_synced_message_with_different_color
+          @ctx.stubs(:message).with("theme.serve.operation.status.synced")
+            .returns("Synced")
+
+          time_freeze do
+            assert_message("{{yellow:Synced}}", @operation.as_synced_message(color: :yellow))
+          end
+        end
+
         def test_as_fix_message
           @ctx.stubs(:message).with("theme.serve.operation.status.fixed")
             .returns("Fixed")

--- a/test/shopify-cli/theme/syncer/unsupported_script_warning_test.rb
+++ b/test/shopify-cli/theme/syncer/unsupported_script_warning_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timecop"
+require "shopify_cli/theme/syncer/unsupported_script_warning"
+
+module ShopifyCLI
+  module Theme
+    class Syncer
+      class UnsupportedScriptWarningTest < Minitest::Test
+        def setup
+          super
+          Context.stubs(:messages).returns(messages_mock)
+
+          file = stub(
+            read: [
+              "http://123.com",
+              "http://456.com",
+              "http://789.com",
+            ].join("\n "),
+            warnings: [
+              { "line" => 1, "column" => 1 },
+              { "line" => 3, "column" => 2 },
+            ]
+          )
+          @warning = UnsupportedScriptWarning.new(@context, file)
+        end
+
+        def test_to_s
+          actual_message = @warning.to_s
+
+          assert_equal(<<~EXPECTED_MESSAGE, actual_message)
+
+
+          {{blue: 1 |}} http://123.com
+          {{yellow:     ^ {{bold:unsupported script}}}}
+
+          {{blue: 3 |}}  http://789.com
+          {{yellow:      ^ {{bold:unsupported script}}}}
+           {{yellow: unsupported script long text, lines:line 1 and column 1line 3 and column 2}}
+          EXPECTED_MESSAGE
+        end
+
+        private
+
+        def messages_mock
+          {
+            theme: {
+              serve: {
+                syncer: {
+                  warnings: {
+                    unsupported_script: "unsupported script",
+                    unsupported_script_text: "unsupported script long text, lines:%s",
+                    line_and_column: "line %s and column %s",
+                  },
+                },
+              },
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/syncer/unsupported_script_warning_test.rb
+++ b/test/shopify-cli/theme/syncer/unsupported_script_warning_test.rb
@@ -32,12 +32,12 @@ module ShopifyCLI
           assert_equal(<<~EXPECTED_MESSAGE, actual_message)
 
 
-          {{blue: 1 |}} http://123.com
-          {{yellow:     ^ {{bold:unsupported script}}}}
+            {{blue: 1 |}} http://123.com
+            {{yellow:     ^ {{bold:unsupported script}}}}
 
-          {{blue: 3 |}}  http://789.com
-          {{yellow:      ^ {{bold:unsupported script}}}}
-           {{yellow: unsupported script long text, lines:line 1 and column 1line 3 and column 2}}
+            {{blue: 3 |}}  http://789.com
+            {{yellow:      ^ {{bold:unsupported script}}}}
+             {{yellow: unsupported script long text, lines:line 1 and column 1line 3 and column 2}}
           EXPECTED_MESSAGE
         end
 


### PR DESCRIPTION
### WHY are these changes introduced?

The Admin API provides warnings when an asset contains unsupported scripts.

This PR introduces support for those warnings in the CLI context and shows a friendly warning message when an unsupported script is present.

### WHAT is this pull request doing?

The `Syncer` module now examines API responses and reports warnings when they are present.

### How to test your changes?

- First of all, let's do a quick **setup**:
  - Clone the `shopify/shopify-cli`
  - Create an alias to the CLI with `alias shopify-dev='<location>/Shopify/shopify-cli/bin/shopify'
  - Run `shopify-dev theme init test_theme`
  - Run `cd test_theme`
  - Run `shopify-dev login -s <your_store>`

- Now, let's test the warning message in the context of the **`serve`** command
  - Run `shopify-dev theme serve`
  - (wait for the progress bar)
  - Add an unsupported script in a theme asset
  - The warning must appear in the terminal

- Finally, let's test the warning message in the context of the **`push`** command
  - Add an unsupported script in an asset
  - Run `shopify-dev theme push -d`
  - The warning must appear in the terminal
 
### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).