### PR TITLE
Do not `replace_asset_urls` in font bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2721](https://github.com/Shopify/shopify-cli/pull/2721): Do not `replace_asset_urls` in font bodies
+
 ## Version 2.34.0 - 2023-01-11
 
 ### Added


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/issues/1199

Starting with Ruby 3.2 – [Homebrew formula](https://github.com/Shopify/homebrew-shopify/blob/master/shopify-cli.rb) just says `depends_on "ruby"`, so that’s why such kind of issues appear now – `body.join.gsub` raises the error `invalid byte sequence in UTF-8` when `body.join` is a font body (which of course doesn’t contain any URLs or other readable characters).

### WHAT is this pull request doing?

1. Does not call `replace_asset_urls` when path starts with `/fonts`.
2. In case other "non-`gsub`able" strings are being `gsub`ed and the same `ArgumentError` containing the message `invalid byte sequence` is raised, body will simply be returned without any replacements.

### How to test your changes?

Test it with both Ruby 3.1 and 3.2:

1. `cd` into a theme directory
2. Call `DEBUG=true shopify theme serve`
3. Open `http://127.0.0.1:9292/`
4. Verify that no _Internal server error_ is thrown

### Post-release steps

- CLI 3.x update

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).