### PR TITLE
Revert "Add a temporary extension mock (#2485)"

### DIFF
--- a/lib/project_types/extension/tasks/fetch_specifications.rb
+++ b/lib/project_types/extension/tasks/fetch_specifications.rb
@@ -7,16 +7,9 @@ module Extension
       property :api_key
 
       def call
-        # TODO: remove me when SFR gets merged
-        response = [
-          {
-            "name" => "Online Store - App Theme Extension",
-            "identifier" => "theme_app_extension",
-            "options" => { "managementExperience" => "cli" },
-            "features" => { "argo" => nil },
-          },
-        ]
-
+        response = ShopifyCLI::PartnersAPI
+          .query(context, "fetch_specifications", api_key: api_key)
+          .dig("data", "extensionSpecifications")
         context.abort(context.message("tasks.errors.parse_error")) if response.nil?
 
         response.reject do |line|


### PR DESCRIPTION
This reverts commit 7df988d8d1a8bf003ba6d468904cb2b532c30d3e (as now we're relying on the SFR in production).