### PR TITLE
Introduce `--only/--ignore` in the `shopify theme serve` help message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2668](https://github.com/Shopify/shopify-cli/pull/2668): Introduce `--only/--ignore` in the `shopify theme serve` help message
+
 ## Version 2.29.0 - 2022-10-19
 
 ### Added

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -124,6 +124,8 @@ module Theme
 
             Options:
               {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of the remote theme.
+              {{command:-o, --only}}             Hot reload only files that match the specified pattern.
+              {{command:-x, --ignore}}           Skip hot reloading any files that match the specified pattern.
               {{command:--port=PORT}}            Local port to serve theme preview from.
               {{command:--poll}}                 Force polling to detect file changes.
               {{command:--host=HOST}}            Set which network interface the web server listens on. The default value is 127.0.0.1.


### PR DESCRIPTION
It's related to https://github.com/Shopify/cli/issues/648

### WHY are these changes introduced?

The `shopify theme serve` help message was not including the `--only/--ignore` flags.

### WHAT is this pull request doing?

This PR introduces the `--only/--ignore` flags in the `shopify theme serve` help message.

### How to test your changes?

- Run `shopify theme serve -h`

![image](https://user-images.githubusercontent.com/1079279/196933702-8404639c-ddf5-4def-a398-8e63a801aade.png)


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).