### PR TITLE
[Functions] Remove payment_methods and TS extension points

### DIFF
--- a/lib/project_types/script/config/extension_points.yml
+++ b/lib/project_types/script/config/extension_points.yml
@@ -1,14 +1,3 @@
-payment_methods:
-  domain: 'checkout'
-  libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-checkout-apis"
-      repo: "https://github.com/Shopify/function-examples"
-    wasm:
-      repo: "https://github.com/Shopify/function-examples"
-    rust:
-      repo: "https://github.com/Shopify/function-examples"
 payment_customization:
   beta: true
   domain: 'checkout'
@@ -20,10 +9,6 @@ payment_customization:
 shipping_methods:
   domain: 'checkout'
   libraries:
-    typescript:
-      beta: true
-      package: "@shopify/scripts-checkout-apis"
-      repo: "https://github.com/Shopify/function-examples"
     wasm:
       repo: "https://github.com/Shopify/function-examples"
     rust:

--- a/test/project_types/script/commands/push_test.rb
+++ b/test/project_types/script/commands/push_test.rb
@@ -17,16 +17,16 @@ module Script
         @config = {
           "project_type" => "script",
           "organization_id" => 1,
-          "extension_point_type" => "payment_methods",
+          "extension_point_type" => "order_discounts",
           "title" => @title,
-          "language" => "typescript",
+          "language" => "wasm",
         }
 
         @env = ShopifyCLI::Resources::EnvFile.new(api_key: @api_key, secret: @secret, extra: { "UUID" => @uuid })
         # @env_content = ShopifyCLI::Resources::EnvFile.read(@env)
         @script_project_repo = TestHelpers::FakeScriptProjectRepository.new
         @script_project_repo.create(
-          language: "typescript",
+          language: "wasm",
           extension_point_type: "discount",
           title: "title",
           env: @env

--- a/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
+++ b/test/project_types/script/layers/infrastructure/script_project_repository_test.rb
@@ -92,7 +92,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
 
     let(:title) { "title" }
     let(:description) { "#{extension_point_type} default script" }
-    let(:extension_point_type) { "payment_methods" }
+    let(:extension_point_type) { "order_discounts" }
     let(:language) { "wasm" }
     let(:uuid) { "uuid" }
     let(:script_config) { "script.config.yml" }
@@ -115,7 +115,7 @@ describe Script::Layers::Infrastructure::ScriptProjectRepository do
     end
     let(:valid_config) do
       config = {
-        "extension_point_type" => "payment_methods",
+        "extension_point_type" => "order_discounts",
         "title" => title,
         "description" => description,
         "script_config" => script_config,

--- a/test/project_types/script/ui/error_handler_test.rb
+++ b/test/project_types/script/ui/error_handler_test.rb
@@ -152,7 +152,7 @@ describe Script::UI::ErrorHandler do
       end
 
       describe "when InvalidLanguageError" do
-        let(:err) { Script::Layers::Infrastructure::Errors::InvalidLanguageError.new("ruby", "payment_methods") }
+        let(:err) { Script::Layers::Infrastructure::Errors::InvalidLanguageError.new("ruby", "order_discounts") }
         it "should call display_and_raise" do
           should_call_display_and_raise
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/script-service/issues/5431

Unsure if we still need to update this repo, but opening this to be thorough because the [function-examples have been deleted](https://github.com/Shopify/function-examples/pull/100)

### WHAT is this pull request doing?

- Remove `payment_methods`
- Remove `shipping_methods` typescript

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).