### PR TITLE
Packaging for release v2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.23.0 - 2022-08-22
+
 ### Fixed
 * [#2528](https://github.com/Shopify/shopify-cli/pull/2528): Switch from using absolute file paths to relative paths for ignore filter
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.22.0)
+    shopify-cli (2.23.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.10.3)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.22.0"
+  VERSION = "2.23.0"
 end


### PR DESCRIPTION
### Fixed
* [#2528](https://github.com/Shopify/shopify-cli/pull/2528): Switch from using absolute file paths to relative paths for ignore filter

### Added
* [#2520](https://github.com/Shopify/shopify-cli/pull/2520): Add the option to ignore new version warnings by passing the `SHOPIFY_CLI_RUN_AS_SUBPROCESS` environment variable
* [#2440](https://github.com/Shopify/shopify-cli/pull/2440): Warn when using CLI 2.0 in a CLI 3.0 project
