### PR TITLE
Show a friendly message when developers use a browser without SSE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Added
 * [#2368](https://github.com/Shopify/shopify-cli/pull/2368): Add performance enhancements to the `theme serve` and `theme push` commands
+* [#2446](https://github.com/Shopify/shopify-cli/pull/2446): Show a friendly message when developers use a browser without SSE support
 
 ### Fixed
 * [#2418](https://github.com/Shopify/shopify-cli/pull/2418): Improve the help message of the `theme open -e/--editor` flag

--- a/lib/shopify_cli/theme/dev_server/hot-reload-no-script.html
+++ b/lib/shopify_cli/theme/dev_server/hot-reload-no-script.html
@@ -1,0 +1,27 @@
+<noscript>
+  <style type="text/css">
+    .shopify-cli-no-script-message {
+      font-family: -apple-system, BlinkMacSystemFont, San Francisco, Segoe UI, Roboto, Helvetica Neue, sans-serif;
+      text-size-adjust: 100%;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      position: fixed;
+      z-index: 999;
+      font-weight: 500;
+      left: 0;
+      top: 0;
+      width: 100vw;
+      height: 100vh;
+      padding: 10rem 0;
+      color: #202223;
+      text-align: center;
+      background-color: #F6F6F7;
+    }
+  </style>
+  <div class="shopify-cli-no-script-message">
+    Shopify CLI requires JavaScript to work.
+    <br />
+    Activate JavaScript support or try a different browser.
+  </div>
+</noscript>

--- a/lib/shopify_cli/theme/dev_server/hot-reload.js
+++ b/lib/shopify_cli/theme/dev_server/hot-reload.js
@@ -1,4 +1,16 @@
 (() => {
+  function verifySSE() {
+    if (typeof (EventSource) === "undefined") {
+      console.error("[HotReload] Error: SSE features are not supported. Try a different browser.");
+    }
+  }
+
+  console.log("[HotReload] Initializing...");
+
+  verifySSE();
+})();
+
+(() => {
   function connect() {
     const eventSource = new EventSource('/hot-reload');
 
@@ -32,7 +44,7 @@
 
   function fetchDOMSections(name) {
     const domSections = sectionNamesByType(name).flatMap((n) => querySelectDOMSections(n));
-    
+
     if (domSections.length > 0) {
       return domSections;
     }
@@ -40,11 +52,11 @@
     return querySelectDOMSections(name);
   }
 
-  function isFullPageReloadMode(){
+  function isFullPageReloadMode() {
     return reloadMode() === 'full-page';
   }
 
-  function isReloadModeActive(){
+  function isReloadModeActive() {
     return reloadMode() !== 'off';
   }
 
@@ -72,7 +84,7 @@
 
     // Hot reload cookie expires in 3 seconds
     date.setSeconds(date.getSeconds() + 3);
-    
+
     var sections = files.join(',');
     var expires = date.toUTCString();
 

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -67,7 +67,9 @@ module ShopifyCLI
 
         def inject_hot_reload_javascript(body)
           hot_reload_js = ::File.read("#{__dir__}/hot-reload.js")
+          hot_reload_no_script = ::File.read("#{__dir__}/hot-reload-no-script.html")
           hot_reload_script = [
+            hot_reload_no_script,
             "<script>",
             params_js,
             hot_reload_js,

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -37,6 +37,9 @@ module ShopifyCLI
           reload_js = ::File.read(
             ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload.js", ShopifyCLI::ROOT)
           )
+          hot_reload_no_script = ::File.read(
+            ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-no-script.html", ShopifyCLI::ROOT)
+          )
 
           injected_script = "<script>\n#{params_js}\n#{reload_js}\n</script>"
 
@@ -45,7 +48,8 @@ module ShopifyCLI
               <head></head>
               <body>
                 <h1>Hello</h1>
-              #{injected_script}
+              #{hot_reload_no_script}
+            #{injected_script}
             </body>
             </html>
           HTML


### PR DESCRIPTION
### WHY are these changes introduced?

I've been following an issue that some partners are facing regarding the SSE streams. The CLI has some debugging support on the server side, but it currently lacks some verification on the client.

### WHAT is this pull request doing?

This PR introduces setup logging messages checking the JavaScript and `EventSource` support.

### How to test your changes?

- Run `shopify-dev theme serve` in a theme directory
- Open the http://127.0.0.1:9292 URL on Chrome
- Deactivate JavaScript on Chrome (in the Chrome Inspector, press <kbd>⌘</kbd> + <kbd>P</kbd> and search `"> JavaScript"`)
- Refresh the http://127.0.0.1:9292 page
- The message should appear

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).