### PR TITLE
Delete checksum after file deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2706](https://github.com/Shopify/shopify-cli/pull/2706): Delete checksum after file deletion
+
 ## Version 2.33.0 - 2022-12-19
 
 ### Added

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -348,6 +348,8 @@ module ShopifyCLI
           }),
         )
 
+        checksums.delete(file) if checksums.has?(file)
+
         response
       end
 

--- a/lib/shopify_cli/theme/syncer/checksums.rb
+++ b/lib/shopify_cli/theme/syncer/checksums.rb
@@ -20,6 +20,12 @@ module ShopifyCLI
           file.checksum != checksum_by_key[file.relative_path]
         end
 
+        def delete(file)
+          checksums_mutex.synchronize do
+            checksum_by_key.delete(to_key(file))
+          end
+        end
+
         def keys
           checksum_by_key.keys
         end


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/733

Files that get added and uploaded, then deleted (both local and remote), then added again, will not get uploaded again, because checksums are outdated.

### WHAT is this pull request doing?

When a file has been successfully deleted (both local and remote), checksum in checksum store is removed, so that the same file can be reuploaded again.

### How to test your changes?

1. In a theme directory, run `shopify theme serve`
2. Add a new file, e.g. `index.js` with content `console.log('…')` in the `assets` folder, and verify that it gets uploaded.
3. Delete the file locally, and verify that it gets deleted remotely too.
4. Revert the delete, and verify that it gets uploaded again.

### Post-release steps

- [ ] New CLI 3.x release

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).