### PR TITLE
Show `extension serve` message following document prototype

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -20,6 +20,15 @@ module Extension
         parser.on("-T", "--theme=NAME_OR_ID", "Theme ID or name of the theme app extension host theme.") do |theme|
           flags[:theme] = theme
         end
+        parser.on("--api-key=API_KEY", "Connect your extension and app by inserting your app's API key") do |api_key|
+          flags[:api_key] = api_key.gsub('"', "")
+        end
+        parser.on("--api-secret=API_SECRET", "The API secret of the app the script is registered with.") do |api_secret|
+          flags[:api_secret] = api_secret.gsub('"', "")
+        end
+        parser.on("--extension-id=EXTENSION_ID", "The id of the extension's registration.") do |registration_id|
+          flags[:registration_id] = registration_id.gsub('"', "")
+        end
       end
 
       class RuntimeConfiguration
@@ -30,6 +39,9 @@ module Extension
         property! :tunnel_requested, accepts: [true, false], reader: :tunnel_requested?, default: true
         property :port, accepts: (1...(2**16))
         property :theme, accepts: String, default: nil
+        property :api_key, accepts: String, default: nil
+        property :api_secret, accepts: String, default: nil
+        property :registration_id, accepts: String, default: nil
       end
 
       def call(_args, _command_name)
@@ -37,7 +49,10 @@ module Extension
           tunnel_requested: tunnel_requested?,
           resource_url: options.flags[:resource_url],
           port: options.flags[:port],
-          theme: options.flags[:theme]
+          theme: options.flags[:theme],
+          api_key: options.flags[:api_key],
+          api_secret: options.flags[:api_secret],
+          registration_id: options.flags[:registration_id]
         )
 
         ShopifyCLI::Result
@@ -93,6 +108,9 @@ module Extension
           tunnel_url: runtime_configuration.tunnel_url,
           port: runtime_configuration.port,
           theme: runtime_configuration.theme,
+          api_key: runtime_configuration.api_key,
+          api_secret: runtime_configuration.api_secret,
+          registration_id: runtime_configuration.registration_id,
           resource_url: runtime_configuration.resource_url
         )
         runtime_configuration

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -104,15 +104,31 @@ module Extension
           Serve your extension in a local simulator for development.
             Usage: {{command:%s extension serve}}
             Options:
-              {{command:--tunnel=TUNNEL}}        Establish an ngrok tunnel (default: false).
-              {{command:-p, --port=PORT}}        Local port of the development serve.
-              {{command:-T, --theme=NAME_OR_ID}} Theme ID or name of the host theme.
+              {{command:-p, --port=PORT}}             Local port of the development serve.
+              {{command:-T, --theme=NAME_OR_ID}}      Theme ID or name of the host theme.
+              {{command:--tunnel=TUNNEL}}             Establish an ngrok tunnel (default: false).
+              {{command:--api-key=API_KEY}}           Connect your extension and app by inserting your app's API key (which you can get from your app setup page on shopify.dev).
+              {{command:--api-secret=API_SECRET}}     The API secret of the app the script is registered with.
+              {{command:--extension-id=EXTENSION_ID}} The id of the extension's registration.
         HELP
-        frame_title: "Serving extension…",
+        frame_title: "Viewing extension…",
+        pushing_extension: "Pushing extension…",
         no_available_ports_found: "No available ports found to run extension.",
         serve_failure_message: "Failed to run extension code.",
         serve_missing_information: "Missing shop or api_key.",
         tunnel_already_running: "A tunnel running on another port has been detected. Close the tunnel and try again.",
