### PR TITLE
Fix theme app extension hot reload to work with added/deleted assets

### DIFF
--- a/lib/shopify_cli/theme/extension/dev_server.rb
+++ b/lib/shopify_cli/theme/extension/dev_server.rb
@@ -127,7 +127,7 @@ module ShopifyCLI
         # Hooks
 
         def broadcast_hooks
-          file_handler = Hooks::FileChangeHook.new(ctx, extension: extension)
+          file_handler = Hooks::FileChangeHook.new(ctx, extension: extension, syncer: syncer)
           [file_handler]
         end
 

--- a/lib/shopify_cli/theme/extension/dev_server/proxy_param_builder.rb
+++ b/lib/shopify_cli/theme/extension/dev_server/proxy_param_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cgi"
+require "shopify_cli/theme/dev_server"
 
 module ShopifyCLI
   module Theme
@@ -55,7 +56,7 @@ module ShopifyCLI
           end
 
           def syncer_templates
-            @syncer&.pending_updates || []
+            @syncer&.pending_files || []
           end
 
           def cookie_files

--- a/lib/shopify_cli/theme/extension/dev_server/watcher.rb
+++ b/lib/shopify_cli/theme/extension/dev_server/watcher.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
+
 require "shopify_cli/file_system_listener"
+require "shopify_cli/theme/dev_server"
 require "forwardable"
 
 module ShopifyCLI
@@ -29,16 +31,14 @@ module ShopifyCLI
             @listener.stop
           end
 
-          def notify_updates(modified, added, _removed)
-            @syncer.enqueue_files(filter_extension_files(modified + added))
+          def notify_updates(modified, added, removed)
+            @syncer.enqueue_updates(files(modified).select { |file| @extension.extension_file?(file) })
+            @syncer.enqueue_creates(files(added).select { |file| @extension.extension_file?(file) })
+            @syncer.enqueue_deletes(files(removed))
           end
 
-          private
-
-          def filter_extension_files(files)
-            files
-              .select { |f| @extension.extension_file?(f) }
-              .map { |f| @extension[f] }
+          def files(paths)
+            paths.map { |file| @extension[file] }
           end
         end
       end

--- a/lib/shopify_cli/theme/extension/syncer.rb
+++ b/lib/shopify_cli/theme/extension/syncer.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
+
 require_relative "syncer/extension_serve_job"
+require_relative "syncer/operation"
+
 require "shopify_cli/thread_pool"
 
 module ShopifyCLI
   module Theme
     module Extension
       class Syncer
-        attr_accessor :pending_updates, :latest_sync
+        attr_accessor :pending_operations, :latest_sync
 
         def initialize(ctx, extension:, project:, specification_handler:)
           @ctx = ctx
@@ -15,15 +18,24 @@ module ShopifyCLI
           @specification_handler = specification_handler
 
           @pool = ThreadPool.new(pool_size: 1)
-          @pending_updates = extension.extension_files
-          @update_mutex = Mutex.new
+          @pending_operations = extension.extension_files.map { |file| Operation.new(file, :update) }
+          @pending_operations_mutex = Mutex.new
           @latest_sync = Time.now - ExtensionServeJob::PUSH_INTERVAL
         end
 
-        def enqueue_files(files)
-          @update_mutex.synchronize do
-            files.each { |f| @pending_updates << f unless @pending_updates.include?(f) }
-          end
+        def enqueue_creates(files)
+          operations = files.map { |file| Operation.new(file, :create) }
+          enqueue_operations(operations)
+        end
+
+        def enqueue_updates(files)
+          operations = files.map { |file| Operation.new(file, :update) }
+          enqueue_operations(operations)
+        end
+
+        def enqueue_deletes(files)
+          operations = files.map { |file| Operation.new(file, :delete) }
+          enqueue_operations(operations)
         end
 
         def start
@@ -34,7 +46,25 @@ module ShopifyCLI
           @pool.shutdown
         end
 
+        def pending_files
+          pending_operations.map(&:file)
+        end
+
+        def any_operation?
+          pending_operations.any?
+        end
+
+        def any_blocking_operation?
+          pending_operations.any? { |operation| operation.delete? || operation.create? }
+        end
+
         private
