### PR TITLE
Fix #2382: Only return latest version when 24 hours has lapsed

### DIFF
--- a/lib/shopify_cli/context.rb
+++ b/lib/shopify_cli/context.rb
@@ -628,9 +628,9 @@ module ShopifyCLI
           thread = Thread.new { retrieve_latest_gem_version }
           at_exit { thread.join }
         end
+        latest_version = ShopifyCLI::Config.get(VERSION_CHECK_SECTION, LATEST_VERSION_FIELD, default: ShopifyCLI::VERSION)
+        latest_version if ::Semantic::Version.new(latest_version) > ::Semantic::Version.new(ShopifyCLI::VERSION)
       end
-      latest_version = ShopifyCLI::Config.get(VERSION_CHECK_SECTION, LATEST_VERSION_FIELD, default: ShopifyCLI::VERSION)
-      latest_version if ::Semantic::Version.new(latest_version) > ::Semantic::Version.new(ShopifyCLI::VERSION)
     end
 
     # Returns file extension depending on OS


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2382

Version check happens on every execution of any command, instead of happening once every 24 hours.

### WHAT is this pull request doing?

Make sure that the version check happens only once every 24 hours.

### How to test your changes?

1. Install older version.
2. Run a command; observe version check.
3. Run a command again within 24 hours; observe no version check.
4. Run a command again after 24 hours; observe version check.

Note: You may test using a shorter interval by changing the value of `VERSION_CHECK_INTERVAL`.

### Post-release steps

None.

### Update checklist

- [X] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [X] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [X] I've left the version number as is (we'll handle incrementing this when releasing).
- [X] I've included any post-release steps in the section above (if needed).