### PR TITLE
Rescue Errno::EIO in read_char

### DIFF
--- a/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
+++ b/vendor/deps/cli-ui/lib/cli/ui/prompt/interactive_options.rb
@@ -339,7 +339,7 @@ module CLI
           else
             $stdin.getc
           end
-        rescue IOError
+        rescue Errno::EIO, Errno::EPIPE, IOError
           "\e"
         end
 


### PR DESCRIPTION
### WHY are these changes introduced?

While working [on introducing `ink`](https://github.com/Shopify/cli/pull/512) in CLI3 we (me and @Arkham) noticed that using `Ctrl+C` was raising the `Errno::EIO` exception inside `read_char`. We think introducing `ink` perhaps messed up with the order of operations when exiting all the processes and left the CLI2 process in a bad state where it could read from a closed pipe.

### WHAT is this pull request doing?

This PR introduces 2 more errors to rescue from. When these errors occur we should ignore them and simply terminate without raising exception.

### How to test your changes?

You can [pull the `ink` work branch](https://github.com/Shopify/cli/pull/512) and run `dev fixture dev`. Closing with `Ctrl+C` after the theme-extension output should show a stracktrace with the `Errno::EIO` error.
We tested this fix by editing manually the vendored dependency in the CLI3 cache folder. 

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).