### PR TITLE
Add the `-t/--theme` parameter to the `shopify theme serve -h` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2512](https://github.com/Shopify/shopify-cli/pull/2512): Add the `-t/--theme` parameter to the `shopify theme serve -h` message
+
 ## Version 2.21.0 - 2022-08-03
 
 ### Fixed

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -112,14 +112,15 @@ module Theme
             Usage: {{command:%s theme serve [ ROOT ]}}
 
             Options:
-              {{command:--port=PORT}}         Local port to serve theme preview from.
-              {{command:--poll}}              Force polling to detect file changes.
-              {{command:--host=HOST}}         Set which network interface the web server listens on. The default value is 127.0.0.1.
-              {{command:--theme-editor-sync}} Synchronize Theme Editor updates in the local theme files.
-              {{command:--live-reload=MODE}}  The live reload mode switches the server behavior when a file is modified:
-                                  - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
-                                  - {{command:full-page}}  Always refreshes the entire page
-                                  - {{command:off}}        Deactivate live reload
+              {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of the remote theme.
+              {{command:--port=PORT}}            Local port to serve theme preview from.
+              {{command:--poll}}                 Force polling to detect file changes.
+              {{command:--host=HOST}}            Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--theme-editor-sync}}    Synchronize Theme Editor updates in the local theme files.
+              {{command:--live-reload=MODE}}     The live reload mode switches the server behavior when a file is modified:
+                                     - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
+                                     - {{command:full-page}}  Always refreshes the entire page
+                                     - {{command:off}}        Deactivate live reload
           HELP
           reload_mode_is_not_valid: "The live reload mode `%s` is not valid.",
           try_a_valid_reload_mode: "Try a valid live reload mode: %s.",


### PR DESCRIPTION
### WHY are these changes introduced?

The help message of `shopify theme serve -h` was missing the `-t/--theme` parameter.

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/1079279/182616542-818203fe-e4f0-4018-8025-c19a284a9fa4.png">

### WHAT is this pull request doing?

This PR adds the `-t/--theme` parameter to the `shopify theme serve -h` message.

### How to test your changes?

- Run `shopify-dev theme serve -h`

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).