### PR TITLE
Introduce the app dev logic for theme app extensions

### DIFF
--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "shopify_cli"
+require "shopify_cli/environment"
 require "securerandom"
 
 module Extension
@@ -82,7 +83,13 @@ module Extension
     end
 
     def specification_identifier
-      config[ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY]
+      key = ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY
+
+      if ShopifyCLI::Environment.run_as_subprocess?
+        get_extra_field(key)
+      else
+        config[key]
+      end
     end
 
     def registration_id?

--- a/lib/project_types/extension/loaders/project.rb
+++ b/lib/project_types/extension/loaders/project.rb
@@ -3,12 +3,13 @@
 module Extension
   module Loaders
     module Project
-      def self.load(context:, directory:, api_key:, registration_id:, api_secret:)
+      def self.load(context:, directory:, api_key:, registration_id:, api_secret:, env: {})
         env_overrides = {
           "SHOPIFY_API_KEY" => api_key,
           "SHOPIFY_API_SECRET" => api_secret,
           "EXTENSION_ID" => registration_id,
-        }.compact
+        }.compact.merge(env)
+
         env_file_present = env_file_exists?(directory)
         env = if env_file_present
           ShopifyCLI::Resources::EnvFile.read(directory, overrides: env_overrides)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -102,7 +102,7 @@ module Extension
       serve: {
         help: <<~HELP,
           Serve your extension in a local simulator for development.
-            Usage: {{command:%s extension serve}}
+            Usage: {{command:%s extension serve [ ROOT ]}}
             Options:
               {{command:-p, --port=PORT}}             Local port of the development serve.
               {{command:-T, --theme=NAME_OR_ID}}      Theme ID or name of the host theme.

--- a/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
+++ b/lib/project_types/extension/models/specification_handlers/theme_app_extension.rb
@@ -76,11 +76,12 @@ module Extension
         def serve(**options)
           @ctx = options[:context]
           root = options[:context]&.root
+          project = options[:project]
           properties = options
             .slice(:port, :theme)
             .compact
             .merge({
-              project: load_project(options),
+              project: project,
               specification_handler: self,
             })
 
@@ -88,16 +89,6 @@ module Extension
         end
 
         private
-
-        def load_project(options)
-          Extension::Loaders::Project.load(
-            context: options[:context],
-            directory: Dir.pwd,
-            api_key: options[:api_key],
-            api_secret: options[:api_secret],
-            registration_id: options[:registration_id]
-          )
-        end
 
         def validate(filename)
           dirname = File.dirname(filename)

--- a/lib/shopify_cli/identity_auth.rb
+++ b/lib/shopify_cli/identity_auth.rb
@@ -87,6 +87,7 @@ module ShopifyCLI
 
     def fetch_or_auth_partners_token
       if EnvAuthToken.partners_token_present?
+        return Environment.auth_token if Environment.run_as_subprocess?
         return EnvAuthToken.fetch_exchanged_partners_token do |env_token|
           exchange_partners_auth_token(env_token)
         end

--- a/lib/shopify_cli/project.rb
+++ b/lib/shopify_cli/project.rb
@@ -109,7 +109,7 @@ module ShopifyCLI
 
       def at(dir)
         proj_dir = directory(dir)
-        unless proj_dir
+        if !proj_dir && !ShopifyCLI::Environment.run_as_subprocess?
           raise(ShopifyCLI::Abort, Context.message("core.project.error.not_in_project"))
         end
         @at ||= Hash.new { |h, k| h[k] = new(directory: k) }

--- a/lib/shopify_cli/tasks/ensure_project_type.rb
+++ b/lib/shopify_cli/tasks/ensure_project_type.rb
@@ -4,7 +4,9 @@ module ShopifyCLI
   module Tasks
     class EnsureProjectType < ShopifyCLI::Task
       def call(ctx, project_type)
-        return true if project_type.to_sym == ShopifyCLI::Project.current_project_type
+        if project_type.to_sym == ShopifyCLI::Project.current_project_type || Environment.run_as_subprocess?
+          return true
+        end
         ctx.abort(ctx.message("core.tasks.ensure_project_type.wrong_project_type", project_type))
       end
     end

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -180,7 +180,6 @@ module ShopifyCLI
 
           ctx.puts(serving_theme_message)
           ctx.open_url!(address)
-          ctx.open_browser_url!(address)
           ctx.puts(preview_message)
         end
       end

--- a/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -96,6 +96,7 @@ module ShopifyCLI
         end
 
         def bearer_token
+          Environment.storefront_renderer_auth_token ||
           ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token) ||
             raise(KeyError, "storefront_renderer_production_exchange_token missing")
         end

