### PR TITLE
Skip `IntegrationTest#test_uploads_files_on_boot` to avoid inconsistent CI

### DIFF
--- a/test/shopify-cli/theme/dev_server/integration_test.rb
+++ b/test/shopify-cli/theme/dev_server/integration_test.rb
@@ -62,6 +62,7 @@ module ShopifyCLI
         end
 
         def test_uploads_files_on_boot
+          skip("Causing flaky behavior in CI, need to revisit")
           start_server_and_wait_sync_files
 
           # Should upload all theme files except the ignored files


### PR DESCRIPTION
I've notice the `IntegrationTest#test_uploads_files_on_boot` is inconsistently failing as well.

This `skip` will also be handled by https://github.com/Shopify/shopify-cli/issues/2473.