### PR TITLE
Deprecate CLI2

### DIFF
--- a/lib/shopify_cli/packager.rb
+++ b/lib/shopify_cli/packager.rb
@@ -69,14 +69,13 @@ module ShopifyCLI
     def build_homebrew
       root_dir = File.join(PACKAGING_DIR, "homebrew")
 
-      build_path = File.join(BUILDS_DIR, "shopify-cli.rb")
-      build_path_2 = File.join(BUILDS_DIR, "shopify-cli@2.rb")
-      puts "\nBuilding Homebrew packages"
+      build_path = File.join(BUILDS_DIR, "shopify-cli@2.rb")
+      puts "\nBuilding Homebrew package"
 
-      puts "Generating formulae…"
+      puts "Generating formula…"
       File.delete(build_path) if File.exist?(build_path)
 
-      spec_contents = File.read(File.join(root_dir, "shopify-cli.base.rb"))
+      spec_contents = File.read(File.join(root_dir, "shopify-cli@2.base.rb"))
       spec_contents = spec_contents.gsub("SHOPIFY_CLI_VERSION", ShopifyCLI::VERSION)
 
       puts "Grabbing sha256 checksum from Rubygems.org"
@@ -90,15 +89,7 @@ module ShopifyCLI
       spec_contents = spec_contents.gsub("SHOPIFY_CLI_GEM_CHECKSUM", gem_checksum)
 
       puts "Writing generated formula\n  To: #{build_path}\n\n"
-      File.write(build_path, spec_contents.gsub("SHOPIFY_CLI_BINSTUB_SUFFIX", ""))
-
-      puts "Writing generated formula\n  To: #{build_path_2}\n\n"
-      File.write(
-        build_path_2,
-        spec_contents
-          .sub("class ShopifyCli < Formula", "class ShopifyCliAT2 < Formula")
-          .sub("SHOPIFY_CLI_BINSTUB_SUFFIX", "2")
-      )
+      File.write(build_path, spec_contents)
     end
 
     private

--- a/packaging/homebrew/shopify-cli@2.base.rb
+++ b/packaging/homebrew/shopify-cli@2.base.rb
@@ -10,7 +10,7 @@
 require "formula"
 require "fileutils"
 
-class ShopifyCli < Formula
+class ShopifyCliAT2 < Formula
   module RubyBin
     def ruby_bin
       Formula["ruby"].opt_bin
@@ -95,7 +95,7 @@ class ShopifyCli < Formula
     ruby_libs = Dir.glob("#{prefix}/gems/*/lib")
     exe = "shopify"
     file = Pathname.new("#{brew_gem_prefix}/bin/#{exe}")
-    (bin + "#{file.basename}SHOPIFY_CLI_BINSTUB_SUFFIX").open("w") do |f|
+    (bin + "#{file.basename}2").open("w") do |f|
       f << <<~RUBY
         #!#{ruby_bin}/ruby -rjson --disable-gems
         ENV['ORIGINAL_ENV']=ENV.to_h.to_json


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Making it easier to install CLI3 than CLI2!

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Instead of generating `shopify-cli` and `shopify-cli@2` formulas, just generate the `@2` formula. The `shopify-cli` formula will come from CLI3 moving forward.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Clear out `packaging/builds` then run `rake package`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

Merge [this PR](https://github.com/Shopify/cli/pull/556) so CLI3 can start pushing the `shopify-cli` formula.

### Update checklist

- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).