### PR TITLE
Fix timeout issue with the `shopify theme push` command with the `--json` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2683](https://github.com/Shopify/shopify-cli/pull/2683): Fix timeout issue with the `shopify theme push` command and the `--json` flag
+
 ## Version 2.31.0 - 2022-11-07
 
 ### Added

--- a/lib/shopify_cli/theme/syncer/uploader.rb
+++ b/lib/shopify_cli/theme/syncer/uploader.rb
@@ -212,7 +212,7 @@ module ShopifyCLI
         end
 
         def update_progress_bar(size, total)
-          @update_progress_bar_block.call(size, total)
+          @update_progress_bar_block&.call(size, total)
         end
 
         # Handler errors

--- a/test/shopify-cli/theme/syncer/uploader_test.rb
+++ b/test/shopify-cli/theme/syncer/uploader_test.rb
@@ -90,7 +90,7 @@ module ShopifyCLI
             syncer,
             delete_remote_assets,
             delay_low_priority_files
-          ) {}
+          )
         end
 
         def syncer


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli/issues/2682

### WHY are these changes introduced?

When users pass the `--json` flag, the uploader fails because it doesn't have a progress bar to update.

### WHAT is this pull request doing?

Now, the `Syncer::Uploader` handles the progress bar as an optional dependency.

### How to test your changes?

- Run `shopify-dev theme push -u -t abc1 --json`
- Notice the upload finishes

### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).