### PR TITLE
Remove Ubuntu 18.04 and add 22.04 to the matrix of OSs used to run CI builds

### DIFF
--- a/.github/workflows/shopify.yml
+++ b/.github/workflows/shopify.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - macos-11
           - ubuntu-20.04
-          - ubuntu-18.04
+          - ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set Git configuration


### PR DESCRIPTION
### WHY are these changes introduced?
Ubuntu 18.04 is [deprecated](https://github.com/actions/runner-images#available-images) on GitHub actions and is [causing some builds to fail](https://github.com/Shopify/shopify-cli/runs/7955238804?check_suite_focus=true).
 
### WHAT is this pull request doing?
I'm removing Ubuntu 18.04 from the matrix and adding the most recent version, 22.04.

### How to test your changes?
CI should pass

### Update checklist
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