+        preview_message: <<~PREVIEW_MESSAGE,
+          Enable your theme app extension:
+          {{green:%s}}
+
+          Setup your theme app extension in the host theme:
+          {{green:%s}}
+
+          Preview your theme app extension:
+          {{green:%s}}
+
+          (Use Ctrl-C to stop)
+        PREVIEW_MESSAGE
       },
       tunnel: {
         duplicate_session: <<~MESSAGE,

--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -76,12 +76,28 @@ module Extension
         def serve(**options)
           @ctx = options[:context]
           root = options[:context]&.root
-          flags = options.slice(:port, :theme).compact
+          properties = options
+            .slice(:port, :theme)
+            .compact
+            .merge({
+              project: load_project(options),
+              specification_handler: self,
+            })
 
-          ShopifyCLI::Theme::Extension::DevServer.start(@ctx, root, **flags)
+          ShopifyCLI::Theme::Extension::DevServer.start(@ctx, root, **properties)
         end
 
         private
+
+        def load_project(options)
+          Extension::Loaders::Project.load(
+            context: options[:context],
+            directory: Dir.pwd,
+            api_key: options[:api_key],
+            api_secret: options[:api_secret],
+            registration_id: options[:registration_id]
+          )
+        end
 
         def validate(filename)
           dirname = File.dirname(filename)

--- a/lib/shopify_cli/theme/app_extension.rb
+++ b/lib/shopify_cli/theme/app_extension.rb
@@ -4,11 +4,13 @@ require_relative "root"
 module ShopifyCLI
   module Theme
     class AppExtension < Root
-      attr_reader :root, :id
+      attr_reader :root, :location, :registration_id
 
-      def initialize(ctx, root:, id:)
+      def initialize(ctx, root:, location: nil, registration_id: nil)
         super(ctx, root: root)
-        @id = id
+
+        @location = location
+        @registration_id = registration_id
       end
 
       def extension_files

--- a/lib/shopify_cli/theme/app_extension.rb
+++ b/lib/shopify_cli/theme/app_extension.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
+
 require_relative "root"
 
 module ShopifyCLI
   module Theme
     class AppExtension < Root
-      attr_reader :root, :location, :registration_id
+      attr_reader :root, :app_id, :location, :registration_id
 
-      def initialize(ctx, root:, location: nil, registration_id: nil)
+      def initialize(ctx, root:, app_id: nil, location: nil, registration_id: nil)
         super(ctx, root: root)
 
+        @app_id = app_id
         @location = location
         @registration_id = registration_id
       end

--- a/lib/shopify_cli/theme/extension/host_theme.rb
+++ b/lib/shopify_cli/theme/extension/host_theme.rb
@@ -78,19 +78,21 @@ module ShopifyCLI
         end
 
         def generate_tmp_theme
+          ctx = @ctx.dup
+
           Dir.mktmpdir do |dir|
             @root = Pathname.new(dir)
-            @ctx.root = dir
+            ctx.root = dir
 
-            syncer = ShopifyCLI::Theme::Syncer.new(@ctx, theme: self)
+            syncer = ShopifyCLI::Theme::Syncer.new(ctx, theme: self)
 
             begin
               syncer.start_threads
-              ::CLI::UI::Frame.open(@ctx.message("theme.push.info.pushing", name, id, shop)) do
+              ::CLI::UI::Frame.open(ctx.message("theme.push.info.pushing", name, id, shop)) do
                 UI::HostThemeProgressBar.new(syncer, dir).progress(:upload_theme!, delete: false)
               end
             rescue Errno::ENOENT => e
-              @ctx.debug(e.message)
+              ctx.debug(e.message)
             ensure
               syncer.shutdown
             end

--- a/lib/shopify_cli/theme/extension/syncer.rb
+++ b/lib/shopify_cli/theme/extension/syncer.rb
@@ -8,9 +8,11 @@ module ShopifyCLI
       class Syncer
         attr_accessor :pending_updates, :latest_sync
 
-        def initialize(ctx, extension:)
+        def initialize(ctx, extension:, project:, specification_handler:)
           @ctx = ctx
           @extension = extension
+          @project = project
+          @specification_handler = specification_handler
 
           @pool = ThreadPool.new(pool_size: 1)
           @pending_updates = []
@@ -25,11 +27,23 @@ module ShopifyCLI
         end
 
         def start
-          @pool.schedule(ExtensionServeJob.new(@ctx, syncer: self, extension: @extension))
+          @pool.schedule(job)
         end
 
         def shutdown
           @pool.shutdown
+        end
+
+        private
+
+        def job
+          ExtensionServeJob.new(
+            @ctx,
+            syncer: self,
+            extension: @extension,
+            project: @project,
+            specification_handler: @specification_handler
+          )
         end
       end
     end

--- a/lib/shopify_cli/theme/extension/syncer.rb
+++ b/lib/shopify_cli/theme/extension/syncer.rb
@@ -15,9 +15,9 @@ module ShopifyCLI
           @specification_handler = specification_handler
 
           @pool = ThreadPool.new(pool_size: 1)
-          @pending_updates = []
+          @pending_updates = extension.extension_files
           @update_mutex = Mutex.new
-          @latest_sync = Time.now
+          @latest_sync = Time.now - ExtensionServeJob::PUSH_INTERVAL
         end
 
         def enqueue_files(files)

--- a/lib/shopify_cli/theme/extension/syncer/extension_serve_job.rb
+++ b/lib/shopify_cli/theme/extension/syncer/extension_serve_job.rb
@@ -43,11 +43,11 @@ module ShopifyCLI
             user_errors = response.dig(USER_ERRORS_FIELD)
 
             if user_errors
-              @ctx.puts(error_message(project.title))
+              @ctx.puts(error_message(@project.title))
               error_files = erroneous_files(user_errors)
               print_items(error_files)
             else
-              @ctx.puts(success_message(project.title))
+              @ctx.puts(success_message(@project.title))
               print_items({}.freeze)
               ::Extension::Tasks::Converters::VersionConverter.from_hash(@ctx, response.dig(VERSION_FIELD))
             end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -102,9 +102,17 @@ module Extension
         expected_resource_url = "foo/bar"
         stub_specification_handler_options(serve, choose_port: true)
 
-        serve.specification_handler
-          .expects(:serve)
-          .with(context: @context, tunnel_url: nil, port: 39351, theme: nil, resource_url: expected_resource_url)
+        serve.specification_handler.expects(:serve).with(
+          context: @context,
+          tunnel_url: nil,
+          port: 39351,
+          theme: nil,
+          api_key: nil,
+          api_secret: nil,
+          registration_id: nil,
+          resource_url: expected_resource_url,
+        )
+
         serve.options.flags[:resource_url] = expected_resource_url
         serve.call([], "serve")
       end
@@ -114,11 +122,43 @@ module Extension
         theme = "dev theme"
         stub_specification_handler_options(serve, choose_port: true)
 
-        serve.specification_handler
-          .expects(:serve)
-          .with(context: @context, tunnel_url: nil, port: 39351, theme: theme, resource_url: nil)
+        serve.specification_handler.expects(:serve).with(
+          context: @context,
+          tunnel_url: nil,
+          port: 39351,
+          theme: theme,
+          api_key: nil,
+          api_secret: nil,
+          registration_id: nil,
+          resource_url: nil,
+        )
 
         serve.options.flags[:theme] = theme
+        serve.call([], "serve")
+      end
+
+      def test_auth_keys_are_forwarded_to_specification_handler_when_provided
+        serve = ::Extension::Command::Serve.new(@context)
+        api_key = "api_key_1234"
+        api_secret = "api_secret_5678"
+        registration_id = "registration_id_9ABC"
+
+        stub_specification_handler_options(serve, choose_port: true)
+
+        serve.specification_handler.expects(:serve).with(
+          context: @context,
+          tunnel_url: nil,
+          port: 39351,
+          theme: nil,
+          api_key: api_key,
+          api_secret: api_secret,
+          registration_id: registration_id,
+          resource_url: nil,
+        )
+
+        serve.options.flags[:api_key] = api_key
+        serve.options.flags[:api_secret] = api_secret
+        serve.options.flags[:registration_id] = registration_id
         serve.call([], "serve")
       end
 

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -164,31 +164,86 @@ module Extension
         end
 
         def test_serve_calls_extension_dev_server_with_context
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with do |ctx, root, flags|
-            ctx == @context && root == @context.root && [nil, {}].include?(flags)
-          end
+          project = mock
+
+          @spec.stubs(:load_project).with({ context: @context }).returns(project)
+
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
+            @context,
+            @context.root,
+            project: project,
+            specification_handler: @spec
+          )
 
           @spec.serve(context: @context)
         end
 
         def test_serve_calls_extension_dev_server_with_port
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(@context, @context.root, port: 9192)
+          project = mock
+
+          @spec.stubs(:load_project).with({ context: @context, port: 9192 }).returns(project)
+
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
+            @context,
+            @context.root,
+            port: 9192,
+            project: project,
+            specification_handler: @spec
+          )
 
           @spec.serve(context: @context, port: 9192)
         end
 
         def test_serve_calls_extension_dev_server_with_theme
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(@context, @context.root, theme: "1234")
+          project = mock
+
+          @spec.stubs(:load_project).with({ context: @context, theme: "1234" }).returns(project)
+
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
+            @context,
+            @context.root,
+            theme: "1234",
+            project: project,
+            specification_handler: @spec
+          )
 
           @spec.serve(context: @context, theme: "1234")
         end
 
         def test_serve_calls_extension_dev_server_with_nil_when_no_context
