### PR TITLE
Show store when the CLI prompts users to select a theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#2636](https://github.com/Shopify/shopify-cli/pull/2636): Show store when the CLI prompts users to select a theme
+
 ## Version 2.25.0 - 2022-09-14
 
 ### Added

--- a/lib/project_types/theme/commands/common/shop_helper.rb
+++ b/lib/project_types/theme/commands/common/shop_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Theme
+  class Command
+    module Common
+      module ShopHelper
+        def shop
+          ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/theme/commands/delete.rb
+++ b/lib/project_types/theme/commands/delete.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 require "shopify_cli/theme/theme"
 require "shopify_cli/theme/development_theme"
+require "project_types/theme/commands/common/shop_helper"
 
 module Theme
   class Command
     class Delete < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
+
       recommend_default_ruby_range
 
       options do |parser, flags|
@@ -22,7 +25,7 @@ module Theme
           form = Forms::Select.ask(
             @ctx,
             [],
-            title: @ctx.message("theme.delete.select"),
+            title: @ctx.message("theme.delete.select", shop),
             exclude_roles: ["live"],
             include_foreign_developments: options.flags[:show_all],
             cmd: :delete

--- a/lib/project_types/theme/commands/list.rb
+++ b/lib/project_types/theme/commands/list.rb
@@ -2,10 +2,13 @@
 
 require "shopify_cli/theme/theme"
 require "project_types/theme/presenters/themes_presenter"
+require "project_types/theme/commands/common/shop_helper"
 
 module Theme
   class Command
     class List < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
+
       recommend_default_ruby_range
 
       def call(_args, _name)
@@ -24,10 +27,6 @@ module Theme
 
       def themes_presenter
         Theme::Presenters::ThemesPresenter.new(@ctx, nil)
-      end
-
-      def shop
-        ShopifyCLI::AdminAPI.get_shop_or_abort(@ctx)
       end
     end
   end

--- a/lib/project_types/theme/commands/open.rb
+++ b/lib/project_types/theme/commands/open.rb
@@ -2,10 +2,13 @@
 
 require "shopify_cli/theme/theme"
 require "shopify_cli/theme/development_theme"
+require "project_types/theme/commands/common/shop_helper"
 
 module Theme
   class Command
     class Open < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
+
       recommend_default_ruby_range
 
       options do |parser, flags|
@@ -60,7 +63,7 @@ module Theme
         form = Forms::Select.ask(
           @ctx,
           [],
-          title: @ctx.message("theme.open.select"),
+          title: @ctx.message("theme.open.select", shop),
           root: nil
         )
         form&.theme

--- a/lib/project_types/theme/commands/publish.rb
+++ b/lib/project_types/theme/commands/publish.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 require "shopify_cli/theme/theme"
+require "project_types/theme/commands/common/shop_helper"
 
 module Theme
   class Command
     class Publish < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
+
       recommend_default_ruby_range
 
       options do |parser, flags|
@@ -17,7 +20,7 @@ module Theme
           form = Forms::Select.ask(
             @ctx,
             [],
-            title: @ctx.message("theme.publish.select"),
+            title: @ctx.message("theme.publish.select", shop),
             exclude_roles: ["live", "development", "demo"],
             cmd: :publish
           )

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -5,12 +5,14 @@ require "shopify_cli/theme/ignore_filter"
 require "shopify_cli/theme/include_filter"
 require "shopify_cli/theme/syncer"
 require "project_types/theme/commands/common/root_helper"
+require "project_types/theme/commands/common/shop_helper"
 require "project_types/theme/conversions/include_glob"
 require "project_types/theme/conversions/ignore_glob"
 
 module Theme
   class Command
     class Pull < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
       include Common::RootHelper
 
       recommend_default_ruby_range
@@ -97,7 +99,7 @@ module Theme
         form = Forms::Select.ask(
           @ctx,
           [],
-          title: @ctx.message("theme.pull.select"),
+          title: @ctx.message("theme.pull.select", shop),
           root: root,
         )
         form&.theme

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -5,12 +5,14 @@ require "shopify_cli/theme/ignore_filter"
 require "shopify_cli/theme/include_filter"
 require "shopify_cli/theme/syncer"
 require "project_types/theme/commands/common/root_helper"
+require "project_types/theme/commands/common/shop_helper"
 require "project_types/theme/conversions/include_glob"
 require "project_types/theme/conversions/ignore_glob"
 
 module Theme
   class Command
     class Push < ShopifyCLI::Command::SubCommand
+      include Common::ShopHelper
       include Common::RootHelper
 
       recommend_default_ruby_range
@@ -134,7 +136,7 @@ module Theme
         form = Forms::Select.ask(
           @ctx,
           [],
-          title: @ctx.message("theme.push.select"),
+          title: @ctx.message("theme.push.select", shop),
           root: root,
         )
         form&.theme

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -47,7 +47,7 @@ module Theme
           not_found: "Theme #%s does not exist",
           no_themes_error: "You don't have any theme to be published.",
           no_themes_resolution: "Try to create an unpublished theme with {{command:theme push -u -t <theme_name>}}.",
-          select: "Select theme to push to",
+          select: "Select theme to push to %s",
           confirm: "Are you sure you want to make %s the new live theme on %s?",
         },
         forms: {
@@ -87,7 +87,7 @@ module Theme
             pushing: "Pushing theme files to %s (#%s) on %s",
           },
           push: "Pushing theme files to Shopify",