--- a/lib/shopify_cli/theme/extension/dev_server.rb
+++ b/lib/shopify_cli/theme/extension/dev_server.rb
@@ -29,7 +29,7 @@ module ShopifyCLI
         attr_accessor :project, :specification_handler
 
         class << self
-          def start(ctx, root, port: 8282, theme: nil, project:, specification_handler:)
+          def start(ctx, root, port: 9292, theme: nil, project:, specification_handler:)
             instance.project = project
             instance.specification_handler = specification_handler
 

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -139,6 +139,18 @@ module Extension
       assert_equal @type, project.specification_identifier
     end
 
+    def test_extension_type_returns_the_type_identifier_from_env
+      project = ExtensionTestHelpers.fake_extension_project
+      type = "type"
+      env = { extra: { ExtensionProjectKeys::SPECIFICATION_IDENTIFIER_KEY => type } }
+
+      ShopifyCLI::Environment.stubs(:run_as_subprocess?).returns(true)
+
+      project.stubs(:env).returns(env)
+
+      assert_equal type, project.specification_identifier
+    end
+
     def test_detects_if_registration_id_is_missing_or_invalid
       invalid_registration_ids = [nil, 0, "wrong"]
 

--- a/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
+++ b/test/project_types/extension/models/specification_handlers/theme_app_extension_test.rb
@@ -166,8 +166,6 @@ module Extension
         def test_serve_calls_extension_dev_server_with_context
           project = mock
 
-          @spec.stubs(:load_project).with({ context: @context }).returns(project)
-
           ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
             @context,
             @context.root,
@@ -175,13 +173,11 @@ module Extension
             specification_handler: @spec
           )
 
-          @spec.serve(context: @context)
+          @spec.serve(context: @context, project: project)
         end
 
         def test_serve_calls_extension_dev_server_with_port
           project = mock
-
-          @spec.stubs(:load_project).with({ context: @context, port: 9192 }).returns(project)
 
           ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
             @context,
@@ -191,13 +187,11 @@ module Extension
             specification_handler: @spec
           )
 
-          @spec.serve(context: @context, port: 9192)
+          @spec.serve(context: @context, port: 9192, project: project)
         end
 
         def test_serve_calls_extension_dev_server_with_theme
           project = mock
-
-          @spec.stubs(:load_project).with({ context: @context, theme: "1234" }).returns(project)
 
           ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
             @context,
@@ -207,43 +201,18 @@ module Extension
             specification_handler: @spec
           )
 
-          @spec.serve(context: @context, theme: "1234")
+          @spec.serve(context: @context, theme: "1234", project: project)
         end
 
         def test_serve_calls_extension_dev_server_with_nil_when_no_context
-          project = mock
-
-          @spec.stubs(:load_project).with({}).returns(project)
-
           ShopifyCLI::Theme::Extension::DevServer.expects(:start).with(
             nil,
             nil,
-            project: project,
+            project: nil,
             specification_handler: @spec
           )
 
           @spec.serve
-        end
-
-        def test_load_project
-          options = {
-            context: @context,
-            api_key: "api_key_1234",
-            api_secret: "api_secret_5678",
-            registration_id: "registration_id_9ABC",
-          }
-
-          Extension::Loaders::Project
-            .expects(:load)
-            .with(
-              context: options[:context],
-              directory: Dir.pwd,
-              api_key: options[:api_key],
-              api_secret: options[:api_secret],
-              registration_id: options[:registration_id]
-            )
-
-          @spec.send(:load_project, options)
         end
 
         private

--- a/test/shopify-cli/identity_auth_test.rb
+++ b/test/shopify-cli/identity_auth_test.rb
@@ -193,6 +193,18 @@ module ShopifyCLI
       assert_equal exchanged_token, got
     end
 
+    def test_fetch_or_auth_partners_token_when_cli_is_running_as_a_subprocess
+      expected_token = "token"
+
+      IdentityAuth::EnvAuthToken.stubs(:partners_token_present?).returns(true)
+      Environment.stubs(:run_as_subprocess?).returns(true)
+      Environment.stubs(:auth_token).returns(expected_token)
+
+      actual_token = identity_auth_client.fetch_or_auth_partners_token
+
+      assert_equal(expected_token, actual_token)
+    end
+
     private
 
     def assert_expected_exchange_tokens(token_suffix:, client:)

