### PR TITLE
Fix issue that prevents the execution of `shopify extension serve` in some scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2645](https://github.com/Shopify/shopify-cli/pull/2645): Fix issue that prevents the execution of `shopify extension serve` in some scenarios
+
 ## Version 2.26.0 - 2022-10-03
 
 ### Added

--- a/lib/project_types/extension/models/specification_handlers/default.rb
+++ b/lib/project_types/extension/models/specification_handlers/default.rb
@@ -52,7 +52,12 @@ module Extension
           argo_runtime(context).supports?(:public_url)
         end
 
-        def serve(context:, port:, tunnel_url:, resource_url:)
+        def serve(**options)
+          context = options[:context]
+          port = options[:port]
+          tunnel_url = options[:tunnel_url]
+          resource_url = options[:resource_url]
+
           Features::ArgoServe.new(
             specification_handler: self,
             argo_runtime: argo_runtime(context),

--- a/test/project_types/extension/models/specification_handlers/default_test.rb
+++ b/test/project_types/extension/models/specification_handlers/default_test.rb
@@ -8,23 +8,57 @@ module Extension
       class DefaultTest < MiniTest::Test
         include ExtensionTestHelpers::TestExtensionSetup
 
-        def test_tagline_returns_empty_string_if_not_defined_in_content
-          base_type = Default.new(specification)
-          base_type.stubs(:identifier).returns("INVALID")
+        def setup
+          super
+          @default_spec = Default.new(specification)
+        end
 
-          assert_equal "", base_type.tagline
+        def test_tagline_returns_empty_string_if_not_defined_in_content
+          @default_spec.stubs(:identifier).returns("INVALID")
+
+          assert_equal "", @default_spec.tagline
+        end
+
+        def test_serve
+          context = mock
+          argo_runtime = mock
+          argo_serve = mock
+
+          @default_spec.stubs(:argo_runtime).with(context).returns(argo_runtime)
+
+          Features::ArgoServe
+            .expects(:new)
+            .with(
+              specification_handler: @default_spec,
+              argo_runtime: argo_runtime,
+              context: context,
+              port: 9999,
+              tunnel_url: "url://tunnel_url",
+              resource_url: "url://resource_url"
+            )
+            .returns(argo_serve)
+
+          argo_serve.expects(:call)
+
+          @default_spec.serve(
+            context: context,
+            port: 9999,
+            tunnel_url: "url://tunnel_url",
+            resource_url: "url://resource_url",
+            other: "other property",
+          )
         end
 
         def test_valid_extension_contexts_returns_empty_array
-          assert_empty(Default.new(specification).valid_extension_contexts)
+          assert_empty(@default_spec.valid_extension_contexts)
         end
 
         def test_extension_context_returns_nil
-          assert_nil(Default.new(specification).extension_context(@context))
+          assert_nil(@default_spec.extension_context(@context))
         end
 
         def test_graphql_identifier_is_upcased
-          assert_equal specification.identifier.upcase, Default.new(specification).graphql_identifier
+          assert_equal specification.identifier.upcase, @default_spec.graphql_identifier
         end
 
         def test_name_defaults_to_specification_name


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/shopify-cli/issues/2638

### WHAT is this pull request doing?

This PR ignores parameters applicable for some specifications, but not required for the default specification handler.

### How to test your changes?

- Run `shopify extension serve` with an extension that's not a theme app extension
- 
![Screenshot 2022-10-04 at 10 28](https://user-images.githubusercontent.com/1079279/193774121-d814aeaf-38d1-4c54-b4ef-e29bcbc8dca5.png)

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).