### PR TITLE
Warn when using CLI 2.0 in a CLI 3.0 project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2520](https://github.com/Shopify/shopify-cli/pull/2520): Add the option to ignore new version warnings by passing the `SHOPIFY_CLI_RUN_AS_SUBPROCESS` environment variable
+* [#2440](https://github.com/Shopify/shopify-cli/pull/2440): Warn when using CLI 2.0 in a CLI 3.0 project
 
 ## Version 2.22.0 - 2022-08-08
 

--- a/lib/shopify_cli/core.rb
+++ b/lib/shopify_cli/core.rb
@@ -4,5 +4,6 @@ module ShopifyCLI
     autoload :Executor, "shopify_cli/core/executor"
     autoload :HelpResolver, "shopify_cli/core/help_resolver"
     autoload :Monorail, "shopify_cli/core/monorail"
+    autoload :CliVersion, "shopify_cli/core/cli_version"
   end
 end

--- a/lib/shopify_cli/core/cli_version.rb
+++ b/lib/shopify_cli/core/cli_version.rb
@@ -1,0 +1,26 @@
+module ShopifyCLI
+  module Core
+    ##
+    # ShopifyCLI::CLI checks that the CLI in use is correct for the project.
+    #
+    class CliVersion
+      class << self
+        def using_3_0?
+          !!cli_3_0_toml
+        end
+
+        private
+
+        def cli_3_0_toml
+          curr = Dir.pwd
+          loop do
+            return nil if curr == "/" || /^[A-Z]:\/$/.match?(curr)
+            file = File.join(curr, "shopify.app.toml")
+            return curr if File.exist?(file)
+            curr = File.dirname(curr)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/core/cli_version.rb
+++ b/lib/shopify_cli/core/cli_version.rb
@@ -1,17 +1,17 @@
 module ShopifyCLI
   module Core
     ##
-    # ShopifyCLI::CLI checks that the CLI in use is correct for the project.
+    # ShopifyCLI::Core::CliVersion checks that the CLI in use is correct for the project.
     #
     class CliVersion
       class << self
         def using_3_0?
-          !!cli_3_0_toml
+          !!cli_3_0_toml_dir
         end
 
         private
 
-        def cli_3_0_toml
+        def cli_3_0_toml_dir
           Utilities.directory("shopify.app.toml", Dir.pwd)
         end
       end

--- a/lib/shopify_cli/core/cli_version.rb
+++ b/lib/shopify_cli/core/cli_version.rb
@@ -12,13 +12,7 @@ module ShopifyCLI
         private
 
         def cli_3_0_toml
-          curr = Dir.pwd
-          loop do
-            return nil if curr == "/" || /^[A-Z]:\/$/.match?(curr)
-            file = File.join(curr, "shopify.app.toml")
-            return curr if File.exist?(file)
-            curr = File.dirname(curr)
-          end
+          Utilities.directory("shopify.app.toml", Dir.pwd)
         end
       end
     end

--- a/lib/shopify_cli/core/entry_point.rb
+++ b/lib/shopify_cli/core/entry_point.rb
@@ -11,7 +11,10 @@ module ShopifyCLI
           unless Environment.run_as_subprocess?
             if ctx.development? && !ctx.testing?
               ctx.warn(
-                ctx.message("core.warning.development_version", File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME))
+                ctx.message(
+                  "core.warning.development_version",
+                  File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME)
+                )
               )
               # because `!ctx.new_version.nil?` will change the config by calling ::Config.set
               # it's important to keep the checks in this order so that we don't trigger it while testing

--- a/lib/shopify_cli/core/entry_point.rb
+++ b/lib/shopify_cli/core/entry_point.rb
@@ -5,19 +5,24 @@ module ShopifyCLI
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
-          if ctx.development? && !ctx.testing?
-            ctx.warn(
-              ctx.message("core.warning.development_version", File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME))
-            )
-          # because `!ctx.new_version.nil?` will change the config by calling ::Config.set
-          # it's important to keep the checks in this order so that we don't trigger it while testing
-          # since changing the config will throw errors
-          elsif !ctx.testing? && !ctx.new_version.nil? && !Environment.run_as_subprocess?
-            ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, ctx.new_version))
-          end
+          # Only instruct the user to update the CLI, or warn them that they're
+          # using CLI2 not CLI3, if they're running CLI2 directly. Otherwise the
+          # warnings will be confusing and/or incorrect.
+          unless Environment.run_as_subprocess?
+            if ctx.development? && !ctx.testing?
+              ctx.warn(
+                ctx.message("core.warning.development_version", File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME))
+              )
+              # because `!ctx.new_version.nil?` will change the config by calling ::Config.set
+              # it's important to keep the checks in this order so that we don't trigger it while testing
+              # since changing the config will throw errors
+            elsif !ctx.testing? && !ctx.new_version.nil?
+              ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, ctx.new_version))
+            end
 
-          if ShopifyCLI::Core::CliVersion.using_3_0?
-            ctx.warn(ctx.message("core.warning.in_3_0_directory"))
+            if ShopifyCLI::Core::CliVersion.using_3_0?
+              ctx.warn(ctx.message("core.warning.in_3_0_directory"))
+            end
           end
 
           ProjectType.load_all

--- a/lib/shopify_cli/core/entry_point.rb
+++ b/lib/shopify_cli/core/entry_point.rb
@@ -16,6 +16,10 @@ module ShopifyCLI
             ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, ctx.new_version))
           end
 
