### PR TITLE
Decouple Themes and Extensions from Hot Reload Logic

### DIFF
--- a/lib/shopify_cli/theme/dev_server/hooks/file_change_hook.rb
+++ b/lib/shopify_cli/theme/dev_server/hooks/file_change_hook.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require_relative "../hot_reload/remote_file_reloader"
+require_relative "../hot_reload/remote_file_deleter"
+
+module ShopifyCLI
+  module Theme
+    class DevServer
+      module Hooks
+        class FileChangeHook
+          def initialize(ctx, theme:, ignore_filter: nil)
+            @ctx = ctx
+            @theme = theme
+            @ignore_filter = ignore_filter
+          end
+
+          def call(modified, added, removed, streams: nil)
+            @streams = streams
+            files = (modified + added)
+              .reject { |f| @ignore_filter&.ignore?(f) }
+              .map { |f| @theme[f] }
+            files -= liquid_css_files = files.select(&:liquid_css?)
+            deleted_files = removed
+              .reject { |f| @ignore_filter&.ignore?(f) }
+              .map { |f| @theme[f] }
+
+            remote_delete(deleted_files) unless deleted_files.empty?
+            reload_page(removed) unless deleted_files.empty?
+
+            hot_reload(files) unless files.empty?
+            remote_reload(liquid_css_files)
+          end
+
+          private
+
+          def hot_reload(files)
+            paths = files.map(&:relative_path)
+            @streams.broadcast(JSON.generate(modified: paths))
+            @ctx.debug("[HotReload] Modified #{paths.join(", ")}")
+          end
+
+          def reload_page(removed)
+            @streams.broadcast(JSON.generate(reload_page: true))
+            @ctx.debug("[ReloadPage] Deleted #{removed.join(", ")}")
+          end
+
+          def remote_reload(files)
+            files.each do |file|
+              @ctx.debug("reload file each -> file.relative_path #{file.relative_path}")
+              remote_file_reloader.reload(file)
+            end
+          end
+
+          def remote_delete(files)
+            files.each do |file|
+              @ctx.debug("delete file each -> file.relative_path #{file.relative_path}")
+              remote_file_deleter.delete(file)
+            end
+          end
+
+          def remote_file_deleter
+            @remote_file_deleter ||= HotReload::RemoteFileDeleter.new(@ctx, theme: @theme, streams: @streams)
+          end
+
+          def remote_file_reloader
+            @remote_file_reloader ||= HotReload::RemoteFileReloader.new(@ctx, theme: @theme, streams: @streams)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/hooks/reload_js_hook.rb
+++ b/lib/shopify_cli/theme/dev_server/hooks/reload_js_hook.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require_relative "../hot_reload/sections_index"
+
+module ShopifyCLI
+  module Theme
+    class DevServer
+      module Hooks
+        class ReloadJSHook
+          def initialize(ctx, theme:)
+            @ctx = ctx
+            @theme = theme
+            @sections_index = HotReload::SectionsIndex.new(@theme)
+          end
+
+          def call(body:, dir:, mode:)
+            @mode = mode
+            hot_reload_no_script = ::File.read("#{dir}/hot-reload-no-script.html")
+            hot_reload_js = ::File.read("#{dir}/hot-reload-theme.js")
+            hot_reload_script = [
+              hot_reload_no_script,
+              "<script>",
+              params_js,
+              hot_reload_js,
+              "</script>",
+            ].join("\n")
+
+            body = body.join.gsub("</body>", "#{hot_reload_script}\n</body>")
+
+            [body]
+          end
+
+          private
+
+          def params_js
+            env = { mode: @mode }
+            env[:section_names_by_type] = @sections_index.section_names_by_type
+
+            <<~JS
+              (() => {
+                window.__SHOPIFY_CLI_ENV__ = #{env.to_json};
+              })();
+            JS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -1,27 +1,18 @@
 # frozen_string_literal: true
 
