### PR TITLE
Delete the client's `HostTheme` on `shopify logout`

### DIFF
--- a/lib/shopify_cli/theme/extension/host_theme.rb
+++ b/lib/shopify_cli/theme/extension/host_theme.rb
@@ -33,6 +33,10 @@ module ShopifyCLI
           self
         end
 
+        def self.delete(ctx)
+          new(ctx, root: nil).delete
+        end
+
         def delete
           delete_theme if exists? # Avoid deleting any existing development theme logic
 

--- a/test/shopify-cli/commands/logout_test.rb
+++ b/test/shopify-cli/commands/logout_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 require "shopify_cli/theme/development_theme"
+require "shopify_cli/theme/extension/host_theme"
 
 module ShopifyCLI
   module Commands
@@ -10,29 +11,50 @@ module ShopifyCLI
       end
 
       def test_call_deletes_db_keys_that_exist
-        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::IDENTITY_ACCESS_TOKENS)
-        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::EXCHANGE_TOKENS)
-
-        ShopifyCLI::DB.expects(:exists?).with(:shop).twice.returns(true)
-        ShopifyCLI::DB.expects(:del).with(:shop).once
-        ShopifyCLI::DB.expects(:exists?).with(:organization_id).once.returns(true)
-        ShopifyCLI::DB.expects(:del).with(:organization_id).once
+        stub_identity_deletions
+        stub_get_shop_and_org_data
+        stub_delete_shop_and_org_data
 
         ShopifyCLI::Shopifolk.expects(:reset).once
 
-        ShopifyCLI::DB.expects(:exists?).with(:development_theme_id).returns(true)
-        ShopifyCLI::DB.expects(:del).with(:development_theme_id).once
-
-        ShopifyCLI::DB.expects(:exists?).with(:development_theme_name).returns(true)
-        ShopifyCLI::DB.expects(:del).with(:development_theme_name).once
+        stub_theme_successful_deletion(:development_theme_id, :development_theme_name)
+        stub_theme_successful_deletion(:host_theme_id, :host_theme_name)
 
         run_cmd("logout")
       end
 
-      def test_call_finishes_if_dev_theme_deletion_fails
-        ShopifyCLI::DB.expects(:exists?).with(:shop).twice.returns(true)
-        ShopifyCLI::DB.expects(:exists?).with(:organization_id).once.returns(true)
-        ShopifyCLI::Theme::DevelopmentTheme.expects(:delete).once.raises(ShopifyCLI::Abort)
+      def test_call_finishes_if_dev_theme_deletion_fails_and_host_theme_deletion_succeeds
+        stub_identity_deletions
+        stub_get_shop_and_org_data
+        stub_delete_shop_and_org_data
+        ShopifyCLI::Shopifolk.expects(:reset).once
+
+        dev_theme_deletion_error = "this is an error"
+
+        ShopifyCLI::Theme::DevelopmentTheme.expects(:delete).once
+          .raises(ShopifyCLI::Abort.new(dev_theme_deletion_error))
+        @context.expects(:debug).with("[Logout Error]: #{dev_theme_deletion_error}").once
+
+        stub_theme_successful_deletion(:host_theme_id, :host_theme_name)
+
+        @context.expects(:puts).with("Successfully logged out of your account")
+
+        run_cmd("logout")
+      end
+
+      def test_call_finishes_if_dev_theme_deletion_succeeds_and_host_theme_deletion_fails
+        stub_identity_deletions
+        stub_get_shop_and_org_data
+        stub_delete_shop_and_org_data
+        ShopifyCLI::Shopifolk.expects(:reset).once
+
+        host_theme_deletion_error = "this is an error"
+
+        stub_theme_successful_deletion(:development_theme_id, :development_theme_name)
+
+        ShopifyCLI::Theme::Extension::HostTheme.expects(:delete).once
+          .raises(ShopifyCLI::Abort.new(host_theme_deletion_error))
+        @context.expects(:debug).with("[Logout Error]: #{host_theme_deletion_error}").once
         @context.expects(:puts).with("Successfully logged out of your account")
 
         run_cmd("logout")
@@ -41,6 +63,31 @@ module ShopifyCLI
       def test_help_argument_calls_help
         @context.expects(:puts).with(ShopifyCLI::Commands::Logout.help)
         run_cmd("help logout")
+      end
+
+      private
+
+      def stub_theme_successful_deletion(id_key, name_key)
+        ShopifyCLI::DB.expects(:exists?).with(id_key).returns(true)
+        ShopifyCLI::DB.expects(:del).with(id_key).once
+
+        ShopifyCLI::DB.expects(:exists?).with(name_key).returns(true)
+        ShopifyCLI::DB.expects(:del).with(name_key).once
+      end
+
+      def stub_identity_deletions
+        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::IDENTITY_ACCESS_TOKENS)
+        ShopifyCLI::DB.expects(:del).with(*ShopifyCLI::IdentityAuth::EXCHANGE_TOKENS)
+      end
+
+      def stub_delete_shop_and_org_data
+        ShopifyCLI::DB.expects(:del).with(:shop).once
+        ShopifyCLI::DB.expects(:del).with(:organization_id).once
+      end
+
+      def stub_get_shop_and_org_data
+        ShopifyCLI::DB.expects(:exists?).with(:shop).times(3).returns(true)
+        ShopifyCLI::DB.expects(:exists?).with(:organization_id).once.returns(true)
       end
     end
   end

--- a/test/shopify-cli/theme/extension/host_theme_test.rb
+++ b/test/shopify-cli/theme/extension/host_theme_test.rb
@@ -85,6 +85,29 @@ module ShopifyCLI
           @host_theme.delete
         end
 
+        def test_delete_static
+          theme_id = "12345678"
+
+          ShopifyCLI::AdminAPI.stubs(:get_shop_or_abort).returns(@shop)
+          ShopifyCLI::DB.stubs(:get).with(:host_theme_id).returns(theme_id)
+          ShopifyCLI::DB.stubs(:exists?).with(:host_theme_id).returns(true)
+          ShopifyCLI::DB.stubs(:del).with(:host_theme_id)
+          ShopifyCLI::DB.stubs(:exists?).with(:host_theme_name).returns(true)
+          ShopifyCLI::DB.stubs(:del).with(:host_theme_name)
+
+          HostTheme.any_instance.expects(:exists?).returns(true).once
+
+          ShopifyCLI::AdminAPI.expects(:rest_request).with(
+            @ctx,
+            shop: @shop,
+            path: "themes/#{theme_id}.json",
+            method: "DELETE",
+            api_version: "unstable",
+          )
+
+          HostTheme.delete(@ctx)
+        end
+
         def test_name_is_valid_when_the_host_contains_an_ascii_character
           ascii_string_char = 0x8f.chr
           hostname = "theme-dev-#{ascii_string_char}.lan"


### PR DESCRIPTION
Currently we don't delete the client's `HostTheme` on logout. This quick PR ensures that a client's `HostTheme` is deleted from local storage and their store on logout.