### PR TITLE
Don't report to monorail when run as subprocess

### DIFF
--- a/lib/shopify_cli/environment.rb
+++ b/lib/shopify_cli/environment.rb
@@ -159,7 +159,7 @@ module ShopifyCLI
       env_variable_truthy?(
         Constants::EnvironmentVariables::MONORAIL_REAL_EVENTS,
         env_variables: env_variables
-      )
+      ) && !run_as_subprocess?(env_variables: env_variables)
     end
 
     def self.auth_token(env_variables: ENV)

--- a/test/shopify-cli/environment_test.rb
+++ b/test/shopify-cli/environment_test.rb
@@ -306,6 +306,37 @@ module ShopifyCLI
       refute got
     end
 
+    def test_use_monorail_is_true
+      env_variables = {
+        Constants::EnvironmentVariables::MONORAIL_REAL_EVENTS.to_s => "1",
+      }
+
+      got = Environment.send_monorail_events?(env_variables: env_variables)
+
+      assert got
+    end
+
+    def test_using_monorail_is_false
+      env_variables = {
+        Constants::EnvironmentVariables::MONORAIL_REAL_EVENTS.to_s => "0",
+      }
+
+      got = Environment.send_monorail_events?(env_variables: env_variables)
+
+      refute got
+    end
+
+    def test_run_as_subprocess_blocks_monorail
+      env_variables = {
+        Constants::EnvironmentVariables::MONORAIL_REAL_EVENTS.to_s => "1",
+        Constants::EnvironmentVariables::RUN_AS_SUBPROCESS.to_s => "1",
+      }
+
+      got = Environment.send_monorail_events?(env_variables: env_variables)
+
+      refute got
+    end
+
     def test_env_variable_truthy
       Environment::TRUTHY_ENV_VARIABLE_VALUES.each do |value|
         assert Environment.env_variable_truthy?("TEST", env_variables: { "TEST" => value })


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/375 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
We already send analytics from 3.0, no need to send from 2.0 as well.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Disables monorail analytics in 2.0 when run as a subprocess of 3.0.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
Not sure, would love some ideas!


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
N/A

### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing) **N/A**
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).