### PR TITLE
Update CI Badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shopify CLI 2.0
   
-  <a href=""><img src="https://github.com/shopify/shopify-cli/workflows/CI/badge.svg" alt="Shopify"></a>
+  <a href="https://github.com/Shopify/shopify-cli/actions/workflows/shopify.yml"><img src="https://github.com/shopify/shopify-cli/actions/workflows/shopify.yml/badge.svg" alt="Shopify"></a>
   <img src="https://img.shields.io/github/v/release/shopify/shopify-cli?include_prereleases&style=flat-square" alt="Latest Version">
   <img src="https://img.shields.io/github/forks/shopify/shopify-cli?style=flat-square" alt="GitHub forks">
   <img src="https://img.shields.io/github/stars/shopify/shopify-cli?style=flat-square" alt="GitHub stars">


### PR DESCRIPTION
### WHY are these changes introduced?

When clicking on the "CI | passing" badge in the README file, the user sees a _Not found_ page, because the `href` attribute is empty.
Moreover, the badge is based on the _CI_ workflow, which hasn't run since 12 months.

### WHAT is this pull request doing?

- Sets the correct `href` attribute so that the user sees the GitHub Actions Workflows page.
- Displays the state of the _Shopify_ workflow.

### How to test your changes?

1. Open README
2. Verify that badge says "Shopify | passing"
3. Click on the badge – do you see the correct GitHub Actions Workflows page?

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing) → not necessary
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).