### PR TITLE
Read storefront renderer token from Environment

### DIFF
--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -77,7 +77,7 @@ module Theme
       end
 
       def storefront_renderer_token
-        Environment.storefront_renderer_auth_token || 
+        ShopifyCLI::Environment.storefront_renderer_auth_token ||
           ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token)
       end
     end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -78,7 +78,7 @@ module Theme
 
       def storefront_renderer_token
         Environment.storefront_renderer_auth_token || 
-        ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token)
+          ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token)
       end
     end
   end

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -77,6 +77,7 @@ module Theme
       end
 
       def storefront_renderer_token
+        Environment.storefront_renderer_auth_token || 
         ShopifyCLI::DB.get(:storefront_renderer_production_exchange_token)
       end
     end

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -81,7 +81,19 @@ module Theme
         end
       end
 
+      def test_valid_authentication_method_when_storefront_renderer_from_CLI3_in_env_is_present
+        ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns("CLI3 SFR Token")
+        ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
+        ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)
+
+        ShopifyCLI::Context.expects(:abort).never
+
+        command = Theme::Command::Serve.new(@ctx)
+        command.send(:valid_authentication_method!)
+      end
+
       def test_valid_authentication_method_when_storefront_renderer_token_and_password_are_present
+        ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns(nil)
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
         ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("SFR token")
 
@@ -92,6 +104,7 @@ module Theme
       end
 
       def test_valid_authentication_method_when_storefront_renderer_token_is_present_and_password_is_not_present
+        ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns(nil)
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns(nil)
         ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns("SFR token")
 
@@ -112,6 +125,7 @@ module Theme
           .with("theme.serve.auth.help_message", ShopifyCLI::TOOL_NAME, ShopifyCLI::TOOL_NAME)
           .returns(help_message)
 
+        ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns(nil)
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
         ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)
 

--- a/test/project_types/theme/commands/serve_test.rb
+++ b/test/project_types/theme/commands/serve_test.rb
@@ -81,7 +81,7 @@ module Theme
         end
       end
 
-      def test_valid_authentication_method_when_storefront_renderer_from_CLI3_in_env_is_present
+      def test_valid_authentication_method_when_storefront_renderer_from_cli3_in_env_is_present
         ShopifyCLI::Environment.stubs(:storefront_renderer_auth_token).returns("CLI3 SFR Token")
         ShopifyCLI::DB.stubs(:get).with(:shopify_exchange_token).returns("password")
         ShopifyCLI::DB.stubs(:get).with(:storefront_renderer_production_exchange_token).returns(nil)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?
When using the CLI2 from CLI3, tokens are passed via Environment and not stored in DB. 
So we need to try to get the token from the Environment first, this was causing a weird edge case for some theme users.

Fixes https://github.com/Shopify/cli/issues/601
Fixes https://github.com/Shopify/cli/issues/545

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- In serve.rb, read the storefront token first from Environment
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->


### Update checklist

- [ ] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [ ] I've left the version number as is (we'll handle incrementing this when releasing).
- [ ] I've included any post-release steps in the section above (if needed).