-          select: "Select theme to push to",
+          select: "Select theme to push to %s",
           live: "Are you sure you want to push to your live theme?",
           theme: "\n  Theme: {{blue:%s #%s}} {{green:[live]}}",
           deprecated_themeid: <<~WARN,
@@ -285,7 +285,7 @@ module Theme
 
             Run without options to select the theme to delete from a list.
           HELP
-          select: "Select theme to delete",
+          select: "Select theme to delete from %s",
           done: "%s theme(s) deleted",
           no_themes_error: "You don't have any theme to be deleted.",
           no_themes_resolution: "Try to create an unpublished theme with {{command:theme push -u -t <theme_name>}}.",
@@ -330,7 +330,7 @@ module Theme
 
             Run without options to select theme from a list.
           HELP
-          select: "Select a theme to pull from",
+          select: "Select a theme to pull from %s",
           pulling: "Pulling theme files from %s (#%s) on %s",
           done: "Theme pulled successfully.",
           done_with_errors: "{{warning:Your theme was pulled with errors.}}",
@@ -340,7 +340,7 @@ module Theme
           theme_not_found: "Theme \"%s\" doesn't exist",
         },
         open: {
-          select: "Select a theme to open",
+          select: "Select a theme to open in %s",
           theme_not_found: "Theme \"%s\" doesn't exist",
           details: <<~DETAILS,
             {{*}} {{bold:%s}}

--- a/test/project_types/theme/commands/common/shop_helper_test.rb
+++ b/test/project_types/theme/commands/common/shop_helper_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "project_types/theme/test_helper"
+require "project_types/theme/commands/common/shop_helper"
+
+module Theme
+  class Command
+    module Common
+      class RootHelperTest < MiniTest::Test
+        include Common::ShopHelper
+
+        def setup
+          super
+          @ctx = TestHelpers::FakeContext.new
+        end
+
+        def test_shop_when_shop_is_present
+          ShopifyCLI::DB.stubs(:exists?).returns(true)
+          ShopifyCLI::DB.stubs(:get).with(:shop).returns("store.myshopify.com")
+
+          assert_equal("store.myshopify.com", shop)
+        end
+
+        def test_shop_when_shop_is_not_present
+          assert_raises(ShopifyCLI::Abort) { shop }
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/theme/commands/delete_test.rb
+++ b/test/project_types/theme/commands/delete_test.rb
@@ -9,6 +9,9 @@ module Theme
       def setup
         super
 
+        ShopifyCLI::DB.stubs(:exists?).returns(true)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns("test.myshopify.com")
+
         @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Delete.new(@ctx)
 
@@ -79,7 +82,8 @@ module Theme
       end
 
       def test_delete_asks_to_select
-        CLI::UI::Prompt.expects(:ask).returns(@theme)
+        CLI::UI::Prompt.expects(:ask).with("Select theme to delete from test.myshopify.com",
+          allow_empty: false).returns(@theme)
         CLI::UI::Prompt.expects(:confirm).returns(true)
 
         @theme.expects(:delete)

--- a/test/project_types/theme/commands/open_test.rb
+++ b/test/project_types/theme/commands/open_test.rb
@@ -7,11 +7,16 @@ module Theme
     class OpenTest < MiniTest::Test
       def setup
         super
+
+        ShopifyCLI::DB.stubs(:exists?).returns(true)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns("test.myshopify.com")
+
         @command = Theme::Command::Open.new(ctx)
       end
 
       def test_open_without_flags
-        CLI::UI::Prompt.expects(:ask).returns(theme)
+        CLI::UI::Prompt.expects(:ask).with("Select a theme to open in test.myshopify.com",
+          allow_empty: false).returns(theme)
 
         ctx.expects(:open_browser_url!).with("https://test.myshopify.io/preview")
 

--- a/test/project_types/theme/commands/publish_test.rb
+++ b/test/project_types/theme/commands/publish_test.rb
@@ -9,6 +9,9 @@ module Theme
       def setup
         super
 
+        ShopifyCLI::DB.stubs(:exists?).returns(true)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns("test.myshopify.com")
+
         @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Publish.new(@ctx)
 
@@ -61,7 +64,8 @@ module Theme
       end
 
       def test_publish_asks_to_select
-        CLI::UI::Prompt.expects(:ask).returns(@theme)
+        CLI::UI::Prompt.expects(:ask).with("Select theme to push to test.myshopify.com",
+          allow_empty: false).returns(@theme)
         CLI::UI::Prompt.expects(:confirm).returns(true)
 
         @theme.expects(:publish)

--- a/test/project_types/theme/commands/pull_test.rb
+++ b/test/project_types/theme/commands/pull_test.rb
@@ -9,6 +9,9 @@ module Theme
       def setup
         super
 
+        ShopifyCLI::DB.stubs(:exists?).returns(true)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns("test.myshopify.com")
+
         @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Pull.new(@ctx)
 
@@ -254,7 +257,8 @@ module Theme
       end
 
       def test_pull_with_asset_errors_displays_warning
-        CLI::UI::Prompt.expects(:ask).returns(@theme)
+        CLI::UI::Prompt.expects(:ask).with("Select a theme to pull from test.myshopify.com",
+          allow_empty: false).returns(@theme)
         @ctx.expects(:warn).with(@ctx.message("theme.pull.done_with_errors")).once
         @ctx.expects(:done).never
 

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -9,6 +9,9 @@ module Theme
       def setup
         super
 
+        ShopifyCLI::DB.stubs(:exists?).returns(true)
+        ShopifyCLI::DB.stubs(:get).with(:shop).returns("test.myshopify.com")
+
         @ctx = ShopifyCLI::Context.new
         @command = Theme::Command::Push.new(@ctx)
 
@@ -473,7 +476,8 @@ module Theme
       end
 
       def test_push_asks_to_select
-        CLI::UI::Prompt.expects(:ask).returns(@theme)
+        CLI::UI::Prompt.expects(:ask).with("Select theme to push to test.myshopify.com",
+          allow_empty: false).returns(@theme)
         @ctx.expects(:done)
 
         @syncer.expects(:upload_theme!).with(delete: true)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2635

### WHAT is this pull request doing?

This PR introduces the store name on all theme commands. So, users (in the CLI 3.x) don't need to frequently run `shopify theme info`.

### How to test your changes?

- Run `shopify-dev theme delete` (and notice the store name appears in the theme selection)
- Run `shopify-dev theme list` (and notice the store name appears in the theme selection)
- Run `shopify-dev theme open` (and notice the store name appears in the theme selection)
- Run `shopify-dev theme publish` (and notice the store name appears in the theme selection)
- Run `shopify-dev theme pull` (and notice the store name appears in the theme selection)
- Run `shopify-dev theme push` (and notice the store name appears in the theme selection)


<img width="70%" alt="Screenshot 2022-09-23 at 10 58 08" src="https://user-images.githubusercontent.com/1079279/191930653-dfd91643-91fa-4720-8942-a0beb13e53b8.png">
<details>

<summary><b>Click here to check the other screenshots</b></summary>

<img width="40%" alt="Screenshot 2022-09-23 at 10 57 17" src="https://user-images.githubusercontent.com/1079279/191930891-0543f7bb-11d2-482d-be13-f4324890a193.png">
<img width="40%" alt="Screenshot 2022-09-23 at 10 57 28" src="https://user-images.githubusercontent.com/1079279/191930898-d17a3c39-8894-4596-b0e9-268223f1cd80.png">
<img width="40%" alt="Screenshot 2022-09-23 at 10 57 37" src="https://user-images.githubusercontent.com/1079279/191930903-92fba3c4-ad4c-40d5-a1b8-be7e610a3b4f.png">
<img width="40%" alt="Screenshot 2022-09-23 at 10 57 49" src="https://user-images.githubusercontent.com/1079279/191930905-830ef9fe-9fcb-4923-bb22-f0bce71887ad.png">
<img width="40%" alt="Screenshot 2022-09-23 at 10 58 00" src="https://user-images.githubusercontent.com/1079279/191930906-df90e93c-a64c-48b2-bc73-afa8bf39a72d.png">


</details>

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).