-          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with do |ctx, root, flags|
-            ctx.nil? && root.nil? && [nil, {}].include?(flags)
-          end
+          project = mock
+
+          @spec.stubs(:load_project).with({}).returns(project)
+
+          ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
+            nil,
+            nil,
+            project: project,
+            specification_handler: @spec
+          )
 
           @spec.serve
+        end
+
+        def test_load_project
+          options = {
+            context: @context,
+            api_key: "api_key_1234",
+            api_secret: "api_secret_5678",
+            registration_id: "registration_id_9ABC",
+          }
+
+          Extension::Loaders::Project
+            .expects(:load)
+            .with(
+              context: options[:context],
+              directory: Dir.pwd,
+              api_key: options[:api_key],
+              api_secret: options[:api_secret],
+              registration_id: options[:registration_id]
+            )
+
+          @spec.send(:load_project, options)
         end
 
         private

--- a/test/shopify-cli/theme/extension/dev_server/hooks/file_change_hook_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/hooks/file_change_hook_test.rb
@@ -19,7 +19,7 @@ module ShopifyCLI
               super
               root = ShopifyCLI::ROOT + "/test/fixtures/extension"
               @ctx = TestHelpers::FakeContext.new(root: root)
-              @extension = AppExtension.new(@ctx, root: root, id: 1234)
+              @extension = AppExtension.new(@ctx, root: root)
               @syncer = stub("Syncer", enqueue_files: true)
               @watcher = Watcher.new(@ctx, extension: @extension, syncer: @syncer)
               @mode = "off"

