### PR TITLE
add `--no-ignore` to skip `.shopifyignore` filters when pulling or pushing theme files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ## [Unreleased]
 
 ### Added
+* [#2550](https://github.com/Shopify/shopify-cli/pull/2550): Added option flag `--no-ignore`/`-e` to `theme push` and `theme pull` commands to skip loading the `.shopifyignore` file
 * [#2520](https://github.com/Shopify/shopify-cli/pull/2520): Add the option to ignore new version warnings by passing the `SHOPIFY_CLI_RUN_AS_SUBPROCESS` environment variable
 * [#2440](https://github.com/Shopify/shopify-cli/pull/2440): Warn when using CLI 2.0 in a CLI 3.0 project
 

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -32,6 +32,7 @@ module Theme
           flags[:ignores] ||= []
           flags[:ignores] |= pattern
         end
+        parser.on("-e", "--noignore") { flags[:load_ignore_file] = false }
       end
 
       def call(_args, name)
@@ -41,7 +42,7 @@ module Theme
         return if theme.nil?
 
         include_filter = ShopifyCLI::Theme::IncludeFilter.new(root, options.flags[:includes])
-        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root)
+        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root, options.flags[:load_ignore_file])
         ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
 
         syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme,

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -37,6 +37,7 @@ module Theme
           flags[:ignores] ||= []
           flags[:ignores] |= pattern
         end
+        parser.on("-e", "--noignore") { flags[:load_ignore_file] = false }
       end
 
       def call(_args, name)
@@ -52,7 +53,7 @@ module Theme
         end
 
         include_filter = ShopifyCLI::Theme::IncludeFilter.new(root, options.flags[:includes])
-        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root)
+        ignore_filter = ShopifyCLI::Theme::IgnoreFilter.from_path(root, options.flags[:load_ignore_file])
         ignore_filter.add_patterns(options.flags[:ignores]) if options.flags[:ignores]
 
         syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: theme,

--- a/lib/shopify_cli/theme/ignore_filter.rb
+++ b/lib/shopify_cli/theme/ignore_filter.rb
@@ -29,10 +29,10 @@ module ShopifyCLI
 
       attr_reader :root, :globs, :regexes
 
-      def self.from_path(root)
+      def self.from_path(root, load_ignore_file = true)
         root = Pathname.new(root)
-        ignore_file = root.join(FILE)
-        patterns = if ignore_file.file?
+        ignore_file = load_ignore_file != false ? root.join(FILE) : nil
+        patterns = if ignore_file&.file?
           parse_ignore_file(ignore_file)
         else
           []

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -22,7 +22,7 @@ module Theme
         @ignore_filter = mock("IgnoreFilter")
         @include_filter = mock("IncludeFilter")
 
-        ShopifyCLI::Theme::IgnoreFilter.stubs(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.stubs(:from_path).with(".", nil).returns(@ignore_filter)
         ShopifyCLI::Theme::IncludeFilter.stubs(:new).returns(@include_filter)
       end
 
@@ -51,7 +51,7 @@ module Theme
           .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -72,7 +72,7 @@ module Theme
           .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -93,7 +93,7 @@ module Theme
           .with(@ctx, root: "dist", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with("dist").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with("dist", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -135,7 +135,7 @@ module Theme
           .with(@ctx, root: ".")
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -219,7 +219,7 @@ module Theme
         @ignore_filter.expects(:add_patterns).with(["config/*"])
 
         ShopifyCLI::Theme::IgnoreFilter.expects(:from_path)
-          .with(".")
+          .with(".", nil)
           .returns(@ignore_filter)
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
@@ -234,6 +234,30 @@ module Theme
 
         @command.options.flags[:theme] = 1234
         @command.options.flags[:ignores] = ["config/*"]
+        @command.call([], "pull")
+      end
+
+      def test_pull_with_no_ignore
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path)
+          .with(".", false)
+          .returns(@ignore_filter)
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:download_theme!).with(delete: true)
+
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme] = 1234
+        @command.options.flags[:load_ignore_file] = false
         @command.call([], "pull")
       end
 

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -25,7 +25,7 @@ module Theme
         @ignore_filter = mock("IgnoreFilter")
         @include_filter = mock("IncludeFilter")
 
-        ShopifyCLI::Theme::IgnoreFilter.stubs(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.stubs(:from_path).with(".", nil).returns(@ignore_filter)
         ShopifyCLI::Theme::IncludeFilter.stubs(:new).returns(@include_filter)
       end
 
@@ -54,7 +54,7 @@ module Theme
           .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
@@ -75,7 +75,7 @@ module Theme
           .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: true)
