### PR TITLE
Fix for "Keep the remote version" deletes files on new development theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2453](https://github.com/Shopify/shopify-cli/pull/2453): Fix [#2382](https://github.com/Shopify/shopify-cli/issues/2382): Ensure we wait 24 hours to show update message again
+* [#2463](https://github.com/Shopify/shopify-cli/pull/2463): Fix for "Keep the remote version" deletes files on new development theme
 
 ## Version 2.20.1 - 2022-07-18
 

--- a/lib/shopify_cli/theme/development_theme.rb
+++ b/lib/shopify_cli/theme/development_theme.rb
@@ -35,6 +35,7 @@ module ShopifyCLI
           @ctx.debug("Using temporary development theme: ##{id} #{name}")
         else
           create
+          @created_at_runtime = true
           @ctx.debug("Created temporary development theme: #{@id}")
           ShopifyCLI::DB.set(development_theme_id: @id)
         end
@@ -50,6 +51,10 @@ module ShopifyCLI
         )
       rescue ShopifyCLI::API::APIRequestNotFoundError
         false
+      end
+
+      def created_at_runtime?
+        @created_at_runtime ||= false
       end
 
       def delete

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -393,7 +393,11 @@ module ShopifyCLI
       end
 
       def overwrite_json?
-        @overwrite_json
+        theme_created_at_runtime? || @overwrite_json
+      end
+
+      def theme_created_at_runtime?
+        @theme.created_at_runtime?
       end
 
       def backingoff?

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -43,6 +43,7 @@ module ShopifyCLI
         ])
 
         @theme.ensure_exists!
+        assert(@theme.created_at_runtime?)
       end
 
       def test_creates_development_theme_when_an_unauthorized_error_happens
@@ -111,6 +112,7 @@ module ShopifyCLI
         ])
 
         @theme.ensure_exists!
+        assert(@theme.created_at_runtime?)
       end
 
       def test_name_is_generated_unless_exists_in_db
@@ -175,6 +177,13 @@ module ShopifyCLI
         ShopifyCLI::DB.expects(:set).with(development_theme_name: theme_name)
 
         assert_equal(theme_name, @theme.name)
+      end
+
+      def test_created_at_runtime_returns_false_if_development_theme_exists_in_db
+        @theme.expects(:exists?).returns(true)
+
+        @theme.ensure_exists!
+        refute(@theme.created_at_runtime?)
       end
 
       def test_delete

--- a/test/shopify-cli/theme/syncer/json_delete_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_delete_handler_test.rb
@@ -19,10 +19,37 @@ module ShopifyCLI
           @to_delete = [@file1, @file3]
         end
 
-        def test_enqueue_json_deletes_when_it_should_overwrite_json_files
+        def test_enqueue_json_deletes_when_overwrite_json_true_theme_created_at_runtime_true
+          @overwrite_json = true
+          @theme_created_at_runtime = true
+
+          expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_when_overwrite_json_false_theme_created_at_runtime_true
+          @overwrite_json = false
+          @theme_created_at_runtime = true
+
+          expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_when_overwrite_json_true_theme_created_at_runtime_false
           @overwrite_json = true
 
           expects(:enqueue_deletes).with(@to_delete)
+
+          enqueue_json_deletes(@files)
+        end
+
+        def test_enqueue_json_deletes_does_not_delete_when_overwrite_json_false_theme_created_at_runtime_false
+          @overwrite_json = false
+
+          expects(:enqueue_deletes).never
+          expects(:handle_delete_conflicts)
 
           enqueue_json_deletes(@files)
         end
@@ -82,9 +109,9 @@ module ShopifyCLI
         private
 
         def mock_files
-          @file1 = mock
-          @file2 = mock
-          @file3 = mock
+          @file1 = stub(exist?: true, relative_path: "file1")
+          @file2 = stub(exist?: true, relative_path: "file2")
+          @file3 = stub(exist?: true, relative_path: "file3")
           stubs(:ignore_file?).with(@file1).returns(false)
           stubs(:ignore_file?).with(@file2).returns(true)
           stubs(:ignore_file?).with(@file3).returns(false)
@@ -93,7 +120,11 @@ module ShopifyCLI
         # Methods required in the host class/module to support the `JsonDeleteHandler`
 
         def overwrite_json?
-          @overwrite_json
+          theme_created_at_runtime? || @overwrite_json
+        end
+
+        def theme_created_at_runtime?
+          @theme_created_at_runtime ||= false
         end
 
         def enqueue_deletes(files); end

