### PR TITLE
Display different theme error messages when CLI2 is spawned by CLI3

### DIFF
--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -8,7 +8,7 @@ module Extension
         return Messages::MESSAGES if type_specific_messages.nil?
 
         if type_specific_messages.key?(:overrides)
-          deep_merge(Messages::MESSAGES, type_specific_messages[:overrides])
+          ShopifyCLI::Utilities.deep_merge(Messages::MESSAGES, type_specific_messages[:overrides])
         else
           Messages::MESSAGES
         end
@@ -28,11 +28,6 @@ module Extension
         return unless Messages::TYPES.key?(type_identifier_symbol)
 
         TYPES[type_identifier_symbol]
-      end
-
-      def self.deep_merge(first, second)
-        merger = proc { |_key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
-        first.merge(second, &merger)
       end
     end
   end

--- a/lib/project_types/theme/cli.rb
+++ b/lib/project_types/theme/cli.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
+
 module Theme
   class Project < ShopifyCLI::ProjectType
     require Project.project_filepath("messages/messages")
-    register_messages(Theme::Messages::MESSAGES)
+    register_messages(Theme::Messages.all)
   end
 
   class Command < ShopifyCLI::Command::ProjectCommand

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -145,7 +145,7 @@ module Theme
               It looks like you are using credentials that do not work with {{command:%s theme serve}}.
             ERROR_MESSAGE
             help_message: <<~HELP_MESSAGE,
-              Run {{command:%s logout}} and {{command:%s login --password "" --store STORE}} to force the authentication thought your browser.
+              Run {{command:%s logout}} and {{command:%s login --password "" --store STORE}} to authenticate again.
             HELP_MESSAGE
           },
           operation: {
@@ -390,5 +390,29 @@ module Theme
         },
       },
     }.freeze
+
+    def self.all
+      # In order to support theme development inside CLI3, we spawn CLI2 as a
+      # subprocess. Whenever an error happens, we want to show the updated
+      # version of the commands for the user to try.
+      if ShopifyCLI::Environment.run_as_subprocess?
+        ShopifyCLI::Utilities.deep_merge(MESSAGES, {
+          theme: {
+            serve: {
+              auth: {
+                error_message: <<~ERROR_MESSAGE,
+                  It looks like you are using credentials that do not work with {{command:%s theme dev}}.
+                ERROR_MESSAGE
+                help_message: <<~HELP_MESSAGE,
+                  Run {{command:%s auth logout}} and {{command:%s theme dev --store STORE}} to authenticate again.
+                HELP_MESSAGE
+              },
+            },
+          },
+        })
+      else
+        MESSAGES
+      end
+    end
   end
 end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -407,6 +407,8 @@ module Theme
                   Run {{command:%s auth logout}} and {{command:%s theme dev --store STORE}} to authenticate again.
                 HELP_MESSAGE
               },
+              binding_error: "Couldn't bind to localhost." \
+                " To serve your theme, set a different address with {{command:%s theme dev --host=<address>}}",
             },
           },
         })

--- a/lib/shopify_cli/utilities.rb
+++ b/lib/shopify_cli/utilities.rb
@@ -12,5 +12,10 @@ module ShopifyCLI
         curr = File.dirname(curr)
       end
     end
+
+    def self.deep_merge(first, second)
+      merger = proc { |_key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+      first.merge(second, &merger)
+    end
   end
 end

--- a/test/project_types/theme/messages/message_loading_test.rb
+++ b/test/project_types/theme/messages/message_loading_test.rb
@@ -14,6 +14,7 @@ module Theme
 
         assert_match(/%s theme serve/, messages.dig(:theme, :serve, :auth, :error_message))
         assert_match(/%s logout/, messages.dig(:theme, :serve, :auth, :help_message))
+        assert_match(/%s theme serve/, messages.dig(:theme, :serve, :binding_error))
       end
 
       def test_new_messages_refer_to_cli3_commands
@@ -22,6 +23,7 @@ module Theme
 
         assert_match(/%s theme dev/, messages.dig(:theme, :serve, :auth, :error_message))
         assert_match(/%s auth logout/, messages.dig(:theme, :serve, :auth, :help_message))
+        assert_match(/%s theme dev/, messages.dig(:theme, :serve, :binding_error))
       end
     end
   end

--- a/test/project_types/theme/messages/message_loading_test.rb
+++ b/test/project_types/theme/messages/message_loading_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module Theme
+  module Messages
+    class MessageLoadingTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCLI::ProjectType.load_type(:theme)
+      end
+
+      def test_original_messages_refer_to_cli2_commands
+        messages = Theme::Messages.all
+
+        assert_match(/%s theme serve/, messages.dig(:theme, :serve, :auth, :error_message))
+        assert_match(/%s logout/, messages.dig(:theme, :serve, :auth, :help_message))
+      end
+
+      def test_new_messages_refer_to_cli3_commands
+        ShopifyCLI::Environment.expects(:run_as_subprocess?).returns(true)
+        messages = Theme::Messages.all
+
+        assert_match(/%s theme dev/, messages.dig(:theme, :serve, :auth, :error_message))
+        assert_match(/%s auth logout/, messages.dig(:theme, :serve, :auth, :help_message))
+      end
+    end
+  end
+end

--- a/test/shopify-cli/utilities_test.rb
+++ b/test/shopify-cli/utilities_test.rb
@@ -29,5 +29,11 @@ module ShopifyCLI
       path = "/some/path/inside/the/system"
       assert_equal(path.split("/")[0...-2].join("/"), Utilities.directory("foo.txt", path))
     end
+
+    def test_deep_merge_merges_two_hashes_deeply
+      first = { a: { b: 1, c: 1 } }
+      second = { a: { b: 2 } }
+      assert_equal({ a: { b: 2, c: 1 } }, Utilities.deep_merge(first, second))
+    end
   end
 end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/602

### WHAT is this pull request doing?

- Detect if CLI2 is being spawned as a subprocess
- If so, change the error messages to refer to updated commands

### How to test your changes?

- Run `bundle exec rake console`
- If you paste this command `ShopifyCLI::ProjectType.load_type(:theme); Theme::Messages.all.dig(:theme, :serve, :auth, :error_message)` you should see the old error message referring `theme serve`
- If you exit and then run `SHOPIFY_CLI_RUN_AS_SUBPROCESS=1 bundle exec rake console`
- If you run the same command you should see the new error message referring `theme dev`

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).