### PR TITLE
Add sunset warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2694](https://github.com/Shopify/shopify-cli/pull/2694): Add sunset warnings
+
 ## Version 2.32.0 - 2022-11-14
 
 ### Added

--- a/lib/shopify_cli/core/entry_point.rb
+++ b/lib/shopify_cli/core/entry_point.rb
@@ -5,28 +5,7 @@ module ShopifyCLI
     module EntryPoint
       class << self
         def call(args, ctx = Context.new)
-          # Only instruct the user to update the CLI, or warn them that they're
-          # using CLI2 not CLI3, if they're running CLI2 directly. Otherwise the
-          # warnings will be confusing and/or incorrect.
-          unless Environment.run_as_subprocess?
-            if ctx.development? && !ctx.testing?
-              ctx.warn(
-                ctx.message(
-                  "core.warning.development_version",
-                  File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME)
-                )
-              )
-              # because `!ctx.new_version.nil?` will change the config by calling ::Config.set
-              # it's important to keep the checks in this order so that we don't trigger it while testing
-              # since changing the config will throw errors
-            elsif !ctx.testing? && !ctx.new_version.nil?
-              ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, ctx.new_version))
-            end
-
-            if ShopifyCLI::Core::CliVersion.using_3_0?
-              ctx.warn(ctx.message("core.warning.in_3_0_directory"))
-            end
-          end
+          show_warnings(ctx, args.join(" "))
 
           ProjectType.load_all
 
@@ -36,6 +15,47 @@ module ShopifyCLI
           executor = ShopifyCLI::Core::Executor.new(ctx, task_registry, log_file: ShopifyCLI.log_file)
           ShopifyCLI::Core::Monorail.log(command_name, args) do
             executor.call(command, command_name, args)
+          end
+        end
+
+        def show_warnings(ctx, args)
+          # Only instruct the user to update the CLI, or warn them that they're
+          # using CLI2 not CLI3, if they're running CLI2 directly. Otherwise the
+          # warnings will be confusing and/or incorrect.
+          return if Environment.run_as_subprocess?
+
+          show_sunset_warning(ctx, args)
+
+          if ctx.development? && !ctx.testing?
+            ctx.warn(
+              ctx.message(
+                "core.warning.development_version",
+                File.join(ShopifyCLI::ROOT, "bin", ShopifyCLI::TOOL_NAME)
+              )
+            )
+            # because `!ctx.new_version.nil?` will change the config by calling ::Config.set
+            # it's important to keep the checks in this order so that we don't trigger it while testing
+            # since changing the config will throw errors
+          elsif !ctx.testing? && !ctx.new_version.nil?
+            ctx.warn(ctx.message("core.warning.new_version", ShopifyCLI::VERSION, ctx.new_version))
+          end
+
+          if ShopifyCLI::Core::CliVersion.using_3_0?
+            ctx.warn(ctx.message("core.warning.in_3_0_directory"))
+          end
+        end
+
+        def show_sunset_warning(ctx, args)
+          return if ctx.testing?
+
+          if args.start_with?("app create") || args.start_with?("app extension create")
+            ctx.warn(ctx.message("core.warning.sunset_create_app"))
+          elsif args.start_with?("app")
+            ctx.warn(ctx.message("core.warning.sunset_app"))
+          elsif args.start_with?("theme")
+            ctx.warn(ctx.message("core.warning.sunset_theme"))
+          else
+            ctx.warn(ctx.message("core.warning.sunset"))
           end
         end
       end

