### PR TITLE
Packaging for release v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.29.0 - 2022-10-19
+
 ### Added
 * [#2664](https://github.com/Shopify/shopify-cli/pull/2664): Enable Theme Kit Access passwords
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.28.0)
+    shopify-cli (2.29.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.11.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.28.0"
+  VERSION = "2.29.0"
 end


### PR DESCRIPTION
### Added
* [#2664](https://github.com/Shopify/shopify-cli/pull/2664): Enable Theme Kit Access passwords