@@ -97,7 +97,7 @@ module Theme
           .with(@ctx, root: "dist", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with("dist").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with("dist", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
@@ -120,7 +120,7 @@ module Theme
           .with(@ctx, root: ".", identifier: "Test theme")
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
@@ -366,7 +366,7 @@ module Theme
           .with(@ctx, root: ".", identifier: 1234)
           .returns(@theme)
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
         @ignore_filter.expects(:add_patterns).with(["config/*"])
 
         ShopifyCLI::Theme::Syncer.expects(:new)
@@ -381,6 +381,28 @@ module Theme
 
         @command.options.flags[:theme] = 1234
         @command.options.flags[:ignores] = ["config/*"]
+        @command.call([], "push")
+      end
+
+      def test_push_with_no_ignore
+        ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
+          .with(@ctx, root: ".", identifier: 1234)
+          .returns(@theme)
+
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", false).returns(@ignore_filter)
+
+        ShopifyCLI::Theme::Syncer.expects(:new)
+          .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)
+          .returns(@syncer)
+
+        @syncer.expects(:start_threads)
+        @syncer.expects(:shutdown)
+
+        @syncer.expects(:upload_theme!).with(delete: true)
+        @ctx.expects(:done)
+
+        @command.options.flags[:theme] = 1234
+        @command.options.flags[:load_ignore_file] = false
         @command.call([], "push")
       end
 
@@ -433,7 +455,7 @@ module Theme
 
         CLI::UI::Prompt.expects(:ask).never
 
-        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".").returns(@ignore_filter)
+        ShopifyCLI::Theme::IgnoreFilter.expects(:from_path).with(".", nil).returns(@ignore_filter)
 
         ShopifyCLI::Theme::Syncer.expects(:new)
           .with(@ctx, theme: @theme, include_filter: @include_filter, ignore_filter: @ignore_filter, stable: nil)

--- a/test/shopify-cli/theme/ignore_filter_test.rb
+++ b/test/shopify-cli/theme/ignore_filter_test.rb
@@ -51,6 +51,17 @@ module ShopifyCLI
         refute_includes(filter.globs, "*")
       end
 
+      def test_from_path_no_ignore_file
+        filter = IgnoreFilter.from_path("#{ShopifyCLI::ROOT}/test/fixtures/theme", false)
+
+        assert_equal(IgnoreFilter::DEFAULT_REGEXES, filter.regexes)
+        assert_equal(IgnoreFilter::DEFAULT_GLOBS, filter.globs)
+        
+        refute_includes(filter.globs, "*config/settings_data.json")
+        refute_includes(filter.globs, "*.jpg")
+        refute_includes(filter.regexes, /\.(txt|gif|bat)$/)
+      end
+
       def test_patterns_to_regexes_and_globs
         tests = [
           { pattern: "config/settings_data.json", glob: "*config/settings_data.json" },

--- a/test/shopify-cli/theme/ignore_filter_test.rb
+++ b/test/shopify-cli/theme/ignore_filter_test.rb
@@ -56,7 +56,7 @@ module ShopifyCLI
 
         assert_equal(IgnoreFilter::DEFAULT_REGEXES, filter.regexes)
         assert_equal(IgnoreFilter::DEFAULT_GLOBS, filter.globs)
-        
+
         refute_includes(filter.globs, "*config/settings_data.json")
         refute_includes(filter.globs, "*.jpg")
         refute_includes(filter.regexes, /\.(txt|gif|bat)$/)


### PR DESCRIPTION
### WHY are these changes introduced?

Provided as potential resolution to #2550.

Please note that I am not a Ruby developer, so hopefully I've followed project and Ruby conventions accordingly.

### WHAT is this pull request doing?

* Adds `--no-ignore`/`-e` option flag for `theme push` and `theme pull` commands to skip any ignore patterns within the `.shopifyignore` file.
* Retains default ignore patterns in [lib/shopify_cli/theme/ignore_filter.rb]
* Added tests to validate `ignore_filter`, `push` and `pull` to support `--no-ignore`

### How to test your changes?

```sh
ruby -I test test/shopify_cli/theme/ignore_filter_test.rb
ruby -I test test/project_types/theme/commands/push_test.rb
ruby -I test test/project_types/theme/commands/pull_test.rb
```

Or

```sh
rake
```

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).