### PR TITLE
Handle `SIGTERM` signal when users kill the CLI Ruby process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2572](https://github.com/Shopify/shopify-cli/pull/2572): **Breaking** Update theme-check to 1.11.0 (dropped support for ruby 2.6)
 
+### Added
+* [#2600](https://github.com/Shopify/shopify-cli/pull/2600): Add support to the `SIGTERM` signal
+
 ## Version 2.23.0 - 2022-08-22
 
 ### Fixed

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -138,6 +138,7 @@ module Theme
           viewing_theme: "Viewing theme…",
           syncing_theme: "Syncing theme #%s on %s",
           open_fail: "Couldn't open the theme",
+          stop_signal: "Stop signal: \"%s\"",
           stopping: "Stopping…",
           auth: {
             error_message: <<~ERROR_MESSAGE,

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -71,7 +71,8 @@ module ShopifyCLI
         sync_theme
 
         # Handle process stop
-        trap("INT") { stop }
+        trap("INT") { stop("SIGINT") }
+        trap("TERM") { stop("SIGTERM") }
 
         # Setup the middleware stack. Mimics Rack::Builder / config.ru, but in reverse order
         @app = middleware_stack
@@ -90,7 +91,9 @@ module ShopifyCLI
         ctx.abort(binding_error_message)
       end
 
-      def stop
+      def stop(signal = nil)
+        ctx.debug(stop_signal(signal)) unless signal.nil?
+
         @stopped = true
 
         ctx.puts(stopping_message)
@@ -254,6 +257,10 @@ module ShopifyCLI
 
       def stopping_message
         ctx.message("theme.serve.stopping")
+      end
+
+      def stop_signal(signal)
+        ctx.message("theme.serve.stop_signal", signal)
       end
 
       def not_found_error_message


### PR DESCRIPTION
### WHY are these changes introduced?

The CLI 3.x stops Ruby commands by relying on the `SIGTERM` signal, so the development server needs to handle it.

### WHAT is this pull request doing?

This PR introduces an extra `trap` call to handle `SIGTERM` signals.

### How to test your changes?

- `SIGINT` scenario
  - Run `DEBUG=1 shopify-dev theme serve`
  - Stops the process with <kbd>Ctrl</kbd> + <kbd>C</kbd>
  - Notice the `DEBUG Stop signal: "SIGINT"` appears

- `SIGTERM` scenario
  - Run `DEBUG=1 shopify-dev theme serve`
  - Stops the process with `pgrep ruby | xargs kill`
  - Notice the `DEBUG Stop signal: "SIGTERM"` appears


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] (N/A) I've included any post-release steps in the section above (if needed).