### PR TITLE
Add support for `--port`/`-T/--theme` flags

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -17,6 +17,9 @@ module Extension
         parser.on("-p", "--port=PORT", "Specify the port to use") do |port|
           flags[:port] = port.to_i
         end
+        parser.on("-T", "--theme=NAME_OR_ID", "Theme ID or name of the theme app extension host theme.") do |theme|
+          flags[:theme] = theme
+        end
       end
 
       class RuntimeConfiguration
@@ -26,13 +29,15 @@ module Extension
         property :resource_url, accepts: String, default: nil
         property! :tunnel_requested, accepts: [true, false], reader: :tunnel_requested?, default: true
         property :port, accepts: (1...(2**16))
+        property :theme, accepts: String, default: nil
       end
 
       def call(_args, _command_name)
         config = RuntimeConfiguration.new(
           tunnel_requested: tunnel_requested?,
           resource_url: options.flags[:resource_url],
-          port: options.flags[:port]
+          port: options.flags[:port],
+          theme: options.flags[:theme]
         )
 
         ShopifyCLI::Result
@@ -87,6 +92,7 @@ module Extension
           context: @ctx,
           tunnel_url: runtime_configuration.tunnel_url,
           port: runtime_configuration.port,
+          theme: runtime_configuration.theme,
           resource_url: runtime_configuration.resource_url
         )
         runtime_configuration

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -104,7 +104,9 @@ module Extension
           Serve your extension in a local simulator for development.
             Usage: {{command:%s extension serve}}
             Options:
-            {{command:--tunnel=TUNNEL}} Establish an ngrok tunnel (default: false)
+              {{command:--tunnel=TUNNEL}}        Establish an ngrok tunnel (default: false).
+              {{command:-p, --port=PORT}}        Local port of the development serve.
+              {{command:-T, --theme=NAME_OR_ID}} Theme ID or name of the host theme.
         HELP
         frame_title: "Serving extension…",
         no_available_ports_found: "No available ports found to run extension.",

--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -76,8 +76,9 @@ module Extension
         def serve(**options)
           @ctx = options[:context]
           root = options[:context]&.root
+          flags = options.slice(:port, :theme).compact
 
-          ShopifyCLI::Theme::Extension::DevServer.start(@ctx, root)
+          ShopifyCLI::Theme::Extension::DevServer.start(@ctx, root, **flags)
         end
 
         private

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -104,8 +104,21 @@ module Extension
 
         serve.specification_handler
           .expects(:serve)
-          .with(context: @context, tunnel_url: nil, port: 39351, resource_url: expected_resource_url)
+          .with(context: @context, tunnel_url: nil, port: 39351, theme: nil, resource_url: expected_resource_url)
         serve.options.flags[:resource_url] = expected_resource_url
+        serve.call([], "serve")
+      end
+
+      def test_theme_is_forwarded_to_specification_handler_if_one_is_provided
+        serve = ::Extension::Command::Serve.new(@context)
+        theme = "dev theme"
+        stub_specification_handler_options(serve, choose_port: true)
+
+        serve.specification_handler
+          .expects(:serve)
+          .with(context: @context, tunnel_url: nil, port: 39351, theme: theme, resource_url: nil)
+
+        serve.options.flags[:theme] = theme
         serve.call([], "serve")
       end
 

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -169,6 +169,18 @@ module Extension
           @spec.serve(context: @context)
         end
 
+        def test_serve_calls_extension_dev_server_with_port
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(@context, @context.root, port: 9192)
+
+          @spec.serve(context: @context, port: 9192)
+        end
+
+        def test_serve_calls_extension_dev_server_with_theme
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(@context, @context.root, theme: "1234")
+
+          @spec.serve(context: @context, theme: "1234")
+        end
+
         def test_serve_calls_extension_dev_server_with_nil_when_no_context
           ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(nil, nil)
 

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -164,7 +164,9 @@ module Extension
         end
 
         def test_serve_calls_extension_dev_server_with_context
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(@context, @context.root)
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with do |ctx, root, flags|
+            ctx == @context && root == @context.root && [nil, {}].include?(flags)
+          end
 
           @spec.serve(context: @context)
         end
@@ -182,7 +184,9 @@ module Extension
         end
 
         def test_serve_calls_extension_dev_server_with_nil_when_no_context
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(nil, nil)
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with do |ctx, root, flags|
+            ctx.nil? && root.nil? && [nil, {}].include?(flags)
+          end
 
           @spec.serve
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2533 https://github.com/Shopify/shopify-cli/issues/2534

### WHAT is this pull request doing?

This PR adds support for the `--port`/`-T/--theme` flags. Notice that we needed to use the capitalized `-T` to disambiguate with the `-t` of the `--[no-]tunnel`

Still, I don't think that's a problem, because this command with be exposed at the [shopify/cli](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/commands/app/dev.ts#L55-L59) and fortunately the [`tunnel-url` doesn't have a `char:`](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/commands/app/dev.ts#L55-L59) property there.

### How to test your changes?

- Run `shopify-dev extension serve --theme <THEME_ID_OR_NAME> --port <PORT>`
<img width="1613" alt="demo" src="https://user-images.githubusercontent.com/1079279/185619814-1929014a-9f50-4d49-89c1-bc57785d47c2.png">

