### PR TITLE
Remove `macos-10.15` from `workflows/shopify.yml`

### DIFF
--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -22,7 +22,6 @@ jobs:
           - 2.6.6
           - 2.7.5
         os:
-          - macos-10.15
           - macos-11
           - ubuntu-20.04
           - ubuntu-18.04


### PR DESCRIPTION
I've removed `macos-10.15` follow [this page](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) and [this issue](https://github.com/Shopify/shopify-cli/issues/2474).

Also, I've considered adding `macos-12`, however `macos-11` still is the latest stable image.