-require_relative "hot_reload/remote_file_reloader"
-require_relative "hot_reload/remote_file_deleter"
-require_relative "hot_reload/sections_index"
-
 module ShopifyCLI
   module Theme
     class DevServer
       class HotReload
-        def initialize(ctx, app, theme:, watcher:, mode:, ignore_filter: nil, extension: nil)
+        def initialize(ctx, app, broadcast_hooks: [], js_hook: nil, watcher:, mode:)
           @ctx = ctx
           @app = app
-          @theme = theme
           @mode = mode
+          @broadcast_hooks = broadcast_hooks
+          @js_hook = js_hook
           @streams = SSE::Streams.new
-          @remote_file_reloader = RemoteFileReloader.new(ctx, theme: @theme, streams: @streams)
-          @remote_file_deleter = RemoteFileDeleter.new(ctx, theme: @theme, streams: @streams)
-          @sections_index = SectionsIndex.new(@theme)
           @watcher = watcher
           @watcher.add_observer(self, :notify_streams_of_file_change)
-          @ignore_filter = ignore_filter
-          @extension = extension
-          @extension_mode = !extension.nil?
         end
 
         def call(env)
@@ -41,80 +32,19 @@ module ShopifyCLI
         end
 
         def notify_streams_of_file_change(modified, added, removed)
-          files = (modified + added)
-            .reject { |file| @ignore_filter&.ignore?(file) }
-            .map { |file| @extension_mode ? @extension[file] : @theme[file] }
-
-          files -= liquid_css_files = files.select(&:liquid_css?)
-
-          deleted_files = removed
-            .reject { |file| @ignore_filter&.ignore?(file) }
-            .map { |file| @theme[file] }
-
-          remote_delete(deleted_files) unless deleted_files.empty?
-          reload_page(removed) unless deleted_files.empty?
-
-          hot_reload(files) unless files.empty?
-          remote_reload(liquid_css_files)
+          @broadcast_hooks.each do |hook|
+            hook.call(modified, added, removed, streams: @streams)
+          end
         end
 
         private
-
-        def hot_reload(files)
-          paths = files.map(&:relative_path)
-          @streams.broadcast(JSON.generate(modified: paths))
-          @ctx.debug("[HotReload] Modified #{paths.join(", ")}")
-        end
-
-        def reload_page(removed)
-          @streams.broadcast(JSON.generate(reload_page: true))
-          @ctx.debug("[ReloadPage] Deleted #{removed.join(", ")}")
-        end
-
-        def remote_delete(files)
-          files.each do |file|
-            @ctx.debug("delete file each -> file.relative_path #{file.relative_path}")
-            @remote_file_deleter.delete(file)
-          end
-        end
-
-        def remote_reload(files)
-          files.each do |file|
-            @ctx.debug("reload file each -> file.relative_path #{file.relative_path}")
-            @remote_file_reloader.reload(file)
-          end
-        end
 
         def request_is_html?(headers)
           headers["content-type"]&.start_with?("text/html")
         end
 
         def inject_hot_reload_javascript(body)
-          hot_reload_filename = @extension_mode ? "hot-reload-tae.js" : "hot-reload-theme.js"
-          hot_reload_no_script = ::File.read("#{__dir__}/hot-reload-no-script.html")
-          hot_reload_js = ::File.read("#{__dir__}/#{hot_reload_filename}")
-          hot_reload_script = [
-            hot_reload_no_script,
-            "<script>",
-            params_js,
-            hot_reload_js,
-            "</script>",
-          ].join("\n")
-
-          body = body.join.gsub("</body>", "#{hot_reload_script}\n</body>")
-
-          [body]
-        end
-
-        def params_js
-          env = { mode: @mode }
-          env[:section_names_by_type] = @extension_mode ? [] : @sections_index.section_names_by_type
-
-          <<~JS
-            (() => {
-              window.__SHOPIFY_CLI_ENV__ = #{env.to_json};
-            })();
-          JS
+          @js_hook&.call(body: body, dir: __dir__, mode: @mode)
         end
 
         def create_stream

