### PR TITLE
Fix for "X zip is required for packaging a theme" on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2668](https://github.com/Shopify/shopify-cli/pull/2668): Introduce `--only/--ignore` in the `shopify theme serve` help message
+* [#2667](https://github.com/Shopify/shopify-cli/pull/2667): Fix for "X zip is required for packaging a theme" on Windows
 
 ## Version 2.29.0 - 2022-10-19
 

--- a/lib/project_types/theme/commands/package.rb
+++ b/lib/project_types/theme/commands/package.rb
@@ -18,11 +18,15 @@ module Theme
         release-notes.md
       ]
 
+      ZIP = "zip"
+      SEVEN_ZIP = "7z"
+
       def call(args, _name)
         path = args.first || "."
 
-        check_prereq_command("zip")
+        check_prereq_command
         zip_name = theme_name(path) + ".zip"
+
         zip(zip_name, path, THEME_DIRECTORIES)
         @ctx.done(@ctx.message("theme.package.done", zip_name))
       end
@@ -33,13 +37,12 @@ module Theme
 
       private
 
-      def check_prereq_command(command)
-        cmd_path = @ctx.which(command)
-        @ctx.abort(@ctx.message("theme.package.error.prereq_command_required", command)) if cmd_path.nil?
+      def check_prereq_command
+        @ctx.abort(@ctx.message("theme.package.error.prereq_command_required")) if command.nil?
       end
 
       def zip(zip_name, path, files)
-        @ctx.system("zip", "-r", zip_name, *files, chdir: path)
+        @ctx.system(command, command_flags, zip_name, *files, chdir: path)
       end
 
       def theme_name(path)
@@ -52,6 +55,18 @@ module Theme
         @ctx.abort(@ctx.message("theme.package.error.missing_theme_name")) unless theme_name
 
         [theme_name, theme_info["theme_version"]].compact.join("-")
+      end
+
+      def command
+        @command ||= if @ctx.which(ZIP)
+          ZIP
+        elsif @ctx.which(SEVEN_ZIP)
+          SEVEN_ZIP
+        end
+      end
+
+      def command_flags
+        @command_flags ||= command == ZIP ? "-r" : "a"
       end
     end
   end

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -302,8 +302,8 @@ module Theme
             Usage: {{command:%s theme package [ ROOT ]}}
           HELP
           error: {
-            prereq_command_required: "%1$s is required for packaging a theme. Please install %1$s "\
-              "using the appropriate package manager for your system.",
+            prereq_command_required: "zip or 7zip is required for packaging a theme. Please install "\
+              "zip or 7zip using the appropriate package manager for your system.",
             missing_config: "Provide a config/settings_schema.json to package your theme",
             missing_theme_name: "Provide a theme_info.theme_name configuration in config/settings_schema.json",
           },

--- a/test/project_types/theme/commands/package_test.rb
+++ b/test/project_types/theme/commands/package_test.rb
@@ -8,10 +8,63 @@ module Theme
 
       def setup
         super
-        @context.stubs(:which).with("zip").returns(true)
       end
 
-      def test_package_theme
+      def test_zip_and_seven_zip_command_present
+        @context.stubs(:which).with("zip").returns("path/to/zip")
+        @context.stubs(:which).with("7z").returns("path/to/7z")
+
+        theme_root = File.join(ShopifyCLI::ROOT, "test/fixtures/theme")
+
+        @context.expects(:system).with(
+          "zip",
+          "-r",
+          "Example-1.0.0.zip",
+          *%w[
+            assets
+            config
+            layout
+            locales
+            sections
+            snippets
+            templates
+            release-notes.md
+          ],
+          chdir: theme_root
+        )
+
+        run_cmd("theme package #{theme_root}")
+      end
+
+      def test_only_seven_zip_command_present
+        @context.stubs(:which).with("zip").returns(nil)
+        @context.stubs(:which).with("7z").returns("path/to/7z")
+
+        theme_root = File.join(ShopifyCLI::ROOT, "test/fixtures/theme")
+        @context.expects(:system).with(
+          "7z",
+          "a",
+          "Example-1.0.0.zip",
+          *%w[
+            assets
+            config
+            layout
+            locales
+            sections
+            snippets
+            templates
+            release-notes.md
+          ],
+          chdir: theme_root
+        )
+
+        run_cmd("theme package #{theme_root}")
+      end
+
+      def test_only_zip_command_present
+        @context.stubs(:which).with("zip").returns("path/to/zip")
+        @context.stubs(:which).with("7z").returns(nil)
+
         theme_root = File.join(ShopifyCLI::ROOT, "test/fixtures/theme")
         @context.expects(:system).with(
           "zip",
@@ -31,6 +84,23 @@ module Theme
         )
 
         run_cmd("theme package #{theme_root}")
+      end
+
+      def test_no_system_zip_command_present
+        @context.stubs(:which).with("zip").returns(nil)
+        @context.stubs(:which).with("7z").returns(nil)
+
+        theme_root = File.join(ShopifyCLI::ROOT, "test/fixtures/theme")
+
+        error = assert_raises(CLI::Kit::Abort) do
+          run_cmd("theme package #{theme_root}")
+        end
+
+        assert_equal(
+          "{{x}} zip or 7zip is required for packaging a theme. Please install "\
+          "zip or 7zip using the appropriate package manager for your system.",
+          error.message
+        )
       end
 
       def test_invalid_theme


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli/issues/2513

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Modifies the package command to use a 7zip to zip files when `theme package` is run on Windows

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

#### Machine Setup
The test steps should be run on all platforms. 

##### Mac
- Clone shopify-cli repo
- Add the following to ~/.zshrc and replace <USERNAME> with your machine username:
```
alias shopify-dev="/Users/<USERNAME>/src/github.com/Shopify/shopify-cli/bin/shopify"
```

##### Windows
- Clone shopify-cli repo and checkout branch with changes
- Change `shopify.bat` name in the bin folder of the repo to `shopify-dev.bat`
- Add the bin folder to the PATH 
- Restart machine
- Confirm setup works by running shopify-dev version

##### Linux

TODO

#### Test Steps 

1. If you don't have a theme available, `shopify-dev theme init`
2. `shopify-dev theme package <path/to/theme>`
3. Confirm zip file is generated in theme directory with theme name and version as the name
4. Unzip the zip file and confirm only directories in [THEME_DIRECTORIES](https://github.com/Shopify/shopify-cli/blob/13990c80751bf0bd301024dc5968b6ccbfedefad/lib/project_types/theme/commands/package.rb#L10-L19) are present
5. Confirm nested folders were also included 
6. `cd <theme-name>`
7. `shopify-dev theme package`
8. Repeat steps 3-5

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->
- Open issue in shopify-dev to update theme package docs to indicate we only support `7zip` for theme package on windows

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).