--- a/test/shopify-cli/theme/extension/dev_server/hot_reload/script_injector_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/hot_reload/script_injector_test.rb
@@ -14,7 +14,7 @@ module ShopifyCLI
               super
               root = ShopifyCLI::ROOT + "/test/fixtures/extension"
               @ctx = TestHelpers::FakeContext.new(root: root)
-              @extension = AppExtension.new(@ctx, root: root, id: 1234)
+              @extension = AppExtension.new(@ctx, root: root)
               @syncer = stub("Syncer", enqueue_files: true)
               @watcher = Watcher.new(@ctx, extension: @extension, syncer: @syncer)
               @mode = "off"

--- a/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
@@ -138,7 +138,7 @@ module ShopifyCLI
             end
             root = ShopifyCLI::ROOT + "/test/fixtures/extension"
             ctx = TestHelpers::FakeContext.new(root: root)
-            extension = AppExtension.new(ctx, root: root, id: 1234)
+            extension = AppExtension.new(ctx, root: root)
             stack = LocalAssets.new(ctx, app, extension)
             request = Rack::MockRequest.new(stack)
             request.get(path)

--- a/test/shopify-cli/theme/extension/host_theme_test.rb
+++ b/test/shopify-cli/theme/extension/host_theme_test.rb
@@ -16,6 +16,8 @@ module ShopifyCLI
           @ctx = TestHelpers::FakeContext.new(root: root)
           @syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: false)
           @host_theme = HostTheme.new(@ctx, root: root)
+
+          @ctx.stubs(:dup).returns(@ctx)
         end
 
         def teardown

--- a/test/shopify-cli/theme/extension/syncer_test.rb
+++ b/test/shopify-cli/theme/extension/syncer_test.rb
@@ -4,8 +4,6 @@ require "timecop"
 require "shopify_cli/theme/app_extension"
 require "shopify_cli/theme/extension/syncer"
 require "shopify_cli/theme/extension/syncer/extension_serve_job"
-require "project_types/extension/loaders/specification_handler"
-require "project_types/extension/loaders/project"
 require "project_types/extension/tasks/converters/version_converter"
 
 module ShopifyCLI
@@ -16,15 +14,14 @@ module ShopifyCLI
           super
           root = ShopifyCLI::ROOT + "/test/fixtures/extension"
           @ctx = TestHelpers::FakeContext.new(root: root)
-          @extension = AppExtension.new(@ctx, root: root, id: 1234)
+          @extension = AppExtension.new(@ctx, root: root, app_id: 1234)
+          @extension.stubs(:extension_files).returns([])
           @extension_title = "Extension Testing"
           @project = generate_fake_project
           @specification_handler = generate_fake_spec_handler
 
-          ::Extension::Loaders::Project.expects(:load).returns(@project)
-          ::Extension::Loaders::SpecificationHandler.expects(:load).returns(@specification_handler)
-
-          @syncer = Syncer.new(@ctx, extension: @extension)
+          @syncer = Syncer.new(@ctx, extension: @extension, project: @project,
+            specification_handler: @specification_handler)
         end
 
         def test_logs_success_when_draft_syncs_successfully


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2538

### WHAT is this pull request doing?

This PR introduces the `https://partners.shopify.com/123/apps/456/extensions/theme_app_extension/789` URL in the `extension serve` message.

For introducing that message, this PR moves the `project` and `specification_handler` instances from the `extension_serve_job.rb` to the `dev_server.rb` level. Also, as we needed to perform those changes, I've introduced support to the `--api-key, --api-secret, --extension-id` flags (then the instance of the `Extension::Loaders::Project` has parity with the `extension push` command).

### How to test your changes?

- Run `shopify-dev extension serve`

![demo](https://user-images.githubusercontent.com/1079279/186382582-8890b2ad-cddf-40ae-9569-61e1dd1fe9ed.gif)




