### PR TITLE
Packaging for release v2.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.27.0 - 2022-10-10
+
 ### Fixed
 * [#2645](https://github.com/Shopify/shopify-cli/pull/2645): Fix issue that prevents the execution of `shopify extension serve` in some scenarios
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.26.0)
+    shopify-cli (2.27.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.11.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.26.0"
+  VERSION = "2.27.0"
 end


### PR DESCRIPTION
### Fixed
* [#2645](https://github.com/Shopify/shopify-cli/pull/2645): Fix issue that prevents the execution of `shopify extension serve` in some scenarios
