### PR TITLE
Port changes from CLI 3 to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+### Fixed
+* [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Remove theme directory confirmation during tests and make confirmation dialogue respect `SHOPIFY_CLI_TTY` (from cli#1369)
+
+### Added
+* [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Pass development theme from CLI 3’s to CLI 2’s local storage (from cli#1410)
+
 ## Version 2.35.0 - 2023-02-22
 
 ### Fixed

--- a/lib/project_types/theme/commands/common/root_helper.rb
+++ b/lib/project_types/theme/commands/common/root_helper.rb
@@ -49,13 +49,14 @@ module Theme
         private
 
         def current_directory_confirmed?
-          raise "Current theme directory can't be confirmed during tests" if @ctx.testing?
+          return true if options.flags[:force]
 
+          @ctx.warn(@ctx.message("theme.current_directory_is_not_theme_directory"))
           Forms::ConfirmStore.ask(
             @ctx,
             [],
             title: @ctx.message("theme.confirm_current_directory"),
-            force: options.flags[:force],
+            force: !ShopifyCLI::Environment.interactive?,
           ).confirmed?
         end
 

--- a/lib/project_types/theme/commands/pull.rb
+++ b/lib/project_types/theme/commands/pull.rb
@@ -35,11 +35,17 @@ module Theme
           flags[:ignores] |= pattern
         end
         parser.on("-f", "--force") { flags[:force] = true }
+        parser.on("--development-theme-id=DEVELOPMENT_THEME_ID") do |development_theme_id|
+          flags[:development_theme_id] = development_theme_id.to_i
+        end
       end
 
       def call(_args, name)
         root = root_value(options, name)
         return if exist_and_not_empty?(root) && !valid_theme_directory?(root)
+
+        development_theme_id = options.flags[:development_theme_id]
+        ShopifyCLI::DB.set(development_theme_id: development_theme_id) unless development_theme_id.nil?
 
         delete = !options.flags[:nodelete]
         theme = find_theme(root, **options.flags)

--- a/lib/project_types/theme/commands/push.rb
+++ b/lib/project_types/theme/commands/push.rb
@@ -40,11 +40,17 @@ module Theme
           flags[:ignores] |= pattern
         end
         parser.on("-f", "--force") { flags[:force] = true }
+        parser.on("--development-theme-id=DEVELOPMENT_THEME_ID") do |development_theme_id|
+          flags[:development_theme_id] = development_theme_id.to_i
+        end
       end
 
       def call(_args, name)
         root = root_value(options, name)
         return unless valid_theme_directory?(root)
+
+        development_theme_id = options.flags[:development_theme_id]
+        ShopifyCLI::DB.set(development_theme_id: development_theme_id) unless development_theme_id.nil?
 
         delete = !options.flags[:nodelete]
         theme = find_theme(root, **options.flags)

--- a/lib/project_types/theme/messages/messages.rb
+++ b/lib/project_types/theme/messages/messages.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Theme
   module Messages
     MESSAGES = {
@@ -18,8 +19,9 @@ module Theme
         ENSURE_USER
         stable_flag_suggestion: "If the current command isn't working as expected," \
           " we suggest re-running the command with the {{command: --stable}} flag",
-        confirm_current_directory: "It doesn’t seem like you’re running this command in a theme directory. " \
-          "Are you sure you want to proceed?",
+        current_directory_is_not_theme_directory: "It doesn’t seem like you’re running this command" \
+          " in a theme directory.",
+        confirm_current_directory: "Are you sure you want to proceed?",
         init: {
           help: <<~HELP,
             {{command:%s theme init}}: Clones a Git repository to use as a starting point for building a new theme.


### PR DESCRIPTION
### WHY are these changes introduced?
Backports changes from CLI 3 to CLI 2, until CLI 2 is sunset.

### WHAT is this pull request doing?

Back-port from
* https://github.com/Shopify/cli/pull/1369
* https://github.com/Shopify/cli/pull/1410