### PR TITLE
Packaging for release v2.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.20.2 - 2022-07-20
+
 ### Fixed
 * [#2453](https://github.com/Shopify/shopify-cli/pull/2453): Fix [#2382](https://github.com/Shopify/shopify-cli/issues/2382): Ensure we wait 24 hours to show update message again
 * [#2463](https://github.com/Shopify/shopify-cli/pull/2463): Fix for "Keep the remote version" deletes files on new development theme

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.20.1)
+    shopify-cli (2.20.2)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.3)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.20.1"
+  VERSION = "2.20.2"
 end


### PR DESCRIPTION
### Fixed
* [#2453](https://github.com/Shopify/shopify-cli/pull/2453): Fix [#2382](https://github.com/Shopify/shopify-cli/issues/2382): Ensure we wait 24 hours to show update message again
* [#2463](https://github.com/Shopify/shopify-cli/pull/2463): Fix for "Keep the remote version" deletes files on new development theme
* [#2405](https://github.com/Shopify/shopify-cli/pull/2405): Fix `theme serve` to trigger page refresh when a file is deleted