### PR TITLE
Fix typo in post authentication messages

### DIFF
--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -498,7 +498,7 @@ module ShopifyCLI
             "{{i}} Authentication required. Login to the URL below with your %s credentials to continue.",
 
           servlet: {
-            success_response: "You've successfuly logged into the Shopify CLI!",
+            success_response: "You've successfully logged into the Shopify CLI!",
             invalid_request_response: "Invalid request: %s",
             invalid_state_response: "The anti-forgery state token does not match the initial request.",
           },


### PR DESCRIPTION
### WHY are these changes introduced?

There is a typo in the post-authentication message. `Succesfuly` → `Successfully`.

![PNG image](https://user-images.githubusercontent.com/17276161/195417495-0632d165-c241-4e15-9682-e7f458eff21e.png)

### WHAT is this pull request doing?

Updates the string to the correct spelling.