--- a/test/shopify-cli/tasks/ensure_project_type_test.rb
+++ b/test/shopify-cli/tasks/ensure_project_type_test.rb
@@ -10,6 +10,14 @@ module ShopifyCLI
 
       def test_returns_true_if_in_proper_project_type
         ShopifyCLI::Project.expects(:current_project_type).returns(:rails)
+
+        assert EnsureProjectType.call(@context, "rails")
+      end
+
+      def test_returns_true_if_cli_is_running_as_a_subprocess
+        ShopifyCLI::Project.expects(:current_project_type).returns(nil)
+        Environment.expects(:run_as_subprocess?).returns(true)
+
         assert EnsureProjectType.call(@context, "rails")
       end
 
@@ -18,6 +26,7 @@ module ShopifyCLI
         exception = assert_raises ShopifyCLI::Abort do
           EnsureProjectType.call(@context, "rails")
         end
+
         assert_includes exception.message, @context.message(
           "core.tasks.ensure_project_type.wrong_project_type", "rails"
         )

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -384,6 +384,29 @@ module ShopifyCLI
           end
         end
 
+        def test_bearer_token_from_environment
+          Environment.stubs(:storefront_renderer_auth_token).returns("TOKEN_A")
+          ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("TOKEN_B")
+
+          assert_equal("TOKEN_A", @proxy.send(:bearer_token))
+        end
+
+        def test_bearer_token_from_db
+          Environment.stubs(:storefront_renderer_auth_token).returns(nil)
+          ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("TOKEN_B")
+
+          assert_equal("TOKEN_B", @proxy.send(:bearer_token))
+        end
+
+        def test_bearer_token_error
+          Environment.stubs(:storefront_renderer_auth_token).returns(nil)
+          ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)
+
+          error = assert_raises(KeyError) { @proxy.send(:bearer_token) }
+
+          assert_equal("storefront_renderer_production_exchange_token missing", error.message)
+        end
+
         private
 
         def request


### PR DESCRIPTION
---

**This PR is part of an ensemble**:
- https://github.com/Shopify/shopify-cli/pull/2585
- https://github.com/Shopify/cli/pull/370

---

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2540.

This PR expose as parameters to allow the `shopify extension serve` command to run as a sub-process of the CLI 3.x.

### WHAT is this pull request doing?

Besides exposing some properties, this PR introduce makes the `shopify extension serve` command to be compatible with CLI 3.x theme app extensions directory structure (that contains TOML files).

### How to test your changes?

- Setup `shopify/shopify-cli` and `shopify/cli`
  - Set your `shopify/shopify-cli` local repository with the `fix-2540` branch
  - Set your `shopify/cli` local repository with the `fix-2540` branch
  - Point your `shopify/cli` repository to your local `shopify/shopify-cli` by running: `export SHOPIFY_CLI_2_0_DIRECTORY=/Users/$USER/src/github.com/Shopify/shopify-cli`
  - Go to the `shopify/cli` local repository with the `fix-2540` branch

- Create the app with a theme app extension
  - Create an app with the CLI 3.x: `npm init @shopify/app@latest` (set a name)
  - Go to the app directory (`cd my-app`)
  - Create a theme app extension with `npm run scaffold extension`
  - Go to the theme app extension directory with `cd extensions/extension-name`
  - Save the current directory path with `pwd` (let's call it `<theme app extension directory>`)

- Try the hot reload from the CLI 3.x
  - Go to your `shopify/cli` local repository
  - Run `yarn shopify app dev --path <theme app extension directory>`
  - Notice the CLI 3.x is running the `extension serve` command

<img width="2094" alt="image" src="https://user-images.githubusercontent.com/1079279/186890528-2c24aee7-93d2-4baa-b955-87bb077640f0.png">

### Post-release steps

None.

### Pre-release steps

- Merge the https://github.com/Shopify/shopify-cli/pull/2585 PR
- Release the CLI 2.x
- Update the https://github.com/Shopify/cli/pull/370 PR to point to the CLI 2.x
- Merge https://github.com/Shopify/cli/pull/370
- Release the CLI 3.x

### Update checklist

- [x] ([N/A](https://github.com/Shopify/shopify-cli/pull/2577)) I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).

