### PR TITLE
Demo themes shouldn't appear in the `shopify theme pull/push/list/open` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2645](https://github.com/Shopify/shopify-cli/pull/2645): Fix issue that prevents the execution of `shopify extension serve` in some scenarios
+* [#2646](https://github.com/Shopify/shopify-cli/pull/2646): Demo themes shouldn't appear in the `shopify theme pull/push/list/open` commands
 
 ### Changed
 * [#2648](https://github.com/Shopify/shopify-cli/pull/2648): Do not warn users when the CLI 2.x is running as a subprocess

--- a/lib/project_types/theme/presenters/themes_presenter.rb
+++ b/lib/project_types/theme/presenters/themes_presenter.rb
@@ -5,7 +5,7 @@ require_relative "theme_presenter"
 module Theme
   module Presenters
     class ThemesPresenter
-      ORDER_BY_ROLE = %w(live unpublished development)
+      SUPPORTED_ROLES = %w(live unpublished development)
 
       def initialize(ctx, root)
         @ctx = ctx
@@ -14,15 +14,12 @@ module Theme
 
       def all
         all_themes
-          .sort_by { |theme| order_by_role(theme) }
+          .select { |theme| SUPPORTED_ROLES.include?(theme.role) }
+          .sort_by { |theme| SUPPORTED_ROLES.index(theme.role) }
           .map { |theme| ThemePresenter.new(theme) }
       end
 
       private
-
-      def order_by_role(theme)
-        ORDER_BY_ROLE.index(theme.role) || ORDER_BY_ROLE.size
-      end
 
       def all_themes
         ShopifyCLI::Theme::Theme.all(@ctx, root: @root)

--- a/test/project_types/theme/presenters/themes_presenter_test.rb
+++ b/test/project_types/theme/presenters/themes_presenter_test.rb
@@ -19,20 +19,20 @@ module Theme
             theme(4, role: "other"),
             theme(5, role: "live"),
             theme(6, role: "development"),
+            theme(7, role: "demo"),
           ])
 
         presenter = ThemesPresenter.new(ctx, root)
 
         actual_presenters = presenter.all.map(&:to_s)
 
-        assert_equal(7, actual_presenters.size)
+        assert_equal(6, actual_presenters.size)
         assert_match(/Theme.*\[live\]/, actual_presenters[0])
         assert_match(/Theme.*\[live\]/, actual_presenters[1])
         assert_match(/Theme.*\[unpublished\]/, actual_presenters[2])
         assert_match(/Theme.*\[unpublished\]/, actual_presenters[3])
         assert_match(/Theme.*\[development\]/, actual_presenters[4])
         assert_match(/Theme.*\[development\]/, actual_presenters[5])
-        assert_match(/Theme.*\[other\]/, actual_presenters[6])
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/568

### WHAT is this pull request doing?

This PR modifies the `ThemesPresenter` to introduce an allow-list of theme roles. Without it, partners might face unexpected scenarios in the CLI with `demo` themes.

### How to test your changes?

- Run `shopify-dev theme pull` and notice the demo themes no longer appear
- Run `shopify-dev theme push` and notice the demo themes no longer appear
- Run `shopify-dev theme list` and notice the demo themes no longer appear
- Run `shopify-dev theme open` and notice the demo themes no longer appear

**Before**:
<img width="50%" alt="before" src="https://user-images.githubusercontent.com/1079279/194253262-e3ddee9b-1a9c-4641-a313-9365923d443d.png">

**After**:
<img width="50%" alt="after" src="https://user-images.githubusercontent.com/1079279/194253294-a19dba77-0e0a-4f2a-9b83-9d8d5acd7499.png">

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).