### PR TITLE
Reject files not in `blocks/` or `snippets/` in proxy param builder

### DIFF
--- a/lib/shopify_cli/theme/extension/dev_server/proxy_param_builder.rb
+++ b/lib/shopify_cli/theme/extension/dev_server/proxy_param_builder.rb
@@ -15,6 +15,7 @@ module ShopifyCLI
             (request_templates + syncer_templates)
               .select(&:liquid?)
               .uniq(&:relative_path)
+              .reject { |file| proxy_cannot_render?(file) }
               .map { |file| as_param(file) }
               .to_h
           end
@@ -40,6 +41,10 @@ module ShopifyCLI
           end
 
           private
+
+          def proxy_cannot_render?(file)
+            !(file&.relative_path&.include?("blocks/") || file&.relative_path&.include?("snippets/"))
+          end
 
           def as_param(file)
             if file&.relative_path&.include?("blocks/")


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2616

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Fixes a bug where proxy param builder tries to include files outside of TAE directories to hot reload. It isn't possible to hot reload files out of these directories for TAE because the directory structure gives us context about how to render the liquid file via SFR API.

### How to test your changes?

Repeat the steps in [this bug report](https://github.com/Shopify/shopify-cli/issues/2616), note that it no longer causes an internal server error

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps
None

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Update checklist

~~I've added a CHANGELOG entry for this PR (if the change is public-facing)~~ Not a public facing change since it's around TAE
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).