--- a/lib/shopify_cli/theme/extension/dev_server/hooks/file_change_hook.rb
+++ b/lib/shopify_cli/theme/extension/dev_server/hooks/file_change_hook.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class DevServer
+        module Hooks
+          class FileChangeHook
+            def initialize(ctx, extension:)
+              @ctx = ctx
+              @extension = extension
+            end
+
+            def call(modified, added, removed, streams: nil)
+              @streams = streams
+              files = (modified + added)
+                .map { |f| @extension[f] }
+                .reject(&:liquid_css?)
+              deleted_files = removed
+                .map { |f| @extension[f] }
+
+              reload_page(removed) unless deleted_files.empty?
+              hot_reload(files) unless files.empty?
+            end
+
+            private
+
+            def hot_reload(files)
+              paths = files.map(&:relative_path)
+              @streams.broadcast(JSON.generate(modified: paths))
+              @ctx.debug("[HotReload] Modified #{paths.join(", ")}")
+            end
+
+            def reload_page(removed)
+              @streams.broadcast(JSON.generate(reload_page: true))
+              @ctx.debug("[ReloadPage] Deleted #{removed.join(", ")}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_cli/theme/extension/dev_server/hooks/reload_js_hook.rb
+++ b/lib/shopify_cli/theme/extension/dev_server/hooks/reload_js_hook.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class DevServer
+        module Hooks
+          class ReloadJSHook
+            def initialize(ctx)
+              @ctx = ctx
+            end
+
+            def call(body:, dir:, mode:)
+              @mode = mode
+              hot_reload_no_script = ::File.read("#{dir}/hot-reload-no-script.html")
+              hot_reload_js = ::File.read("#{dir}/hot-reload-tae.js")
+              hot_reload_script = [
+                hot_reload_no_script,
+                "<script>",
+                params_js,
+                hot_reload_js,
+                "</script>",
+              ].join("\n")
+
+              body = body.join.gsub("</body>", "#{hot_reload_script}\n</body>")
+
+              [body]
+            end
+
+            private
+
+            def params_js
+              env = { mode: @mode }
+              <<~JS
+                (() => {
+                  window.__SHOPIFY_CLI_ENV__ = #{env.to_json};
+                })();
+              JS
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/hooks/file_change_hook_test.rb
+++ b/test/shopify-cli/theme/dev_server/hooks/file_change_hook_test.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rack/mock"
+require "shopify_cli/theme/dev_server"
+
+module ShopifyCLI
+  module Theme
+    class DevServer
+      module Hooks
+        class FileChangeHookTest < Minitest::Test
+          def setup
+            super
+            root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+            @ctx = TestHelpers::FakeContext.new(root: root)
+            @theme = Theme.new(@ctx, root: root)
+            @syncer = stub("Syncer", enqueue_uploads: true, enqueue_deletes: true, enqueue_updates: true,
+              ignore_file?: false)
+            @syncer.stubs(remote_file?: true)
+            @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer)
+            @mode = "off"
+          end
+
+          def test_streams_on_hot_reload_path
+            SSE::Stream.any_instance.expects(:each).yields("")
+            serve(path: "/hot-reload")
+          end
+
+          def test_broadcasts_watcher_events_when_file_modified
+            modified = ["style.css"]
+            SSE::Streams.any_instance
+              .expects(:broadcast)
+              .with(JSON.generate(modified: modified))
+
+            app = -> { [200, {}, []] }
+            HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks, watcher: @watcher, mode: @mode)
+
+            @watcher.changed
+            @watcher.notify_observers(modified, [], [])
+          end
+
+          def test_broadcasts_watcher_events_when_file_deleted
+            deleted = ["announcement.liquid"]
+            HotReload::RemoteFileDeleter
+              .stubs(:new)
+              .returns(remote_file_deleter)
+
+            SSE::Streams.any_instance
+              .expects(:broadcast)
+              .with(JSON.generate(reload_page: true))
+
+            app = -> { [200, {}, []] }
+            HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks, watcher: @watcher, mode: @mode)
+
+            @watcher.changed
+            @watcher.notify_observers([], [], deleted)
+          end
+
+          def test_doesnt_broadcast_watcher_events_when_modified_list_is_empty
+            root_path = Pathname.new(__dir__)
+            ignore_filter = ShopifyCLI::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
+            modified = ["ignored/style.css"]
+            SSE::Streams.any_instance
+              .expects(:broadcast)
+              .with(JSON.generate(modified: modified))
+              .never
+
+            app = -> { [200, {}, []] }
+            HotReload.new(
+              @ctx, app,
+              broadcast_hooks: broadcast_hooks(ignore_filter),
+              watcher: @watcher,
+              mode: @mode,
+            )
+
+            @watcher.changed
+            @watcher.notify_observers(modified, [], [])
+          end
+
+          def test_doesnt_broadcast_watcher_events_when_deleted_list_is_empty
+            root_path = Pathname.new(__dir__)
+            ignore_filter = ShopifyCLI::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
+            deleted = ["ignored/announcement.liquid"]
+            SSE::Streams.any_instance
+              .expects(:broadcast)
+              .with(JSON.generate(reload_page: true))
+              .never
+
+            app = -> { [200, {}, []] }
+            HotReload.new(
+              @ctx, app,
+              broadcast_hooks: broadcast_hooks(ignore_filter),
+              watcher: @watcher,
+              mode: @mode,
+            )
+
+            @watcher.changed
+            @watcher.notify_observers([], [], deleted)
+          end
+
+          def test_doesnt_broadcast_watcher_events_when_modified_file_is_a_liquid_css
+            modified = ["assets/generated.css.liquid"]
+            HotReload::RemoteFileReloader
+              .stubs(:new)
+              .returns(remote_file_reloader)
+            SSE::Streams.any_instance
+              .expects(:broadcast)
+              .with(JSON.generate(modified: modified))
+              .never
+
+            app = -> { [200, {}, []] }
+            HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks, watcher: @watcher, mode: @mode)
+
+            @watcher.changed
+            @watcher.notify_observers(modified, [], [])
+          end
+
+          private
+
+          def remote_file_reloader
+            reloader = mock("Reloader")
+            reloader.stubs(reload: nil)
+            reloader
+          end
+
+          def remote_file_deleter
+            deleter = mock("Deleter")
+            deleter.stubs(delete: nil)
+            deleter
+          end
+
+          def serve(response_body = "", path: "/", headers: {})
+            app = lambda do |_env|
+              [200, headers, [response_body]]
+            end
+            stack = HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks, watcher: @watcher, mode: @mode)
+            request = Rack::MockRequest.new(stack)
+            request.get(path).body
+          end
+
+          def broadcast_hooks(ignore_filter = nil)
+            file_change_hook = FileChangeHook.new(@ctx, theme: @theme, ignore_filter: ignore_filter)
+            [file_change_hook]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/hooks/reload_js_hook_test.rb
+++ b/test/shopify-cli/theme/dev_server/hooks/reload_js_hook_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rack/mock"
+require "shopify_cli/theme/dev_server"
+
+module ShopifyCLI
+  module Theme
+    class DevServer
+      module Hooks
+        class ReloadJSHookTest < Minitest::Test
+          def setup
+            super
+            root = ShopifyCLI::ROOT + "/test/fixtures/theme"
+            @ctx = TestHelpers::FakeContext.new(root: root)
+            @theme = Theme.new(@ctx, root: root)
+            @syncer = stub("Syncer", enqueue_uploads: true, enqueue_deletes: true, enqueue_updates: true,
+              ignore_file?: false)
+            @syncer.stubs(remote_file?: true)
+            @watcher = Watcher.new(@ctx, theme: @theme, syncer: @syncer)
+            @mode = "off"
+          end
+
+          def test_hot_reload_js_injected_if_html_request
+            html = <<~HTML
+              <html>
+                <head></head>
+                <body>
+                  <h1>Hello</h1>
+                </body>
+              </html>
+            HTML
+
+            params_js = <<~JS
+              (() => {
+                window.__SHOPIFY_CLI_ENV__ = {"mode":"off","section_names_by_type":{"main-blog":["main"]}};
+              })();
+            JS
+
+            reload_js = ::File.read(
+              ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-theme.js", ShopifyCLI::ROOT)
+            )
+            hot_reload_no_script = ::File.read(
+              ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-no-script.html", ShopifyCLI::ROOT)
+            )
+
+            injected_script = "<script>\n#{params_js}\n#{reload_js}\n</script>"
+
+            expected_html = <<~HTML
+              <html>
+                <head></head>
+                <body>
+                  <h1>Hello</h1>
+                #{hot_reload_no_script}
+              #{injected_script}
+              </body>
+              </html>
+            HTML
+
+            response = serve(html, headers: { "content-type" => "text/html" })
+
+            assert_equal(expected_html, response)
+          end
+
+          def test_does_not_inject_hot_reload_js_for_non_html_responses
+            css = <<~CSS
+              .body { color: red }
+            CSS
+
+            response = serve(css, headers: { "content-type" => "text/css" })
+
+            assert_equal(css, response)
+          end
+
+          private
+
+          def serve(response_body = "", path: "/", headers: {})
+            app = lambda do |_env|
+              [200, headers, [response_body]]
+            end
+            js_hook = ReloadJSHook.new(@ctx, theme: @theme)
+            stack = HotReload.new(@ctx, app, watcher: @watcher, mode: @mode, js_hook: js_hook)
+            request = Rack::MockRequest.new(stack)
+            request.get(path).body
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 require "test_helper"
-require "shopify_cli/theme/dev_server"
-require "shopify_cli/theme/dev_server/hot_reload/remote_file_reloader"
-require "shopify_cli/theme/dev_server/hot_reload/remote_file_deleter"
 require "rack/mock"
