### PR TITLE
Fix proxy to redirect to host and port set by cli

### DIFF
--- a/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -65,7 +65,7 @@ module ShopifyCLI
             )
           end
 
-          headers = get_response_headers(response)
+          headers = get_response_headers(response, env)
 
           unless headers["x-storefront-renderer-rendered"]
             @core_endpoints << env["PATH_INFO"]
@@ -170,7 +170,7 @@ module ShopifyCLI
           @secure_session_id
         end
 
-        def get_response_headers(response)
+        def get_response_headers(response, env)
           response_headers = normalize_headers(
             response.respond_to?(:headers) ? response.headers : response.to_hash
           )
@@ -180,7 +180,7 @@ module ShopifyCLI
           response_headers.reject! { |k| HOP_BY_HOP_HEADERS.include?(k.downcase) }
 
           if response_headers["location"]&.include?("myshopify.com")
-            response_headers["location"].gsub!(%r{(https://#{shop})}, "http://127.0.0.1:9292")
+            response_headers["location"].gsub!(%r{(https://#{shop})}, "http://#{host(env)}")
           end
 
           new_session_id = extract_secure_session_id_from_response_headers(response_headers)

--- a/test/shopify-cli/theme/dev_server/proxy_test.rb
+++ b/test/shopify-cli/theme/dev_server/proxy_test.rb
@@ -171,11 +171,12 @@ module ShopifyCLI
             .to_return(status: 302, headers: {
               "Location" => "https://dev-theme-server-store.myshopify.com/password",
             })
+          @proxy.stubs(:host).returns("127.0.0.1:8282")
 
           stub_session_id_request
           response = request.get("/")
 
-          assert_equal("http://127.0.0.1:9292/password", response.headers["Location"])
+          assert_equal("http://127.0.0.1:8282/password", response.headers["Location"])
         end
 
         def test_non_storefront_redirect_headers_are_not_rewritten


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2606

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Use the host and port set by the cli to replace URLs in the proxy. Before it defaulted to `127.0.0.1:9292` but this isn't correct for extension serve

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
Testing steps assume you have a theme app extension (TAE) created

- Create a new dev store
- Run `extension serve` in your TAE
- In your browser go to `http://127.0.0.1:8282`
- Confirm you're redirected to the store password page
- Input your password and confirm you can get into the store
<!--
  Please, provide steps for the reviewer to test your changes locally.
-->



https://user-images.githubusercontent.com/18431672/189174595-2a0d5dc2-ee7f-4119-a292-9869242b1058.mp4



