### PR TITLE
Fix `shopify theme push` to report pushes with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2683](https://github.com/Shopify/shopify-cli/pull/2683): Fix timeout issue with the `shopify theme push` command and the `--json` flag
+* [#2688](https://github.com/Shopify/shopify-cli/pull/2688): Fix `shopify theme push` to report pushes with errors
 
 ## Version 2.31.0 - 2022-11-07
 

--- a/lib/shopify_cli/theme/syncer/uploader.rb
+++ b/lib/shopify_cli/theme/syncer/uploader.rb
@@ -26,13 +26,11 @@ module ShopifyCLI
           :ignore_file?,
           :overwrite_json?,
           :bulk_updates_activated?,
-
           # enqueue
           :enqueue_deletes,
           :enqueue_get,
           :enqueue_union_merges,
           :enqueue_updates,
-
           # checksums
           :checksums,
           :update_checksums,
@@ -112,7 +110,7 @@ module ShopifyCLI
           retries = 0
           pending_items = files.map { |file| bulk_item(file) }
 
-          while pending_items.any? && retries < 4
+          while pending_items.any? && retries < 2
             bulk = Bulk.new(ctx, theme, api_client)
 
             files
@@ -183,7 +181,7 @@ module ShopifyCLI
             [
               theme["config/settings_schema.json"],
               theme["config/settings_data.json"],
-            ]
+            ],
           )
         end
 
@@ -217,8 +215,14 @@ module ShopifyCLI
 
         # Handler errors
 
-        def report(file, _error)
-          error_message = "The asset #{file.relative_path} could not be uploaded.\n#{e.inspect}"
+        def report(file, error)
+          file_path = file.relative_path
+
+          error_message = syncer
+            .parse_api_errors(file, error)
+            .map { |error_message| "#{file_path}: #{error_message}" }
+            .join("\n")
+
           syncer.report_file_error(file, error_message)
         end
       end

--- a/lib/shopify_cli/theme/syncer/uploader.rb
+++ b/lib/shopify_cli/theme/syncer/uploader.rb
@@ -220,7 +220,7 @@ module ShopifyCLI
 
           error_message = syncer
             .parse_api_errors(file, error)
-            .map { |error_message| "#{file_path}: #{error_message}" }
+            .map { |msg| "#{file_path}: #{msg}" }
             .join("\n")
 
           syncer.report_file_error(file, error_message)

--- a/test/shopify-cli/theme/syncer/uploader_test.rb
+++ b/test/shopify-cli/theme/syncer/uploader_test.rb
@@ -83,13 +83,29 @@ module ShopifyCLI
           uploader.delete_files!
         end
 
+        def test_report
+          file = theme["layout/theme.liquid"]
+          error = StandardError.new
+
+          syncer
+            .stubs(:parse_api_errors)
+            .with(file, error)
+            .returns(["Unknown error"])
+
+          syncer
+            .expects(:report_file_error)
+            .with(file, "layout/theme.liquid: Unknown error")
+
+          uploader.send(:report, file, error)
+        end
+
         private
 
         def uploader(delete_remote_assets: true, delay_low_priority_files: false)
           @uploader ||= Uploader.new(
             syncer,
             delete_remote_assets,
-            delay_low_priority_files
+            delay_low_priority_files,
           )
         end
 
@@ -100,7 +116,7 @@ module ShopifyCLI
             include_filter: nil,
             ignore_filter: nil,
             overwrite_json: true,
-            stable: false
+            stable: false,
           ).tap do |syncer|
             syncer.stubs(:wait!).returns(nil)
           end

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -47,7 +47,7 @@ module ShopifyCLI
               key: "assets/theme.css",
               value: @theme["assets/theme.css"].read,
             },
-          })
+          }),
         ).returns([
           200,
           {
@@ -76,7 +76,7 @@ module ShopifyCLI
               key: "assets/logo.png",
               attachment: Base64.encode64(@theme["assets/logo.png"].read),
             },
-          })
+          }),
         ).returns([
           200,
           {
@@ -104,7 +104,7 @@ module ShopifyCLI
             asset: {
               key: "assets/theme.css",
             },
-          })
+          }),
         ).returns([
           200,
           {
@@ -128,7 +128,7 @@ module ShopifyCLI
             method: "GET",
             shop: @theme.shop,
             path: "themes/#{@theme.id}/assets.json",
-            query: "asset%5Bkey%5D=assets%2Ftheme.css"
+            query: "asset%5Bkey%5D=assets%2Ftheme.css",
           )
           .returns([200, { "asset" => { "value" => "new content" } }, {}])
 
@@ -163,7 +163,7 @@ module ShopifyCLI
             method: "GET",
             shop: @theme.shop,
             path: "themes/#{@theme.id}/assets.json",
-            query: "asset%5Bkey%5D=assets%2Flogo.png"
+            query: "asset%5Bkey%5D=assets%2Flogo.png",
           )
           .returns([200, {}, {}])
 
@@ -194,7 +194,6 @@ module ShopifyCLI
           method: "GET",
           shop: @theme.shop,
           path: "themes/#{@theme.id}/assets.json",
-
         ).returns([
           200,
           {
@@ -219,7 +218,6 @@ module ShopifyCLI
           api_version: "unstable",
           method: "GET",
           path: "themes/#{@theme.id}/assets.json",
-
         ).returns([
           200,
           {
@@ -446,7 +444,7 @@ module ShopifyCLI
           api_version: "unstable",
           method: "GET",
           shop: @theme.shop,
-          path: "themes/#{@theme.id}/assets.json"
+          path: "themes/#{@theme.id}/assets.json",
         ).returns([
           200,
           { "assets" => response_assets },
@@ -465,7 +463,7 @@ module ShopifyCLI
               asset: {
                 key: "assets/removed.css",
               },
-            )
+            ),
           ))
           .returns([200, {}, {}])
 
@@ -514,7 +512,7 @@ module ShopifyCLI
           12:30:59 {{red:ERROR }} {{>}} {{blue:update sections/footer.liquid}}:
             An error
             Then some
-          EOS
+        EOS
 
         @syncer.start_threads
         file = @theme["sections/footer.liquid"]
@@ -525,7 +523,7 @@ module ShopifyCLI
               "An error",
               "Then some\nThis is truncated",
             ],
-          }
+          },
         )
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
@@ -542,7 +540,7 @@ module ShopifyCLI
         @ctx.expects(:error).with(<<~EOS.chomp)
           12:30:59 {{red:ERROR }} {{>}} {{blue:update sections/footer.liquid}}:
             message