+require "shopify_cli/theme/dev_server"
 
 module ShopifyCLI
   module Theme
@@ -21,174 +19,42 @@ module ShopifyCLI
           @mode = "off"
         end
 
-        def test_hot_reload_js_injected_if_html_request
-          html = <<~HTML
-            <html>
-              <head></head>
-              <body>
-                <h1>Hello</h1>
-              </body>
-            </html>
-          HTML
-
-          params_js = <<~JS
-            (() => {
-              window.__SHOPIFY_CLI_ENV__ = {"mode":"off","section_names_by_type":{"main-blog":["main"]}};
-            })();
-          JS
-
-          reload_js = ::File.read(
-            ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-theme.js", ShopifyCLI::ROOT)
-          )
-          hot_reload_no_script = ::File.read(
-            ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-no-script.html", ShopifyCLI::ROOT)
-          )
-
-          injected_script = "<script>\n#{params_js}\n#{reload_js}\n</script>"
-
-          expected_html = <<~HTML
-            <html>
-              <head></head>
-              <body>
-                <h1>Hello</h1>
-              #{hot_reload_no_script}
-            #{injected_script}
-            </body>
-            </html>
-          HTML
-
-          response = serve(html, headers: { "content-type" => "text/html" })
-
-          assert_equal(expected_html, response)
-        end
-
-        def test_does_not_inject_hot_reload_js_for_non_html_responses
-          css = <<~CSS
-            .body { color: red }
-          CSS
-
-          response = serve(css, headers: { "content-type" => "text/css" })
-
-          assert_equal(css, response)
-        end
-
-        def test_streams_on_hot_reload_path
-          SSE::Stream.any_instance.expects(:each).yields("")
-          serve(path: "/hot-reload")
-        end
-
-        def test_broadcasts_watcher_events_when_file_modified
-          modified = ["style.css"]
-          SSE::Streams.any_instance
-            .expects(:broadcast)
-            .with(JSON.generate(modified: modified))
-
+        def test_calls_broadcast_hooks_when_available
           app = -> { [200, {}, []] }
