### PR TITLE
Improve validation of files in locales/ folder

### DIFF
--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -155,6 +155,23 @@ module Extension
           end
         end
 
+        def test_missing_locale_default
+          write("locales/en.json", "{}")
+          error = assert_raises Extension::Errors::ExtensionError do
+            @spec.config(@context)
+          end
+          assert_equal "Missing default locale file for locales/en.json", error.message
+        end
+
+        def test_too_many_default_locales
+          write("locales/en.default.json", "{}")
+          write("locales/fr.default.json", "{}")
+          error = assert_raises Extension::Errors::ExtensionError do
+            @spec.config(@context)
+          end
+          assert_equal "Too many default locale files: locales/en.default.json, locales/fr.default.json", error.message
+        end
+
         private
 
         def write(filename, content, mode: "w", encoding: "utf-8")


### PR DESCRIPTION
### WHY are these changes introduced?

Theme app extensions require default locale files to be present in some cases. This PR implements additional client-side validation so that we can catch errors locally instead of needing to push the extension to Shopify first.

re: https://github.com/Shopify/cli/issues/134 

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).