### PR TITLE
Increase job retries for .json dependencies and support wider range of asset API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2458](https://github.com/Shopify/shopify-cli/pull/2458): Fix shop URL in unauthorized error message
 * [#2459](https://github.com/Shopify/shopify-cli/pull/2459): Fix `.json` file ignore issues with `shopify theme push`
+* [#2460](https://github.com/Shopify/shopify-cli/pull/2460): Fix job retries for .json theme file dependencies and support wider range of asset API errors
 
 ## Version 2.20.0 - 2022-07-11
 

--- a/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
+++ b/lib/shopify_cli/theme/theme_admin_api_throttler/bulk_job.rb
@@ -10,7 +10,7 @@ module ShopifyCLI
     class ThemeAdminAPIThrottler
       class BulkJob < ShopifyCLI::ThreadPool::Job
         JOB_TIMEOUT = 0.2 # 200ms
-        MAX_RETRIES = 5
+        MAX_RETRIES = 10
 
         attr_reader :bulk
 


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses issues:
- [#2457](https://github.com/Shopify/shopify-cli/issues/2457)
- [#2456](https://github.com/Shopify/shopify-cli/issues/2456)
- [#2450](https://github.com/Shopify/shopify-cli/issues/2450)

Theme `.json` files currently do not wait long enough for their liquid file dependencies. This causes asynchronous bulk jobs to be created while other `.liquid` jobs are still processing. Increasing the maximum # of retries for bulk jobs seemingly solves this issue.

Unknown files like `package.json` or `package-lock.json` return different error messages from the assets API. This causes `theme serve` to occasionally stall while uploading files.

### WHAT is this pull request doing?

1. Increasing bulk job max retry count
2. Allowing for a broader range of errors from Assets API as well as adding a catchall error in case parsing fails.

### How to test your changes?

For [#2450](https://github.com/Shopify/shopify-cli/issues/2450):
1. Move into a theme which has liquid dependencies in json files. 
2. Run `shopify theme serve` and note section errors. 
3. Run `shopify theme delete` to remove this Development theme.
4. Checkout `bulk-jobs-dependency-and-error-handling`, run `shopify-dev theme serve` and note no section errors.

For [#2456](https://github.com/Shopify/shopify-cli/issues/2456) and [#2457](https://github.com/Shopify/shopify-cli/issues/2457):
1. Move into a theme which has non-theme files and that are not ignored by default(i.e `package.json`, etc.).
2. Run `shopify theme serve` and note stalling. 
3. Run `shopify theme delete` to remove this Development theme.
4. Checkout `bulk-jobs-dependency-and-error-handling`, run `shopify-dev theme serve` and note no stalling.

### Post-release steps

Follow up with issue threads linked above to confirm fixes worked.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).