### PR TITLE
Avoid filtering against absolute path in ignore filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2528](https://github.com/Shopify/shopify-cli/pull/2528): Switch from using absolute file paths to relative paths for ignore filter
+
 ### Added
 * [#2520](https://github.com/Shopify/shopify-cli/pull/2520): Add the option to ignore new version warnings by passing the `SHOPIFY_CLI_RUN_AS_SUBPROCESS` environment variable
 

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -40,14 +40,14 @@ module ShopifyCLI
 
         def notify_streams_of_file_change(modified, added, removed)
           files = (modified + added)
-            .reject { |file| @ignore_filter&.ignore?(file) }
             .map { |file| @theme[file] }
+            .reject { |file| @ignore_filter&.ignore?(file.relative_path) }
 
           files -= liquid_css_files = files.select(&:liquid_css?)
 
           deleted_files = removed
-            .reject { |file| @ignore_filter&.ignore?(file) }
             .map { |file| @theme[file] }
+            .reject { |file| @ignore_filter&.ignore?(file.relative_path) }
 
           remote_delete(deleted_files) unless deleted_files.empty?
           reload_page(removed) unless deleted_files.empty?

--- a/lib/shopify_cli/theme/syncer/ignore_helper.rb
+++ b/lib/shopify_cli/theme/syncer/ignore_helper.rb
@@ -10,7 +10,7 @@ module ShopifyCLI
         end
 
         def ignore_file?(file)
-          path = file.path
+          path = file.relative_path
           ignore_path?(path)
         end
 

--- a/test/shopify-cli/theme/syncer/ignore_helper_test.rb
+++ b/test/shopify-cli/theme/syncer/ignore_helper_test.rb
@@ -30,19 +30,19 @@ module ShopifyCLI
         end
 
         def test_ignore_file_when_it_returns_true
-          path = mock
-          file = stub(path: path)
+          relative_path = mock
+          file = stub(relative_path: relative_path)
 
-          expects(:ignore_path?).with(path).returns(true)
+          expects(:ignore_path?).with(relative_path).returns(true)
 
           assert(ignore_file?(file))
         end
 
         def test_ignore_file_when_it_returns_false
-          path = mock
-          file = stub(path: path)
+          relative_path = mock
+          file = stub(relative_path: relative_path)
 
-          expects(:ignore_path?).with(path).returns(false)
+          expects(:ignore_path?).with(relative_path).returns(false)
 
           refute(ignore_file?(file))
         end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -375,7 +375,7 @@ module ShopifyCLI
       def test_download_theme_with_ignores
         @syncer.ignore_filter = mock("IgnoreFilter")
         @syncer.ignore_filter.stubs(:ignore?).returns(false)
-        @syncer.ignore_filter.expects(:ignore?).with(@theme["assets/generated.css.liquid"].path).returns(true)
+        @syncer.ignore_filter.expects(:ignore?).with(@theme["assets/generated.css.liquid"].relative_path).returns(true)
 
         @syncer.start_threads
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#2457](https://github.com/Shopify/shopify-cli/issues/2457)

As seen in the issue, a developer had an issue with the syncer's ignore filter matching the absolute path of their theme files against the contents of their `.shopifyignore`. Their root theme directory was named `shopify-webpack` and the `.shopifyignore` file contained a line: `webpack/*` which matched against this root directory name.

### WHAT is this pull request doing?

This PR changes the `ignore_helper.rb`'s path matching from using absolute to relative paths.

### How to test your changes?

1. Create a theme with an absolute path name that matches some pattern inside the `.shopifyignore` file. Maybe doing `src/github.com/Shopify/testing_theme` and having `src/*` inside your `.shopifyignore`.
2. Checkout `main` and run `shopify theme serve`. Edit a file and notice that no file changes are being recognized.
3. Checkout `switch-absolute-to-relative-paths-for-filters` and rerun `shopify theme serve`. Edit a file and notice that changes are being recognized.

### Post-release steps

Follow up with developer to ensure they are seeing no further issues.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).