+          if ShopifyCLI::Core::CliVersion.using_3_0?
+            ctx.warn(ctx.message("core.warning.in_3_0_directory"))
+          end
+
           ProjectType.load_all
 
           task_registry = ShopifyCLI::Tasks::Registry

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -791,6 +791,10 @@ module ShopifyCLI
               {{underline:https://shopify.dev/tools/cli/troubleshooting#upgrade-shopify-cli}}}}
 
           MESSAGE
+
+          in_3_0_directory: <<~MESSAGE,
+            {{*}} {{yellow:You appear to be working with a CLI 3.0 project. Please use CLI 3.0 instead.}}
+          MESSAGE
         },
         reporting: {
           help: <<~HELP,

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -794,6 +794,9 @@ module ShopifyCLI
 
           in_3_0_directory: <<~MESSAGE,
             {{*}} {{yellow:You appear to be working with a CLI 3.0 project. Please use CLI 3.0 instead.}}
+
+              For more information on CLI 3.0, see the documentation:
+              {{underline:https://shopify.dev/apps/tools/cli}}
           MESSAGE
         },
         reporting: {

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -793,7 +793,7 @@ module ShopifyCLI
           MESSAGE
 
           in_3_0_directory: <<~MESSAGE,
-            {{*}} {{yellow:You appear to be working with a CLI 3.0 project. Please use CLI 3.0 instead.}}
+            {{*}} {{yellow:You appear to be working with a CLI 3.0 project, but running a CLI 2.0 command. New syntax documentation: https://shopify.dev/apps/tools/cli/commands#command-syntax}}
 
               For more information on CLI 3.0, see the documentation:
               {{underline:https://shopify.dev/apps/tools/cli}}

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -797,6 +797,9 @@ module ShopifyCLI
 
               For more information on CLI 3.0, see the documentation:
               {{underline:https://shopify.dev/apps/tools/cli}}
+
+              Already have CLI 3.0 installed? Run it using your node package manager, as explained here:
+              {{underline:https://shopify.dev/apps/tools/cli/cli-2#running-shopify-cli-2-x-and-3-x-in-the-same-environment}}
           MESSAGE
         },
         reporting: {

--- a/lib/shopify_cli/project.rb
+++ b/lib/shopify_cli/project.rb
@@ -119,17 +119,8 @@ module ShopifyCLI
       private
 
       def directory(dir)
-        @dir ||= Hash.new { |h, k| h[k] = __directory(k) }
+        @dir ||= Hash.new { |h, k| h[k] = Utilities.directory(".shopify-cli.yml", k) }
         @dir[dir]
-      end
-
-      def __directory(curr)
-        loop do
-          return nil if curr == "/" || /^[A-Z]:\/$/.match?(curr)
-          file = File.join(curr, ".shopify-cli.yml")
-          return curr if File.exist?(file)
-          curr = File.dirname(curr)
-        end
       end
     end
 

--- a/lib/shopify_cli/utilities.rb
+++ b/lib/shopify_cli/utilities.rb
@@ -3,5 +3,14 @@ module ShopifyCLI
     def self.version_dropping_pre_and_build(version)
       Semantic::Version.new("#{version.major}.#{version.minor}.#{version.patch}")
     end
+
+    def self.directory(pattern, curr)
+      loop do
+        return nil if curr == "/" || /^[A-Z]:\/$/.match?(curr)
+        file = File.join(curr, pattern)
+        return curr if File.exist?(file)
+        curr = File.dirname(curr)
+      end
+    end
   end
 end

--- a/test/shopify-cli/core/cli_version_test.rb
+++ b/test/shopify-cli/core/cli_version_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+module ShopifyCLI
+  module Core
+    class CliVersionTest < MiniTest::Test
+      include TestHelpers::Project
+
+      def test_directory_recurses
+        Dir.mktmpdir do |dir|
+          Dir.stubs(:pwd).returns("#{dir}/a/b/c/d")
+          FileUtils.mkdir_p("#{dir}/a/b/c/d")
+          refute(CliVersion.using_3_0?)
+          FileUtils.touch("#{dir}/shopify.app.toml")
+          assert(CliVersion.using_3_0?)
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/utilities_test.rb
+++ b/test/shopify-cli/utilities_test.rb
@@ -12,5 +12,22 @@ module ShopifyCLI
       # Then
       assert_equal Semantic::Version.new("1.2.3"), got
     end
+
+    def test_directory_returns_nil_when_search_path_exhausted
+      File.stubs(:exist?).returns(true)
+      assert_nil(Utilities.directory("foo.txt", "/"))
+      assert_nil(Utilities.directory("foo.txt", "C:/"))
+    end
+
+    def test_directory_returns_nil_when_file_not_found
+      File.stubs(:exist?).returns(false)
+      assert_nil(Utilities.directory("foo.txt", "/some/path/inside/the/system"))
+    end
+
+    def test_directory_returns_directory_when_file_found
+      File.expects(:exist?).times(3).returns(false, false, true)
+      path = "/some/path/inside/the/system"
+      assert_equal(path.split("/")[0...-2].join("/"), Utilities.directory("foo.txt", path))
+    end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-cli-planning/issues/278

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Warns when using CLI 2.0 but you're inside a 3.0 project. Because you probably meant to use 3.0.

Currently just warns, but we might consider this a full-blown error condition.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Run any CLI command inside a 3.0 project

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).