--- a/test/shopify-cli/theme/syncer/json_update_handler_test.rb
+++ b/test/shopify-cli/theme/syncer/json_update_handler_test.rb
@@ -19,8 +19,26 @@ module ShopifyCLI
           @to_update = [@file1, @file3, @file5, @delayed_file1, @delayed_file2]
         end
 
-        def test_enqueue_json_updates_when_it_should_overwrite_json_files
+        def test_enqueue_json_updates_when_overwrite_json_true_theme_created_at_runtime_false
           @overwrite_json = true
+
+          expects(:enqueue_updates).with(@to_update - [@delayed_file1, @delayed_file2])
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_overwrite_json_false_theme_created_at_runtime_true
+          @overwrite_json = false
+          @theme_created_at_runtime = true
+
+          expects(:enqueue_updates).with(@to_update - [@delayed_file1, @delayed_file2])
+
+          enqueue_json_updates(@files)
+        end
+
+        def test_enqueue_json_updates_when_overwrite_json_true_theme_created_at_runtime_true
+          @overwrite_json = true
+          @theme_created_at_runtime = true
 
           expects(:enqueue_updates).with(@to_update - [@delayed_file1, @delayed_file2])
 
@@ -101,7 +119,7 @@ module ShopifyCLI
           enqueue_json_updates(@files)
         end
 
-        def test_enqueue_delayed_files_updates_when_overwrite_json_is_true
+        def test_enqueue_delayed_files_updates_when_overwrite_json_true_theme_created_at_runtime_false
           @overwrite_json = true
 
           expects(:update).with(@delayed_file1)
@@ -110,7 +128,27 @@ module ShopifyCLI
           enqueue_delayed_files_updates
         end
 
-        def test_enqueue_delayed_files_updates_when_overwrite_json_is_false
+        def test_enqueue_delayed_files_updates_when_overwrite_json_false_theme_created_at_runtime_true
+          @overwrite_json = false
+          @theme_created_at_runtime = true
+
+          expects(:update).with(@delayed_file1)
+          expects(:update).with(@delayed_file2)
+
+          enqueue_delayed_files_updates
+        end
+
+        def test_enqueue_delayed_files_updates_when_overwrite_json_true_theme_created_at_runtime_true
+          @overwrite_json = true
+          @theme_created_at_runtime = true
+
+          expects(:update).with(@delayed_file1)
+          expects(:update).with(@delayed_file2)
+
+          enqueue_delayed_files_updates
+        end
+
+        def test_enqueue_delayed_files_updates_when_overwrite_json_false_theme_created_at_runtime_false
           @overwrite_json = false
 
           expects(:update).with(@delayed_file1).never
@@ -176,7 +214,11 @@ module ShopifyCLI
         attr_reader :checksums, :theme
 
         def overwrite_json?
-          @overwrite_json
+          theme_created_at_runtime? || @overwrite_json
+        end
+
+        def theme_created_at_runtime?
+          @theme_created_at_runtime ||= false
         end
 
         def enqueue_get(files); end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -16,6 +16,7 @@ module ShopifyCLI
         @theme.stubs(:shop).returns("dev-theme-server-store.myshopify.com")
         @syncer = Syncer.new(@ctx, theme: @theme, stable: true)
         @syncer.stubs(:wait).returns(nil)
+        @syncer.stubs(:theme_created_at_runtime?).returns(false)
 
         ShopifyCLI::DB.stubs(:exists?).with(:shop).returns(true)
         ShopifyCLI::DB


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2433 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds `@created_at_runtime` variable that gets set to true if development theme is created
- Defaults to using local files `@created_at_runtime=true`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

#### New development themes defaults to local files
- In your partners dashboard, create a new dev store
- Create a new staff account for your work email if your partners account isn't associated with your work email (you need to do this so you can you use the cli with the new store)
- Accept invite for staff account 

##### In a new terminal

```
$ shopify theme init
$ cd <name of theme>
$ git init
$ git add —all
$ git commit -am "init"
$ pwd
```
Copy the path printed after `pwd`

##### In another terminal 
```
$ git fetch
$ git checkout fix-remote-file-local-delete
$ shopify-dev login —store <new store name>
$ shopify-dev theme serve </Path/to/theme/ that you copied> --theme-editor-sync
```

Confirm local files get uploaded and don't get deleted. Some files do get updated locally though

#### Existing development theme prompts user for strategy

In the theme directory run `git reset --hard` to restore the files. In the shopify-cli directory run `shopify-dev theme serve </Path/to/theme/> --theme-editor-sync` again and confirm you're prompted to pick a sync strategy

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps
None
<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).