### PR TITLE
Fix `--ignore` flag issue when dealing with delayed json files on `shopify theme push`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2458](https://github.com/Shopify/shopify-cli/pull/2458): Fix shop URL in unauthorized error message
+* [#2459](https://github.com/Shopify/shopify-cli/pull/2459): Fix `.json` file ignore issues with `shopify theme push`
 
 ## Version 2.20.0 - 2022-07-11
 

--- a/lib/shopify_cli/theme/syncer/json_update_handler.rb
+++ b/lib/shopify_cli/theme/syncer/json_update_handler.rb
@@ -10,7 +10,7 @@ module ShopifyCLI
         def enqueue_json_updates(files)
           # Update remote JSON files and delays `delayed_files` update
           files = files
-            .select { |file| !ignore_file?(file) && file.exist? && checksums.file_has_changed?(file) }
+            .select { |file| ready_to_update?(file) }
             .sort_by { |file| delayed_files.include?(file) ? 1 : 0 }
             .reject { |file| overwrite_json? && delayed_files.include?(file) }
 
@@ -26,7 +26,7 @@ module ShopifyCLI
           return unless overwrite_json?
           # Update delayed files synchronously
           delayed_files.each do |file|
-            update(file) if checksums.file_has_changed?(file)
+            update(file) if ready_to_update?(file)
           end
         end
 
@@ -85,6 +85,10 @@ module ShopifyCLI
 
         def ask_update_strategy(file)
           Forms::SelectUpdateStrategy.ask(@ctx, [], file: file, exists_remotely: file_exist_remotely?(file)).strategy
+        end
+
+        def ready_to_update?(file)
+          !ignore_file?(file) && file.exist? && checksums.file_has_changed?(file)
         end
       end
     end

--- a/test/shopify-cli/theme/syncer/json_update_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_update_handler_test.rb
@@ -119,6 +119,16 @@ module ShopifyCLI
           enqueue_delayed_files_updates
         end
 
+        def test_enqueue_delayed_files_updates_when_overwrite_json_is_true_and_file1_ignored
+          @overwrite_json = true
+          stubs(:ignore_file?).with(@delayed_file1).returns(true)
+
+          expects(:update).with(@delayed_file1).never
+          expects(:update).with(@delayed_file2).once
+
+          enqueue_delayed_files_updates
+        end
+
         private
 
         def mock_files


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#2455](https://github.com/Shopify/shopify-cli/issues/2455)
Fixes [#2454](https://github.com/Shopify/shopify-cli/issues/2454)

`shopify theme push --ignore *.json` will not work properly (w or w/o stable flag). The ignore flag still works properly for non-json files

### WHAT is this pull request doing?

Allows `.json` files to be ignored again.

### How to test your changes?

1. Run `shopify theme pull` in a theme directory of your choice
2. Modify an asset file (`.js/.css`), `.liquid` file, and a `.json` file locally.
3. Run `shopify theme push --ignore [asset filename] [liquid filename] [json filename]` and note that the json file is not ignored.
4. Checkout `bulk-maintenance` branch.
5. Repeat 1-3 and notice that json file is ignored.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).