+
+        def enqueue_operations(operations)
+          @pending_operations_mutex.synchronize do
+            operations.each { |f| @pending_operations << f unless @pending_operations.include?(f) }
+          end
+        end
 
         def job
           ExtensionServeJob.new(

--- a/lib/shopify_cli/theme/extension/syncer/operation.rb
+++ b/lib/shopify_cli/theme/extension/syncer/operation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class Syncer
+        class Operation < Struct.new(:file, :kind)
+          def delete?
+            kind == :delete
+          end
+
+          def create?
+            kind == :create
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/extension/dev_server/proxy_param_builder_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/proxy_param_builder_test.rb
@@ -11,7 +11,7 @@ module ShopifyCLI
           def setup
             super
             @param_builder = ProxyParamBuilder.new
-            @syncer = stub(pending_updates: [])
+            @syncer = stub(pending_files: [])
           end
 
           def test_empty_build
@@ -22,7 +22,7 @@ module ShopifyCLI
             @param_builder
               .with_syncer(@syncer)
 
-            @syncer.expects(:pending_updates).returns([
+            @syncer.expects(:pending_files).returns([
               extension["blocks/block.liquid"],
               extension["snippets/snippet.liquid"],
             ])

--- a/test/shopify-cli/theme/extension/dev_server/watcher_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server/watcher_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/extension/dev_server/watcher"
+require "shopify_cli/theme/extension/app_extension"
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class DevServer
+        class WatcherTest < Minitest::Test
+          def setup
+            super
+            @watcher = Watcher.new(ctx, extension: extension, syncer: syncer, poll: false)
+          end
+
+          def test_notify_updates
+            block1_file = extension["blocks/block1.liquid"]
+
+            modified = ["blocks/block1.liquid", ".env"]
+            added = ["blocks/block1.liquid", ".config.json"]
+            removed = ["blocks/block1.liquid"]
+
+            syncer.expects(:enqueue_updates).with([block1_file])
+            syncer.expects(:enqueue_creates).with([block1_file])
+            syncer.expects(:enqueue_deletes).with([block1_file])
+
+            @watcher.notify_updates(modified, added, removed)
+          end
+
+          private
+
+          def root
+            @root ||= ShopifyCLI::ROOT + "/test/fixtures/extension"
+          end
+
+          def ctx
+            @ctx ||= TestHelpers::FakeContext.new(root: root)
+          end
+
+          def extension
+            @extension ||= AppExtension.new(ctx, root: root)
+          end
+
+          def syncer
+            @syncer ||= stub(
+              "Syncer",
+              enqueue_creates: nil,
+              enqueue_updates: nil,
+              enqueue_deletes: nil,
+              any_blocking_operation?: false,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/extension/syncer/operation_test.rb
+++ b/test/shopify-cli/theme/extension/syncer/operation_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "shopify_cli/theme/extension/syncer/operation"
+
+module ShopifyCLI
+  module Theme
+    module Extension
+      class Syncer
+        class OperationTest < Minitest::Test
+          def test_delete?
+            operation1 = Operation.new(nil, :delete)
+            operation2 = Operation.new(nil, :something)
+
+            assert(operation1.delete?)
+            refute(operation2.delete?)
+          end
+
+          def test_create?
+            operation1 = Operation.new(nil, :create)
+            operation2 = Operation.new(nil, :something)
+
+            assert(operation1.create?)
+            refute(operation2.create?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/shopify-cli/theme/extension/syncer_test.rb
+++ b/test/shopify-cli/theme/extension/syncer_test.rb
@@ -49,7 +49,7 @@ module ShopifyCLI
 
           @syncer.start
           time_freeze do
-            @syncer.enqueue_files(files)
+            @syncer.enqueue_updates(files)
             @syncer.shutdown
           end
         end
@@ -79,7 +79,7 @@ module ShopifyCLI
             .with(files[2]).once
           @syncer.start
           time_freeze do
-            @syncer.enqueue_files(files)
+            @syncer.enqueue_updates(files)
             @syncer.shutdown
           end
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2586.

Now, when a file gets created or deleted, the CLI waits for the upload of the theme app extension and refreshes the browser. In both scenarios, we can't patch theme extension rendering at SFR level, as they don't exist remotely.

### WHAT is this pull request doing?

This PR introduces blocking operations in the `FileChangeHook` and in the `Syncer`. In the `FileChangeHook` side, blocking operations hold the broadcast events until the extension gets uploaded. In the `Syncer` side, blocking operations are not throttled by the  `ExtensionServeJob`, as we need to upload the extension immediately to refresh the browser. 

### How to test your changes?

- Run `shopify-dev extension serve`
- Remove a file
- Notice the browser is refreshed
- Add a file
- Notice the browser is refreshed

![demo](https://user-images.githubusercontent.com/1079279/188942971-5e50f35a-26d8-41f3-aa0e-1db4677caa2f.gif)

### Post-release steps

None.

### Update checklist

- [x] ([N/A](https://github.com/Shopify/shopify-cli/pull/2577)) I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).