### PR TITLE
The CLI should not report IO messages when the `--json` flag is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2721](https://github.com/Shopify/shopify-cli/pull/2721): Do not `replace_asset_urls` in font bodies
 * [#2729](https://github.com/Shopify/shopify-cli/pull/2729): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1370)
-* [#0000](https://github.com/Shopify/shopify-cli/pull/0000): The CLI should not report IO messages when the `--json` flag is passed
+* [#2731](https://github.com/Shopify/shopify-cli/pull/2731): The CLI should not report IO messages when the `--json` flag is passed
 
 ### Added
 * [#2724](https://github.com/Shopify/shopify-cli/pull/2724): Introduce hidden `--overwrite-json` flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 ### Fixed
 * [#2721](https://github.com/Shopify/shopify-cli/pull/2721): Do not `replace_asset_urls` in font bodies
 * [#2729](https://github.com/Shopify/shopify-cli/pull/2729): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1370)
+* [#0000](https://github.com/Shopify/shopify-cli/pull/0000): The CLI should not report IO messages when the `--json` flag is passed
 
 ### Added
 * [#2724](https://github.com/Shopify/shopify-cli/pull/2724): Introduce hidden `--overwrite-json` flag

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -67,6 +67,7 @@ module Theme
         begin
           syncer.start_threads
           if options.flags[:json]
+            syncer.standard_reporter.disable!
             syncer.upload_theme!(delete: delete)
           else
             CLI::UI::Frame.open(@ctx.message("theme.push.info.pushing", theme.name, theme.id, theme.shop)) do

--- a/lib/shopify_cli/theme/syncer.rb
+++ b/lib/shopify_cli/theme/syncer.rb
@@ -33,7 +33,7 @@ module ShopifyCLI
         :union_merge, # - Union merges the local file content with the remote file content
       ]
 
-      attr_reader :ctx, :theme, :checksums, :error_checksums, :api_client, :pending
+      attr_reader :ctx, :theme, :checksums, :error_checksums, :api_client, :pending, :standard_reporter
       attr_accessor :include_filter, :ignore_filter
 
       def_delegators :@error_reporter, :has_any_error?

--- a/lib/shopify_cli/theme/syncer/standard_reporter.rb
+++ b/lib/shopify_cli/theme/syncer/standard_reporter.rb
@@ -24,7 +24,7 @@ module ShopifyCLI
         end
 
         def report(message)
-          ctx.puts(message) if @enabled
+          ctx.error(message) if @enabled
         end
       end
     end

--- a/lib/shopify_cli/theme/syncer/standard_reporter.rb
+++ b/lib/shopify_cli/theme/syncer/standard_reporter.rb
@@ -5,7 +5,7 @@ module ShopifyCLI
     class Syncer
       ##
       # ShopifyCLI::Theme::Syncer::StdReporter allows disabling/enabling
-      # messages reported in the standard output (ShopifyCLI::Context#puts).
+      # messages reported in the standard error output (ShopifyCLI::Context#puts).
       #
       class StandardReporter
         attr_reader :ctx

--- a/test/project_types/theme/commands/push_test.rb
+++ b/test/project_types/theme/commands/push_test.rb
@@ -24,7 +24,7 @@ module Theme
           editor_url: "https://test.myshopify.io/",
           live?: false,
         )
-        @syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: false)
+        @syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: false, standard_reporter: mock)
         @ignore_filter = mock("IgnoreFilter")
         @include_filter = mock("IncludeFilter")
 
@@ -226,6 +226,7 @@ module Theme
         @syncer.expects(:start_threads)
         @syncer.expects(:shutdown)
 
+        @syncer.standard_reporter.expects(:disable!)
         @syncer.expects(:upload_theme!).with(delete: true)
         @command.expects(:puts).with("{\"theme\":{}}")
 
@@ -239,7 +240,8 @@ module Theme
       end
 
       def test_push_when_syncer_has_an_error_json
-        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true)
+        syncer = stub("Syncer", lock_io!: nil, unlock_io!: nil, has_any_error?: true,
+          standard_reporter: stub(disable!: nil))
 
         ShopifyCLI::Theme::Theme.expects(:find_by_identifier)
           .with(@ctx, root: @root, identifier: 1234)

--- a/test/shopify-cli/theme/syncer_test.rb
+++ b/test/shopify-cli/theme/syncer_test.rb
@@ -573,7 +573,7 @@ module ShopifyCLI
         @syncer.start_threads
 
         # Assert a single synced message
-        @ctx.expects(:puts)
+        @ctx.expects(:error)
           .with("12:30:59 {{green:Synced}} {{>}} {{blue:update #{file_path}}}").once
 
         file.stubs(checksum: "initial")
@@ -637,7 +637,7 @@ module ShopifyCLI
         end
 
         # Assert a single fix message
-        @ctx.expects(:puts).with("12:30:59 {{cyan:Fixed }} {{>}} {{blue:update sections/footer.liquid}}").once
+        @ctx.expects(:error).with("12:30:59 {{cyan:Fixed }} {{>}} {{blue:update sections/footer.liquid}}").once
         file.stubs(checksum: "initial")
         time_freeze do
           @syncer.enqueue_updates([file])


### PR DESCRIPTION
### WHY are these changes introduced?

Backport https://github.com/Shopify/cli/pull/1379

### Update checklist

- [x] I've added a CHANGELOG entry for this PR (if the change is public-facing)