### PR TITLE
Port changes from CLI 3 to CLI 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ### Fixed
 * [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Remove theme directory confirmation during tests and make confirmation dialogue respect `SHOPIFY_CLI_TTY` (from cli#1369)
+* [#2737](https://github.com/Shopify/shopify-cli/pull/2737): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1568)
 
 ### Added
 * [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Pass development theme from CLI 3’s to CLI 2’s local storage (from cli#1410)

--- a/lib/shopify_cli/theme/dev_server/hot_reload.rb
+++ b/lib/shopify_cli/theme/dev_server/hot_reload.rb
@@ -47,7 +47,7 @@ module ShopifyCLI
         end
 
         def leads_to_injectable_body?(path)
-          path !~ /web-pixels-manager.+sandbox/
+          path !~ /.+\/sandbox/
         end
 
         def inject_hot_reload_javascript(body)

--- a/test/shopify-cli/theme/dev_server/hot_reload_test.rb
+++ b/test/shopify-cli/theme/dev_server/hot_reload_test.rb
@@ -41,6 +41,18 @@ module ShopifyCLI
           assert_equal(correct_output, request.get("/").body)
         end
 
+        def test_does_not_call_reload_script_injector_for_web_pixels_manager_sandbox
+          correct_output = "<html></html>"
+          app = lambda do |_env|
+            [200, { "content-type" => "text/html" }, [correct_output]]
+          end
+          stack = HotReload.new(@ctx, app, watcher: @watcher, mode: @mode)
+          request = Rack::MockRequest.new(stack)
+
+          assert_equal(correct_output, request.get("/web-pixels-manager@0.0.219/sandbox/").body)
+          assert_equal(correct_output, request.get("/wpm@0.0.233@6b2037/sandbox/").body)
+        end
+
         private
 
         def app


### PR DESCRIPTION
### WHY are these changes introduced?
Backports changes from CLI 3 to CLI 2, until CLI 2 is sunset.

### WHAT is this pull request doing?
Back-port from
* https://github.com/Shopify/cli/pull/1568