### PR TITLE
Move 'created_at_runtime?' from 'DevelopmentTheme' to 'Theme'

### DIFF
--- a/lib/shopify_cli/theme/development_theme.rb
+++ b/lib/shopify_cli/theme/development_theme.rb
@@ -35,7 +35,6 @@ module ShopifyCLI
           @ctx.debug("Using temporary development theme: ##{id} #{name}")
         else
           create
-          @created_at_runtime = true
           @ctx.debug("Created temporary development theme: #{@id}")
           ShopifyCLI::DB.set(development_theme_id: @id)
         end
@@ -51,10 +50,6 @@ module ShopifyCLI
         )
       rescue ShopifyCLI::API::APIRequestNotFoundError
         false
-      end
-
-      def created_at_runtime?
-        @created_at_runtime ||= false
       end
 
       def delete

--- a/lib/shopify_cli/theme/theme.rb
+++ b/lib/shopify_cli/theme/theme.rb
@@ -120,6 +120,7 @@ module ShopifyCLI
         )
 
         @id = body["theme"]["id"]
+        @created_at_runtime = true
       end
 
       def delete
@@ -145,6 +146,10 @@ module ShopifyCLI
 
       def foreign_development?
         development? && id != ShopifyCLI::DB.get(:development_theme_id)
+      end
+
+      def created_at_runtime?
+        @created_at_runtime ||= false
       end
 
       def to_h

--- a/test/shopify-cli/theme/development_theme_test.rb
+++ b/test/shopify-cli/theme/development_theme_test.rb
@@ -179,13 +179,6 @@ module ShopifyCLI
         assert_equal(theme_name, @theme.name)
       end
 
-      def test_created_at_runtime_returns_false_if_development_theme_exists_in_db
-        @theme.expects(:exists?).returns(true)
-
-        @theme.ensure_exists!
-        refute(@theme.created_at_runtime?)
-      end
-
       def test_delete
         shop = "dev-theme-server-store.myshopify.com"
         theme_id = "12345678"

--- a/test/shopify-cli/theme/theme_test.rb
+++ b/test/shopify-cli/theme/theme_test.rb
@@ -182,6 +182,7 @@ module ShopifyCLI
         assert_match("Development", theme.name)
         assert_equal "development", theme.role
         assert theme.development?
+        refute theme.created_at_runtime?
       end
 
       def test_development_when_does_not_exist
@@ -228,6 +229,7 @@ module ShopifyCLI
         assert_equal id, theme.id
         assert_equal name, theme.name
         assert_equal "unpublished", theme.role
+        assert theme.created_at_runtime?
       end
 
       def test_create_unpublished_with_default_name
@@ -243,6 +245,7 @@ module ShopifyCLI
         assert_equal id, theme.id
         assert_equal name, theme.name
         assert_equal "unpublished", theme.role
+        assert theme.created_at_runtime?
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?

The `created_at_runtime?` logic is used accross components that don't handle only development themes.

### WHAT is this pull request doing?

This PR moves the `created_at_runtime?` logic to the `theme.rb`

### How to test your changes?

It's pretty much the same steps defined here: https://github.com/Shopify/shopify-cli/pull/2463. However, in the `shopify theme serve` step, it's important to use the `-t` flag with a non-development theme. Notice it won't fail.

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).