### PR TITLE
Packaging for release v2.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.23.1 - 2022-08-29
+
 ### Fixed
 * [#2527](https://github.com/Shopify/shopify-cli/pull/2527): **Breaking** Update theme-check to 1.11.0 (dropped support for ruby 2.6)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.23.0)
+    shopify-cli (2.23.1)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.11.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.23.0"
+  VERSION = "2.23.1"
 end


### PR DESCRIPTION
### Fixed
* [#2527](https://github.com/Shopify/shopify-cli/pull/2527): **Breaking** Update theme-check to 1.11.0 (dropped support for ruby 2.6)
