### PR TITLE
Packaging for release v2.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.35.0 - 2023-02-22
+
 ### Fixed
 * [#2721](https://github.com/Shopify/shopify-cli/pull/2721): Do not `replace_asset_urls` in font bodies
 * [#2729](https://github.com/Shopify/shopify-cli/pull/2729): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1370)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.34.0)
+    shopify-cli (2.35.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.14.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.34.0"
+  VERSION = "2.35.0"
 end


### PR DESCRIPTION
### Fixed
* [#2721](https://github.com/Shopify/shopify-cli/pull/2721): Do not `replace_asset_urls` in font bodies
* [#2729](https://github.com/Shopify/shopify-cli/pull/2729): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1370)
* [#2731](https://github.com/Shopify/shopify-cli/pull/2731): The CLI should not report IO messages when the `--json` flag is passed

### Added
* [#2724](https://github.com/Shopify/shopify-cli/pull/2724): Introduce hidden `--overwrite-json` flag
* [#2729](https://github.com/Shopify/shopify-cli/pull/2729): Introduce hidden `--generate_tmp_theme` flag (from cli#1264)
