### PR TITLE
Accept commented keys on .env file and don't remove them

### DIFF
--- a/lib/shopify_cli/resources/env_file.rb
+++ b/lib/shopify_cli/resources/env_file.rb
@@ -30,7 +30,7 @@ module ShopifyCLI
         def parse(directory)
           File.read(path(directory))
             .gsub("\r\n", "\n").split("\n").each_with_object({}) do |line, output|
-            match = /\A([A-Za-z_0-9]+)\s*=\s*(.*)\z/.match(line)
+            match = /\A(#*\s*[A-Za-z_0-9]+)\s*=\s*(.*)\z/.match(line)
             if match
               key = match[1]
               output[key] = case match[2]

--- a/test/fixtures/project/.env
+++ b/test/fixtures/project/.env
@@ -2,4 +2,5 @@ SHOPIFY_API_KEY=apikey
 SHOPIFY_API_SECRET=secret
 HOST=https://example.com
 SHOP=my-test-shop.myshopify.com
+#COMMENTED_KEY=value
 AWSKEY=awskey

--- a/test/shopify-cli/resources/env_file_test.rb
+++ b/test/shopify-cli/resources/env_file_test.rb
@@ -13,6 +13,7 @@ module ShopifyCLI
         assert_equal("https://example.com", env_file.host)
         assert_equal("my-test-shop.myshopify.com", env_file.shop)
         assert_equal("awskey", env_file.extra["AWSKEY"])
+        assert_equal("value", env_file.extra["#COMMENTED_KEY"])
       end
 
       def test_parse_external_env
@@ -21,7 +22,7 @@ module ShopifyCLI
         assert_equal("secret", env_file[:secret])
         assert_equal("https://example.com", env_file[:host])
         assert_equal("my-test-shop.myshopify.com", env_file[:shop])
-        assert_equal({ "AWSKEY" => "awskey" }, env_file[:extra])
+        assert_equal({ "AWSKEY" => "awskey", "#COMMENTED_KEY" => "value" }, env_file[:extra])
       end
 
       def test_write_writes_env_content_to_file
@@ -29,13 +30,14 @@ module ShopifyCLI
           api_key: "foo",
           secret: "bar",
           host: "baz",
-          extra: { "AWSKEY" => "awskey" },
+          extra: { "AWSKEY" => "awskey", "#COMMENTED_KEY" => "value" },
         )
         content = <<~CONTENT
           SHOPIFY_API_KEY=foo
           SHOPIFY_API_SECRET=bar
           HOST=baz
           AWSKEY=awskey
+          #COMMENTED_KEY=value
         CONTENT
         @context.expects(:write).with(".env", content)
         @context.expects(:print_task).with("writing .env file")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
The CLI reads the .env file, updates the values as needed and re-writes the file.
We keep any other ENV_VAR that is not ours, but we were discarding commented lines

Fixes https://github.com/Shopify/shopify-cli/issues/2514

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Updated the env parser to accept commented lines (any line starting with at least one `#`)
```
#VAR=value
# VAR=value
## VAR=value
```
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Add commented variables to your .env file,
`shopify app serve` should not remove those variables from the file
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).