### PR TITLE
Packaging for release v2.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.32.0 - 2022-11-14
+
 ### Added
 * [#2680](https://github.com/Shopify/shopify-cli/pull/2680): Validate on `shopify theme share/pull/push/serve` if users are running the command in a theme/empty directory
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.31.0)
+    shopify-cli (2.32.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.11.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.31.0"
+  VERSION = "2.32.0"
 end


### PR DESCRIPTION
### Added
* [#2680](https://github.com/Shopify/shopify-cli/pull/2680): Validate on `shopify theme share/pull/push/serve` if users are running the command in a theme/empty directory

### Fixed
* [#2683](https://github.com/Shopify/shopify-cli/pull/2683): Fix timeout issue with the `shopify theme push` command and the `--json` flag
