### PR TITLE
Do not warn users when the CLI 2.x is running as a subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2645](https://github.com/Shopify/shopify-cli/pull/2645): Fix issue that prevents the execution of `shopify extension serve` in some scenarios
 
+### Changed
+* [#2648](https://github.com/Shopify/shopify-cli/pull/2648): Do not warn users when the CLI 2.x is running as a subprocess
+
 ## Version 2.26.0 - 2022-10-03
 
 ### Added

--- a/lib/shopify_cli/command.rb
+++ b/lib/shopify_cli/command.rb
@@ -117,7 +117,7 @@ module ShopifyCLI
       end
 
       def check_version(version, range:, runtime:, context: Context.new)
-        return if Environment.test?
+        return if Environment.test? || Environment.run_as_subprocess?
         return if range.nil?
 
         version_without_pre_nor_build = Utilities.version_dropping_pre_and_build(version)

--- a/test/shopify-cli/commands/command_test.rb
+++ b/test/shopify-cli/commands/command_test.rb
@@ -29,6 +29,51 @@ module ShopifyCLI
         assert_match(CLI::UI.fmt(ShopifyCLI::Commands::Populate::Customer.help), io.join)
       end
 
+      def test_check_version_when_it_is_activated
+        Environment.stubs(:test?).returns(false)
+        Environment.stubs(:run_as_subprocess?).returns(false)
+
+        context = mock
+        context.expects(:warn)
+
+        Command.check_version(
+          version(1),
+          range: range(2, 4),
+          runtime: "Ruby",
+          context: context
+        )
+      end
+
+      def test_check_version_when_running_in_a_test_environment
+        Environment.stubs(:test?).returns(true)
+        Environment.stubs(:run_as_subprocess?).returns(false)
+
+        context = mock
+        context.expects(:warn).never
+
+        Command.check_version(
+          version(1),
+          range: range(2, 4),
+          runtime: "Ruby",
+          context: context
+        )
+      end
+
+      def test_check_version_when_running_as_subprocess
+        Environment.stubs(:test?).returns(false)
+        Environment.stubs(:run_as_subprocess?).returns(true)
+
+        context = mock
+        context.expects(:warn).never
+
+        Command.check_version(
+          version(1),
+          range: range(2, 4),
+          runtime: "Ruby",
+          context: context
+        )
+      end
+
       [
         "",
         "http://",
@@ -60,6 +105,23 @@ module ShopifyCLI
             ])
           end
         end
+      end
+
+      private
+
+      def version(major)
+        stub(
+          major: major,
+          minor: 0,
+          patch: 0
+        )
+      end
+
+      def range(from, to)
+        stub(
+          from: version(from),
+          to: version(to),
+        )
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/569

### WHAT is this pull request doing?

When the CLI 2.x is running as a subprocess, the CLI 3.x decides which [Ruby executable](https://github.com/Shopify/cli/blob/7d056bd2a6397960198a84af248a31df5e7e726b/packages/cli-kit/src/node/ruby.ts#L282) must be used (ref: https://github.com/Shopify/cli/issues/569#issuecomment-1269483269).

Thus, PR deactivates warnings in the CLI 2.x when it's running as a subprocess. 

### How to test your changes?

- Setup an enviorment with multiple Ruby versions
- Run `shopify theme init` the CLI 3.x
- Notice the warning no longer appears

![](https://user-images.githubusercontent.com/1079279/193868241-f5acae6c-4a58-4e20-a44f-a2e33fd6fe7c.png)

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).