--- a/lib/shopify_cli/messages/messages.rb
+++ b/lib/shopify_cli/messages/messages.rb
@@ -804,6 +804,22 @@ module ShopifyCLI
               Already have CLI 3.0 installed? Run it using your node package manager, as explained here:
               {{underline:https://shopify.dev/apps/tools/cli/cli-2#running-shopify-cli-2-x-and-3-x-in-the-same-environment}}
           MESSAGE
+
+          sunset: <<~MESSAGE,
+            {{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023.}}
+          MESSAGE
+
+          sunset_create_app: <<~MESSAGE,
+            {{*}} {{yellow:Note that this CLI 2.x command will be sunset on April 28, 2023. Check here for instructions on how to migrate over to CLI 3.x: {{underline:https://shopify.dev/apps/tools/cli/migrate}}.}}
+          MESSAGE
+
+          sunset_app: <<~MESSAGE,
+            {{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023. Check here for instructions on how to migrate over to CLI 3.x: {{underline:https://shopify.dev/apps/tools/cli/migrate}}.}}
+          MESSAGE
+
+          sunset_theme: <<~MESSAGE,
+            {{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023. Check here for instructions on how to migrate over to CLI 3.x: {{underline:https://shopify.dev/themes/tools/cli/migrate}}.}}
+          MESSAGE
         },
         reporting: {
           help: <<~HELP,

--- a/packaging/homebrew/shopify-cli@2.base.rb
+++ b/packaging/homebrew/shopify-cli@2.base.rb
@@ -108,4 +108,12 @@ class ShopifyCliAT2 < Formula
       RUBY
     end
   end
+
+  def post_install
+    message = <<~POSTINSTALL_MESSAGE
+      Note that Shopify CLI 2.x will be sunset on May 31, 2023.
+      More info: https://shopify.dev/changelog/cli-2-0-to-be-sunset-on-may-31-2023
+    POSTINSTALL_MESSAGE
+    message.each_line { |line| ohai line.chomp }
+  end
 end

--- a/test/shopify-cli/core/entry_point_test.rb
+++ b/test/shopify-cli/core/entry_point_test.rb
@@ -70,6 +70,7 @@ module ShopifyCLI
 
         @context.stubs(
           development?: false,
+          new_version: nil,
           testing?: false
         )
         @context.expects(:warn).with(create_app_message).once
@@ -85,6 +86,7 @@ module ShopifyCLI
 
         @context.stubs(
           development?: false,
+          new_version: nil,
           testing?: false
         )
         @context.expects(:warn).with(create_app_message).once
@@ -100,6 +102,7 @@ module ShopifyCLI
 
         @context.stubs(
           development?: false,
+          new_version: nil,
           testing?: false
         )
         @context.expects(:warn).with(app_message).once
@@ -115,6 +118,7 @@ module ShopifyCLI
 
         @context.stubs(
           development?: false,
+          new_version: nil,
           testing?: false
         )
         @context.expects(:warn).with(theme_message).once

--- a/test/shopify-cli/core/entry_point_test.rb
+++ b/test/shopify-cli/core/entry_point_test.rb
@@ -16,34 +16,18 @@ module ShopifyCLI
         EntryPoint.call(args, @context)
       end
 
-      def test_does_not_warn_of_new_version_in_tests
+      def test_no_warnings_in_tests
         args = %w(help argone argtwo)
 
         @context.stubs(
           development?: false,
-          new_version: "1.0.0",
+          new_version: "2.99.0",
         )
         @context.expects(:warn).never
         EntryPoint.call(args, @context)
       end
 
-      def test_warns_of_new_version_in_non_tests_when_not_running_as_subprocess
-        args = %w(help argone argtwo)
-
-        ShopifyCLI::Environment.stubs(
-          run_as_subprocess?: false,
-        )
-
-        @context.stubs(
-          development?: false,
-          new_version: "1.0.0",
-          testing?: false
-        )
-        @context.expects(:warn).once
-        EntryPoint.call(args, @context)
-      end
-
-      def test_does_not_warn_of_new_version_in_non_tests_when_running_as_subprocess
+      def test_no_warnings_when_running_as_subprocess
         args = %w(help argone argtwo)
 
         ShopifyCLI::Environment.stubs(
@@ -52,12 +36,116 @@ module ShopifyCLI
 
         @context.stubs(
           development?: false,
-          new_version: "1.0.0",
+          new_version: "2.99.0",
           testing?: false
         )
 
         @context.expects(:warn).never
         EntryPoint.call(args, @context)
+      end
+
+      def test_new_version_warning
+        args = %w(help argone argtwo)
+
+        ShopifyCLI::Environment.stubs(
+          run_as_subprocess?: false,
+        )
+
+        @context.stubs(
+          development?: false,
+          new_version: "2.99.0",
+          testing?: false
+        )
+        @context.expects(:warn).with(new_version_message).once
+        @context.expects(:warn).with(sunset_message).once
+        EntryPoint.call(args, @context)
+      end
+
+      def test_app_create_sunset_warning
+        args = %w(app create)
+
+        ShopifyCLI::Environment.stubs(
+          run_as_subprocess?: false,
+        )
+
+        @context.stubs(
+          development?: false,
+          testing?: false
+        )
+        @context.expects(:warn).with(create_app_message).once
+        EntryPoint.call(args, @context)
+      end
+
+      def test_extension_create_sunset_warning
+        args = %w(app extension create)
+
+        ShopifyCLI::Environment.stubs(
+          run_as_subprocess?: false,
+        )
+
+        @context.stubs(
+          development?: false,
+          testing?: false
+        )
+        @context.expects(:warn).with(create_app_message).once
+        EntryPoint.call(args, @context)
+      end
+
+      def test_app_sunset_warning
+        args = %w(app)
+
+        ShopifyCLI::Environment.stubs(
+          run_as_subprocess?: false,
+        )
+
+        @context.stubs(
+          development?: false,
+          testing?: false
+        )
+        @context.expects(:warn).with(app_message).once
+        EntryPoint.call(args, @context)
+      end
+
+      def test_theme_sunset_warning
+        args = %w(theme)
+
+        ShopifyCLI::Environment.stubs(
+          run_as_subprocess?: false,
+        )
+
+        @context.stubs(
+          development?: false,
+          testing?: false
+        )
+        @context.expects(:warn).with(theme_message).once
+        EntryPoint.call(args, @context)
+      end
+
+      private
+
+      def new_version_message
+        "{{*}} {{yellow:A new version of Shopify CLI is available! You have version 2.32.0 and the latest version is "\
+          "2.99.0.\n\n  To upgrade, follow the instructions for the package manager you’re using:\n  "\
+          "{{underline:https://shopify.dev/themes/tools/cli/upgrade-uninstall}}}}\n\n"
+      end
+
+      def sunset_message
+        "{{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023.}}\n"
+      end
+
+      def create_app_message
+        "{{*}} {{yellow:Note that this CLI 2.x command will be sunset on April 28, 2023. Check here for instructions "\
+          "on how to migrate over to CLI 3.x: {{underline:https://shopify.dev/apps/tools/cli/migrate}}.}}\n"
+      end
+
+      def app_message
+        "{{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023. Check here for instructions on how to "\
+          "migrate over to CLI 3.x: {{underline:https://shopify.dev/apps/tools/cli/migrate}}.}}\n"
+      end
+
+      def theme_message
+        "{{*}} {{yellow:Note that CLI 2.x will be sunset on May 31, 2023. Check here for instructions on how to "\
+          "migrate over to CLI 3.x: {{underline:https://shopify.dev/themes/tools/cli/migrate}}.}}\n"
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-cli-planning/issues/453

The [CLI 2.x will be sunset on April 28, 2023](https://shopify.dev/changelog/cli-2-0-to-be-sunset-on-may-31-2023), so we want to warn about that on each command.

### WHAT is this pull request doing?

- Adds a warning on each command, including extra information for app, theme, and app/extension creation commands
- Adds a post installation message for Homebrew

![25-30-vicee-ynllt](https://user-images.githubusercontent.com/14979109/203976986-b2e140a2-2b85-42c1-8d96-915a65c05332.png)

### How to test your changes?

Just run any command

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).