-          EOS
+        EOS
 
         @syncer.start_threads
         file = @theme["sections/footer.liquid"]
@@ -550,7 +548,7 @@ module ShopifyCLI
         response_body = JSON.generate(
           errors: {
             message: "oops",
-          }
+          },
         )
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
@@ -631,7 +629,7 @@ module ShopifyCLI
         @ctx.expects(:error).with(<<~EOS.chomp)
           12:30:59 {{red:ERROR }} {{>}} {{blue:update sections/footer.liquid}}:
             message
-          EOS
+        EOS
         file.stubs(checksum: "modified")
         time_freeze do
           @syncer.enqueue_updates([file])
@@ -658,7 +656,7 @@ module ShopifyCLI
               "An error",
               "Then some",
             ],
-          }
+          },
         )
 
         ShopifyCLI::AdminAPI.expects(:rest_request)
@@ -712,7 +710,7 @@ module ShopifyCLI
       end
 
       def test_parse_valid_theme_asset_with_errors
-        operation = stub(file: "sections/footer.liquid", method: "update")
+        file = "sections/footer.liquid"
         expected_error = ["Something is wrong with this theme file."]
         body = {
           "errors" => {
@@ -721,13 +719,13 @@ module ShopifyCLI
         }
         error = ShopifyCLI::API::APIRequestError.new(body, response: { body: body })
 
-        actual_error = @syncer.send(:parse_api_errors, operation, error)
+        actual_error = @syncer.parse_api_errors(file, error)
 
         assert_equal(expected_error, actual_error)
       end
 
       def test_parse_invalid_theme_asset_with_many_errors
-        operation = stub(file: "package.json", method: "update")
+        file = "package.json"
         expected_error = [
           "This is not a valid theme file",
           "Please check the file type",
@@ -737,30 +735,30 @@ module ShopifyCLI
         }
         error = ShopifyCLI::API::APIRequestError.new(body, response: { body: body })
 
-        actual_error = @syncer.send(:parse_api_errors, operation, error)
+        actual_error = @syncer.parse_api_errors(file, error)
 
         assert_equal(expected_error, actual_error)
       end
 
       def test_parse_invalid_theme_asset_with_a_single_error
-        operation = stub(file: "package.json", method: "update")
+        file = "package.json"
         error = "This is not a valid theme file"
         body = {
           "errors" => error,
         }
         err = ShopifyCLI::API::APIRequestError.new(body, response: { body: body })
 
-        actual_error = @syncer.send(:parse_api_errors, operation, err)
+        actual_error = @syncer.parse_api_errors(file, err)
         expected_error = [error]
 
         assert_equal(expected_error, actual_error)
       end
 
       def test_parse_api_errors_wiht_a_standard_errors
-        operation = stub(file: "package.json", method: "update")
+        file = "package.json"
         error = Errno::EADDRINUSE.new
 
-        actual_error = @syncer.send(:parse_api_errors, operation, error)
+        actual_error = @syncer.parse_api_errors(file, error)
         expected_error = ["Address already in use"]
 
         assert_equal(expected_error, actual_error)


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-cli/issues/2685

### WHY are these changes introduced?

When users push a file with errors (e.g., a Liquid template with some syntax error), the CLI must report it.

### WHAT is this pull request doing?

Now, the `Syncer::Uploader` is properly handling errors in the `report` method.

### How to test your changes?

- Run `shopify theme push` in a theme with errors

Before:
<img width="1268" alt="before" src="https://user-images.githubusercontent.com/1079279/201602422-ffbaa597-f42a-4178-98c7-5677f857f451.png">

After:
<img width="1269" alt="after" src="https://user-images.githubusercontent.com/1079279/201602400-f0051f8e-c64e-46ca-9d83-ec947ce1072f.png">


### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).