### PR TITLE
temporarily remove id check test

### DIFF
--- a/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/local_assets_test.rb
@@ -8,27 +8,6 @@ module ShopifyCLI
     module Extension
       class DevServer
         class LocalAssetsTest < Minitest::Test
-          def test_replace_correct_extension_asset_when_same_name
-            skip # TODO: remove skip once id checks are working
-            original_html = <<~HTML
-              <html>
-                <head>
-                  <link rel="stylesheet" href="https://cdn.shopify.com/extensions/some-alphanumeric-id/0.0.0/assets/block1.css?v=1657160440" id="1234"/>
-                  <link rel="stylesheet" href="https://cdn.shopify.com/extensions/some-alphanumeric-id/0.0.0/assets/block1.css?v=1657160440" id="5678"/>
-                </head>
-              </html>
-            HTML
-            expected_html = <<~HTML
-              <html>
-                <head>
-                  <link rel="stylesheet" href="/assets/block1.css?v=1657160440" id="1234"/>
-                  <link rel="stylesheet" href="https://cdn.shopify.com/extensions/some-alphanumeric-id/0.0.0/assets/block1.css?v=1657160440" id="5678"/>
-                </head>
-              </html>
-            HTML
-            assert_equal(expected_html, serve(original_html).body)
-          end
-
           def test_replace_local_assets_in_reponse_body_https
             original_html = <<~HTML
               <html>


### PR DESCRIPTION
This PR just removes the skipped ID check test in the `local_assets_test.rb` file until we have the necessary ID checks in place.