### PR TITLE
Introduce hidden `--overwrite-json` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Added
+* [#2724](https://github.com/Shopify/shopify-cli/pull/2724): Introduce hidden `--overwrite-json` flag
+
 ## Version 2.34.0 - 2023-01-11
 
 ### Added

--- a/lib/project_types/theme/commands/serve.rb
+++ b/lib/project_types/theme/commands/serve.rb
@@ -35,6 +35,7 @@ module Theme
           flags[:ignores] |= pattern
         end
         parser.on("-f", "--force") { flags[:force] = true }
+        parser.on("--overwrite-json") { flags[:overwrite_json] = true }
       end
 
       def call(_args, name)

--- a/lib/shopify_cli/theme/dev_server.rb
+++ b/lib/shopify_cli/theme/dev_server.rb
@@ -41,6 +41,7 @@ module ShopifyCLI
           port: 9292,
           poll: false,
           editor_sync: false,
+          overwrite_json: false,
           stable: false,
           mode: ReloadMode.default,
           includes: nil,
@@ -55,6 +56,7 @@ module ShopifyCLI
             port,
             poll,
             editor_sync,
+            overwrite_json,
             stable,
             mode,
             includes,
@@ -78,6 +80,7 @@ module ShopifyCLI
         port,
         poll,
         editor_sync,
+        overwrite_json,
         stable,
         mode,
         includes,
@@ -91,6 +94,7 @@ module ShopifyCLI
         @port = port
         @poll = poll
         @editor_sync = editor_sync
+        @overwrite_json = overwrite_json
         @stable = stable
         @mode = mode
         @includes = includes
@@ -199,7 +203,7 @@ module ShopifyCLI
           theme: theme,
           include_filter: include_filter,
           ignore_filter: ignore_filter,
-          overwrite_json: !editor_sync,
+          overwrite_json: !editor_sync || @overwrite_json,
           stable: stable
         )
       end

--- a/test/shopify-cli/theme/dev_server_test.rb
+++ b/test/shopify-cli/theme/dev_server_test.rb
@@ -118,9 +118,10 @@ module ShopifyCLI
       private
 
       def dev_server(identifier: nil, ignores: nil, includes: nil)
-        host, port, poll, editor_sync, stable, mode = nil
+        host, port, poll, editor_sync, overwrite_json, stable, mode = nil
         server = DevServer.instance
-        server.setup(ctx, root, host, identifier, port, poll, editor_sync, stable, mode, includes, ignores)
+        server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, includes,
+          ignores)
         server
       end
 

--- a/test/shopify-cli/theme/extension/dev_server_test.rb
+++ b/test/shopify-cli/theme/extension/dev_server_test.rb
@@ -147,9 +147,10 @@ module ShopifyCLI
         private
 
         def dev_server(identifier: nil)
-          host, port, poll, editor_sync, stable, mode, ignores, includes = nil
+          host, port, poll, editor_sync, overwrite_json, stable, mode, ignores, includes = nil
           server = Extension::DevServer.instance
-          server.setup(ctx, root, host, identifier, port, poll, editor_sync, stable, mode, ignores, includes)
+          server.setup(ctx, root, host, identifier, port, poll, editor_sync, overwrite_json, stable, mode, ignores,
+            includes)
           server.project = project
           server.specification_handler = specification_handler
           server


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/internal-cli-foundations/issues/509
Is required by https://github.com/Shopify/cli/pull/1169

Issue https://github.com/Shopify/shopify-cli/issues/2433 was fixed with https://github.com/Shopify/shopify-cli/pull/2463.
With https://github.com/Shopify/cli/pull/1169, Node CLI needs to pass Ruby CLI a hidden flag to differentiate themes created at runtime.

### WHAT is this pull request doing?

Introduces `--overwrite-json` flag that Node CLI can pass to Ruby CLI.

### How to test your changes?

1. In `lib/shopify_cli/theme/theme.rb`, remove the line `@created_at_runtime = true`, because theme will already have been created by Node CLI.
2. Make sure that your current store has 0 development themes.
3. Execute `shopify(-dev) theme serve /path/to/theme --theme-editor-sync`
4. Verify that CLI asks "Keep the remote version".
5. Exit the prompt.
6. Delete the development theme that has been created.
7. Execute `shopify(-dev) theme serve /path/to/theme --theme-editor-sync --overwrite-json`
8. Verify that CLI does not display any prompt.

### Post-release steps

–

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've left the version number as is (we'll handle incrementing this when releasing).
- [x] I've included any post-release steps in the section above (if needed).