### PR TITLE
Packaging for release v2.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.20.1 - 2022-07-18
+
 ### Fixed
 * [#2458](https://github.com/Shopify/shopify-cli/pull/2458): Fix shop URL in unauthorized error message
 * [#2459](https://github.com/Shopify/shopify-cli/pull/2459): Fix `.json` file ignore issues with `shopify theme push`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.20.0)
+    shopify-cli (2.20.1)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.3)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.20.0"
+  VERSION = "2.20.1"
 end


### PR DESCRIPTION
### Fixed
* [#2458](https://github.com/Shopify/shopify-cli/pull/2458): Fix shop URL in unauthorized error message
* [#2459](https://github.com/Shopify/shopify-cli/pull/2459): Fix `.json` file ignore issues with `shopify theme push`
* [#2460](https://github.com/Shopify/shopify-cli/pull/2460): Fix job retries for .json theme file dependencies and support wider range of asset API errors
