### PR TITLE
Remove shopify-cli.rb from release task

### DIFF
--- a/lib/shopify_cli/release.rb
+++ b/lib/shopify_cli/release.rb
@@ -120,10 +120,8 @@ module ShopifyCLI
     end
 
     def update_homebrew_repo
-      %w(shopify-cli.rb shopify-cli@2.rb).each do |source_filename|
-        source_file = File.join(package_dir, source_filename)
-        FileUtils.copy(source_file, homebrew_path)
-      end
+      source_file = File.join(package_dir, "shopify-cli@2.rb")
+      FileUtils.copy(source_file, homebrew_path)
       Dir.chdir(homebrew_path) do
         system_or_fail("git commit -am '#{homebrew_update_message}'", "commit homebrew update")
         system_or_fail("git push -u origin #{homebrew_release_branch}", "push homebrew branch")


### PR DESCRIPTION
### WHY are these changes introduced?

As a follow up of this PR https://github.com/Shopify/shopify-cli/pull/2643 we need to update the release rake task to not use the `shopify-cli.rb` source file since it's no longer present in the build folder.

### WHAT is this pull request doing?

This PR removes that file from the release task.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).