### PR TITLE
Improve logs when an authentication error happens

### DIFF
--- a/lib/shopify_cli/theme/theme_admin_api.rb
+++ b/lib/shopify_cli/theme/theme_admin_api.rb
@@ -61,6 +61,7 @@ module ShopifyCLI
         if empty_response?(error)
           return permission_error
         elsif unauthorized_response?(error)
+          @ctx.debug("[#{self.class}] (#{error.class}) cause: #{response_body(error)}")
           raise ShopifyCLI::Abort, @ctx.message("theme.unauthorized_error", @shop)
         end
 


### PR DESCRIPTION
### WHY are these changes introduced?

We've been noticing that the following error is happening with a higher frequency:
```
You can't use Shopify CLI with development stores if you only have Partner staff member access. If you want to use Shopify CLI to work on a development store, then you should be the store owner or create a staff account on the store.
```

Thus, this PR introduces a new debug log to provide better instrumentation and help us un understanding the root cause of a possible bug.


### WHAT is this pull request doing?

This PR logs the the body of the API error.

### How to test your changes?

- Add a new user at your store in **Settings > Users and permissions** screen
- Run `shopify-dev logout`
- Run `shopify-dev login -s <your_store>`
- Use the new user at the login
- Run `shopify-dev theme list`
- Notice it works
- Suspend the new user at **Settings > Users and permissions** (in the user screen)
- Run `DEBUG=1 shopify-dev theme list`
- Notice that new the error is logged

![image](https://user-images.githubusercontent.com/1079279/203995229-a5fcb0f9-4483-4a6c-9e3f-9dd7d5093d36.png)



### Post-release steps

None.

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing) - It's not a public-facing change
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).