-          HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
-
+          @ctx.expects(:debug).with("Ran 1").once
+          @ctx.expects(:debug).with("Ran 2").once
+          @ctx.expects(:debug).with("Ran 3").once
+          HotReload.new(@ctx, app, broadcast_hooks: broadcast_hook_mock, watcher: @watcher, mode: @mode)
           @watcher.changed
-          @watcher.notify_observers(modified, [], [])
+          @watcher.notify_observers([], [], [])
         end
 
-        def test_broadcasts_watcher_events_when_file_deleted
-          deleted = ["announcement.liquid"]
-          HotReload::RemoteFileDeleter
-            .stubs(:new)
-            .returns(remote_file_deleter)
+        def test_calls_reload_js_hook
+          app = lambda do |_env|
+            [200, { "content-type" => "text/html" }, []]
+          end
+          correct_output = "<html><script>console.log('testing');</script></html>"
+          stack = HotReload.new(@ctx, app, watcher: @watcher, mode: @mode, js_hook: reload_js_hook_mock(correct_output))
+          request = Rack::MockRequest.new(stack)
 
-          SSE::Streams.any_instance
-            .expects(:broadcast)
-            .with(JSON.generate(reload_page: true))
-
-          app = -> { [200, {}, []] }
-          HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
-
-          @watcher.changed
-          @watcher.notify_observers([], [], deleted)
-        end
-
-        def test_doesnt_broadcast_watcher_events_when_modified_list_is_empty
-          root_path = Pathname.new(__dir__)
-          ignore_filter = ShopifyCLI::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
-          modified = ["ignored/style.css"]
-          SSE::Streams.any_instance
-            .expects(:broadcast)
-            .with(JSON.generate(modified: modified))
-            .never
-
-          app = -> { [200, {}, []] }
-          HotReload.new(
-            @ctx, app,
-            theme: @theme,
-            watcher: @watcher,
-            mode: @mode,
-            ignore_filter: ignore_filter
-          )
-
-          @watcher.changed
-          @watcher.notify_observers(modified, [], [])
-        end
-
-        def test_doesnt_broadcast_watcher_events_when_deleted_list_is_empty
-          root_path = Pathname.new(__dir__)
-          ignore_filter = ShopifyCLI::Theme::IgnoreFilter.new(root_path, patterns: ["ignored/**"])
-          deleted = ["ignored/announcement.liquid"]
-          SSE::Streams.any_instance
-            .expects(:broadcast)
-            .with(JSON.generate(reload_page: true))
-            .never
-
-          app = -> { [200, {}, []] }
-          HotReload.new(
-            @ctx, app,
-            theme: @theme,
-            watcher: @watcher,
-            mode: @mode,
-            ignore_filter: ignore_filter
-          )
-
-          @watcher.changed
-          @watcher.notify_observers([], [], deleted)
-        end
-
-        def test_doesnt_broadcast_watcher_events_when_modified_file_is_a_liquid_css
-          modified = ["assets/generated.css.liquid"]
-          HotReload::RemoteFileReloader
-            .stubs(:new)
-            .returns(remote_file_reloader)
-          SSE::Streams.any_instance
-            .expects(:broadcast)
-            .with(JSON.generate(modified: modified))
-            .never
-
-          app = -> { [200, {}, []] }
-          HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
-
-          @watcher.changed
-          @watcher.notify_observers(modified, [], [])
+          assert_equal(correct_output, request.get("/").body)
         end
 
         private
 
