### PR TITLE
Add warnings when theme push/pull completed with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2512](https://github.com/Shopify/shopify-cli/pull/2512): Add the `-t/--theme` parameter to the `shopify theme serve -h` message
+* [#2505](https://github.com/Shopify/shopify-cli/pull/2505): Show warning messages when `shopify theme push/pull` has errors
 
 ## Version 2.21.0 - 2022-08-03
 

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -52,7 +52,11 @@ module Theme
           CLI::UI::Frame.open(@ctx.message("theme.pull.pulling", theme.name, theme.id, theme.shop)) do
             UI::SyncProgressBar.new(syncer).progress(:download_theme!, delete: delete)
           end
-          @ctx.done(@ctx.message("theme.pull.done"))
+          if syncer.has_any_error?
+            @ctx.warn(@ctx.message("theme.pull.done_with_errors"))
+          else
+            @ctx.done(@ctx.message("theme.pull.done"))
+          end
         rescue ShopifyCLI::API::APIRequestNotFoundError
           @ctx.abort(@ctx.message("theme.pull.theme_not_found", "##{theme.id}"))
         ensure

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -43,6 +43,7 @@ module Theme
               Run without arguments to select theme from a list.
           HELP
           done: "Your theme is now live at %s",
+          done_with_errors: "{{warning:Your theme was published with errors and is now live at %s.}}",
           not_found: "Theme #%s does not exist",
           no_themes_error: "You don't have any theme to be published.",
           no_themes_resolution: "Try to create an unpublished theme with {{command:theme push -u -t <theme_name>}}.",
@@ -102,6 +103,15 @@ module Theme
               {{info:Customize this theme in the Theme Editor:}}
               {{underline:%s}}
           DONE
+          done_with_errors: <<~WARN,
+            {{yellow:Your theme was pushed with errors.}}
+
+              {{info:View your theme:}}
+              {{underline:%s}}
+
+              {{info:Customize this theme in the Theme Editor:}}
+              {{underline:%s}}
+          WARN
           name: "Theme name",
         },
         serve: {
@@ -319,7 +329,8 @@ module Theme
           HELP
           select: "Select a theme to pull from",
           pulling: "Pulling theme files from %s (#%s) on %s",
-          done: "Theme pulled successfully",
+          done: "Theme pulled successfully.",
+          done_with_errors: "{{warning:Your theme was pulled with errors.}}",
           deprecated_themeid: <<~WARN,
             {{warning:The {{command:-i, --themeid}} flag is deprecated. Use {{command:-t, --theme}} instead.}}
           WARN


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #[2150](https://github.com/Shopify/shopify-cli/issues/2150)

Context: the issue above raises the suggestion that we should warn the user when `shopify theme push` or `shopify theme pull` completes with errors.

### WHAT is this pull request doing?

This PR adds new messaging to handle these cases when errors do appear during the referenced commands.

#### Previous `shopify theme push` workflow with errors:
<img width="1511" alt="Screen Shot 2022-08-01 at 1 10 08 PM" src="https://user-images.githubusercontent.com/60304332/182204889-1548b3e5-83e7-469c-97ac-0d547b848e4b.png">

#### New `shopify theme push` workflow with errors:
![Screen Shot 2022-08-03 at 10 53 52 AM](https://user-images.githubusercontent.com/60304332/182639887-ecc181a0-2648-40e4-a7f9-2e20b60c8d24.png)


#### `shopify theme pull` images:
The workflow tests are stubbed (see `pull` testing below), so adding images for non-existent errors didn't seem right.
@karreiro – I can add here should you need.


### How to test your changes?

#### `shopify theme push`
1. Update a theme file such that an error is present
2. Checkout `main` and run `shopify theme push` (select a theme)
3. Note "Your theme was pushed successfully." even though there were errors.
4. Checkout `change-messaging-push-with-errors` and rerun same command.
5. Note "Your theme was pushed with errors."
#### `shopify theme pull`
1. Stub/Hardcode the `Syncer#has_any_error?` method to return true (this will not actually cause asset errors to appear, but we still get same result I/O).
2. Checkout `main` and run `shopify theme pull` (select a theme)
3. Note "Your theme was pulled successfully." even though there were errors.
4. Checkout `change-messaging-push-with-errors` and rerun same command.
5. Note "Your theme was pulled with errors."

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).