### PR TITLE
[Feature] Add short flag "-e" for "--theme-editor-sync"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+
 ### Added
 * [#2676](https://github.com/Shopify/shopify-cli/pull/2676): Introduce shorthand `-e` for `--theme-editor-sync` in `shopify theme serve`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 From version 2.6.0, the sections in this file adhere to the [keep a changelog](https://keepachangelog.com/en/1.0.0/) specification.
 
 ## [Unreleased]
+### Added
+* [#2676](https://github.com/Shopify/shopify-cli/pull/2676): Introduce shorthand `-e` for `--theme-editor-sync` in `shopify theme serve`
 
 ## Version 2.30.0 - 2022-11-01
 

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -23,7 +23,7 @@ module Theme
         parser.on("--port=PORT") { |port| flags[:port] = port.to_i }
         parser.on("--poll") { flags[:poll] = true }
         parser.on("--live-reload=MODE") { |mode| flags[:mode] = as_reload_mode(mode) }
-        parser.on("--theme-editor-sync") { flags[:editor_sync] = true }
+        parser.on("-e", "--theme-editor-sync") { flags[:editor_sync] = true }
         parser.on("--stable") { flags[:stable] = true }
         parser.on("-t", "--theme=NAME_OR_ID") { |theme| flags[:theme] = theme }
         parser.on("-o", "--only=PATTERN", Conversions::IncludeGlob) do |pattern|

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -123,17 +123,17 @@ module Theme
             Usage: {{command:%s theme serve [ ROOT ]}}
 
             Options:
-              {{command:-t, --theme=NAME_OR_ID}} Theme ID or name of the remote theme.
-              {{command:-o, --only}}             Hot reload only files that match the specified pattern.
-              {{command:-x, --ignore}}           Skip hot reloading any files that match the specified pattern.
-              {{command:--port=PORT}}            Local port to serve theme preview from.
-              {{command:--poll}}                 Force polling to detect file changes.
-              {{command:--host=HOST}}            Set which network interface the web server listens on. The default value is 127.0.0.1.
-              {{command:--theme-editor-sync}}    Synchronize Theme Editor updates in the local theme files.
-              {{command:--live-reload=MODE}}     The live reload mode switches the server behavior when a file is modified:
-                                     - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
-                                     - {{command:full-page}}  Always refreshes the entire page
-                                     - {{command:off}}        Deactivate live reload
+              {{command:-t, --theme=NAME_OR_ID}}  Theme ID or name of the remote theme.
+              {{command:-o, --only}}              Hot reload only files that match the specified pattern.
+              {{command:-x, --ignore}}            Skip hot reloading any files that match the specified pattern.
+              {{command:-e, --theme-editor-sync}} Synchronize Theme Editor updates in the local theme files.
+              {{command:--port=PORT}}             Local port to serve theme preview from.
+              {{command:--poll}}                  Force polling to detect file changes.
+              {{command:--host=HOST}}             Set which network interface the web server listens on. The default value is 127.0.0.1.
+              {{command:--live-reload=MODE}}      The live reload mode switches the server behavior when a file is modified:
+                                      - {{command:hot-reload}} Hot reloads local changes to CSS and sections (default)
+                                      - {{command:full-page}}  Always refreshes the entire page
+                                      - {{command:off}}        Deactivate live reload
           HELP
           reload_mode_is_not_valid: "The live reload mode `%s` is not valid.",
           try_a_valid_reload_mode: "Try a valid live reload mode: %s.",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2587

Partner would like a short flag for `--theme-editor-sync`.

CLI 3.x-related changes: https://github.com/Shopify/cli/pull/721

### WHAT is this pull request doing?

Adds short flag `-e` for `--theme-editor-sync`.

### How to test your changes?

1. `shopify-dev theme serve -e`
2. Open the theme editor and make some changes.
3. Verify that these changes are now visible in your source code.

### Post-release steps

- [x] Create update request to shopify.dev docs ([example](https://github.com/Shopify/shopify-dev/issues/18455)) and assign it to shainaraskas 👉🏻 https://github.com/Shopify/shopify-dev/issues/27822

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).