-        def remote_file_reloader
-          reloader = mock("Reloader")
-          reloader.stubs(reload: nil)
-          reloader
+        def app
         end
 
-        def remote_file_deleter
-          deleter = mock("Deleter")
-          deleter.stubs(delete: nil)
-          deleter
+        def reload_js_hook_mock(body)
+          hook = mock("ReloadJSHook", call: body)
+          hook
         end
 
-        def serve(response_body = "", path: "/", headers: {})
-          app = lambda do |_env|
-            [200, headers, [response_body]]
-          end
-          stack = HotReload.new(@ctx, app, theme: @theme, watcher: @watcher, mode: @mode)
-          request = Rack::MockRequest.new(stack)
-          request.get(path).body
+        def broadcast_hook_mock
+          hook1 = mock("BroadcastHook1", call: @ctx.debug("Ran 1"))
+          hook2 = mock("BroadcastHook2", call: @ctx.debug("Ran 2"))
+          hook3 = mock("BroadcastHook3", call: @ctx.debug("Ran 3"))
+          [hook1, hook2, hook3]
         end
       end
     end

--- a/test/shopify-cli/theme/extension/dev_server/hooks/file_change_hook_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/hooks/file_change_hook_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rack/mock"
+require "shopify_cli/theme/app_extension"
+require "shopify_cli/theme/extension/dev_server"
+require "shopify_cli/theme/dev_server/sse"
+require "shopify_cli/theme/dev_server/hot_reload"
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class DevServer
+        module Hooks
+          class FileChangeHookTest < Minitest::Test
+            SSE = ::ShopifyCLI::Theme::DevServer::SSE
+            HotReload = ::ShopifyCLI::Theme::DevServer::HotReload
+
+            def setup
+              super
+              root = ShopifyCLI::ROOT + "/test/fixtures/extension"
+              @ctx = TestHelpers::FakeContext.new(root: root)
+              @extension = AppExtension.new(@ctx, root: root, id: 1234)
+              @syncer = stub("Syncer", enqueue_files: true)
+              @watcher = Watcher.new(@ctx, extension: @extension, syncer: @syncer)
+              @mode = "off"
+            end
+
+            def test_streams_on_hot_reload_path
+              SSE::Stream.any_instance.expects(:each).yields("")
+              serve(path: "/hot-reload")
+            end
+
+            def test_broadcasts_watcher_events_when_file_modified
+              modified = ["style.css"]
+              SSE::Streams.any_instance
+                .expects(:broadcast)
+                .with(JSON.generate(modified: modified))
+
+              app = -> { [200, {}, []] }
+              HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks,
+                watcher: @watcher, mode: @mode)
+
+              @watcher.changed
+              @watcher.notify_observers(modified, [], [])
+            end
+
+            def test_broadcasts_watcher_events_when_file_deleted
+              deleted = ["announcement.liquid"]
+              HotReload::RemoteFileDeleter
+                .stubs(:new)
+                .returns(remote_file_deleter)
+
+              SSE::Streams.any_instance
+                .expects(:broadcast)
+                .with(JSON.generate(reload_page: true))
+
+              app = -> { [200, {}, []] }
+              HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks,
+                watcher: @watcher, mode: @mode)
+
+              @watcher.changed
+              @watcher.notify_observers([], [], deleted)
+            end
+
+            def test_doesnt_broadcast_watcher_events_when_modified_file_is_a_liquid_css
+              modified = ["assets/generated.css.liquid"]
+              HotReload::RemoteFileReloader
+                .stubs(:new)
+                .returns(remote_file_reloader)
+              SSE::Streams.any_instance
+                .expects(:broadcast)
+                .with(JSON.generate(modified: modified))
+                .never
+
+              app = -> { [200, {}, []] }
+              HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks,
+                watcher: @watcher, mode: @mode)
+
+              @watcher.changed
+              @watcher.notify_observers(modified, [], [])
+            end
+
+            private
+
+            def remote_file_reloader
+              reloader = mock("Reloader")
+              reloader.stubs(reload: nil)
+              reloader
+            end
+
+            def remote_file_deleter
+              deleter = mock("Deleter")
+              deleter.stubs(delete: nil)
+              deleter
+            end
+
+            def serve(response_body = "", path: "/", headers: {})
+              app = lambda do |_env|
+                [200, headers, [response_body]]
+              end
+              stack = HotReload.new(@ctx, app, broadcast_hooks: broadcast_hooks,
+                watcher: @watcher, mode: @mode)
+              request = Rack::MockRequest.new(stack)
+              request.get(path).body
+            end
+
+            def broadcast_hooks
+              file_change_hook = FileChangeHook.new(@ctx, extension: @extension)
+              [file_change_hook]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/extension/dev_server/hooks/reload_js_hook_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/hooks/reload_js_hook_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+require "test_helper"
+require "rack/mock"
+require "shopify_cli/theme/extension/dev_server"
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class DevServer
+        module Hooks
+          class ReloadJSHookTest < Minitest::Test
+            HotReload = ::ShopifyCLI::Theme::DevServer::HotReload
+            def setup
+              super
+              root = ShopifyCLI::ROOT + "/test/fixtures/extension"
+              @ctx = TestHelpers::FakeContext.new(root: root)
+              @extension = AppExtension.new(@ctx, root: root, id: 1234)
+              @syncer = stub("Syncer", enqueue_files: true)
+              @watcher = Watcher.new(@ctx, extension: @extension, syncer: @syncer)
+              @mode = "off"
+            end
+
+            def test_hot_reload_js_injected_if_html_request
+              html = <<~HTML
+                <html>
+                  <head></head>
+                  <body>
+                    <h1>Hello</h1>
+                  </body>
+                </html>
+              HTML
+
+              params_js = <<~JS
+                (() => {
+                  window.__SHOPIFY_CLI_ENV__ = {"mode":"off"};
+                })();
+              JS
+
+              reload_js = ::File.read(
+                ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-tae.js", ShopifyCLI::ROOT)
+              )
+              hot_reload_no_script = ::File.read(
+                ::File.expand_path("lib/shopify_cli/theme/dev_server/hot-reload-no-script.html", ShopifyCLI::ROOT)
+              )
+
+              injected_script = "<script>\n#{params_js}\n#{reload_js}\n</script>"
+
+              expected_html = <<~HTML
+                <html>
+                  <head></head>
+                  <body>
+                    <h1>Hello</h1>
+                  #{hot_reload_no_script}
+                #{injected_script}
+                </body>
+                </html>
+              HTML
+
+              response = serve(html, headers: { "content-type" => "text/html" })
+
+              assert_equal(expected_html, response)
+            end
+
+            def test_does_not_inject_hot_reload_js_for_non_html_responses
+              css = <<~CSS
+                .body { color: red }
+              CSS
+
+              response = serve(css, headers: { "content-type" => "text/css" })
+
+              assert_equal(css, response)
+            end
+
+            private
+
+            def serve(response_body = "", path: "/", headers: {})
+              app = lambda do |_env|
+                [200, headers, [response_body]]
+              end
+              js_hook = ReloadJSHook.new(@ctx)
+              stack = HotReload.new(@ctx, app, watcher: @watcher, mode: @mode,
+                js_hook: js_hook)
+              request = Rack::MockRequest.new(stack)
+              request.get(path).body
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?

Closes [#2536](https://github.com/Shopify/shopify-cli/issues/2536)

This PR addresses the issue of decoupling the extension/theme logic from our HotReload middleware. I've introduced the concept of "hooks," specifically broadcast_hooks and js_reload hooks. The broadcast hooks deal with any logic following an event from the directory Watcher. The JS reload hooks deal with injecting our respective hot reload scripts into the response body being returned to the client.

I could separate this broadcast_hooks array into a list of hooks that run before we have any interaction with our SSE streams, and one that deals with actually broadcasting these changes to our SSE clients. I do think single `broadcast_hooks` approach is viable, as we can just rely on the ordering of hooks within the array.

Note: I've moved the `hot_reload.rb` core testing logic around a bit, since now the behavior of HotReload is just to execute the "lambdas" it's been given. This approach seemed to work better, as in the future if someone wants to add another hook to either middleware stack, they only need to create/change the test file related to their new hook, and not alter the main `hot_reload_test.rb` file.

### How to test your changes?

1. Try running `shopify-dev theme serve` and note proper behavior.
2. Try running `shopify-dev extension serve` and note proper behavior (snippets and js assets reloading page, everything else DOM hot reloading).