### PR TITLE
Enable Theme Access passwords for theme serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#2681](https://github.com/Shopify/shopify-cli/pull/2681): Enable Theme Access passwords for theme serve
+
 ## Version 2.31.0 - 2022-11-07
 
 ### Added

--- a/lib/shopify_cli/theme/dev_server/proxy.rb
+++ b/lib/shopify_cli/theme/dev_server/proxy.rb
@@ -199,13 +199,13 @@ module ShopifyCLI
         end
 
         def request(method, path, headers: nil, query: [], form_data: nil, body_stream: nil)
-          uri = URI.join("https://#{@theme.shop}", path)
+          uri = URI.join("https://#{shop}", path)
 
           if Environment.theme_access_password?
             headers = headers ? headers.slice("ACCEPT", "CONTENT-TYPE", "CONTENT-LENGTH", "Cookie") : {}
             headers.merge!({
               "X-Shopify-Access-Token" => Environment.admin_auth_token,
-              "X-Shopify-Shop" => @theme.shop,
+              "X-Shopify-Shop" => shop,
             })
             uri = URI.join("https://#{ThemeAccessAPI::BASE_URL}", "cli/sfr#{path}")
           end


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/shopify-cli-planning/issues/376

### WHAT is this pull request doing?

Proxies Storefront Renderer requests from the dev server through Theme Access API when a password is provided

### How to test your changes?
Once https://github.com/Shopify/theme-access/pull/2463 and https://github.com/Shopify/storefront-renderer/pull/15845 are released, it can be tested with: `SHOPIFY_SHOP=your-shop SHOPIFY_CLI_ADMIN_AUTH_TOKEN=password SHOPIFY_CLI_STOREFRONT_RENDERER_AUTH_TOKEN=password shopify theme serve`

Otherwise, it requires updating the [Theme Access URL](https://github.com/Shopify/shopify-cli/blob/9ac01ccc6d278dd469f57dda5c547dc4daea60e6/lib/shopify_cli/theme/theme_access_api.rb#L12) to local/staging and hard-coding an access token for SFR [here](https://github.com/Shopify/theme-access/blob/9e3633d0548191e0dc44007cd9acbaeba44ca7ab/lib/storefront_renderer_proxy.rb#L67).

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).