### PR TITLE
Packaging for release v2.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ From version 2.6.0, the sections in this file adhere to the [keep a changelog](h
 
 ## [Unreleased]
 
+## Version 2.36.0 - 2023-05-03
+
 ### Fixed
 * [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Remove theme directory confirmation during tests and make confirmation dialogue respect `SHOPIFY_CLI_TTY` (from cli#1369)
 * [#2737](https://github.com/Shopify/shopify-cli/pull/2737): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1568)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify-cli (2.35.0)
+    shopify-cli (2.36.0)
       bugsnag (~> 6.22)
       listen (~> 3.7.0)
       theme-check (~> 1.14.0)

--- a/lib/shopify_cli/version.rb
+++ b/lib/shopify_cli/version.rb
@@ -1,3 +1,3 @@
 module ShopifyCLI
-  VERSION = "2.35.0"
+  VERSION = "2.36.0"
 end


### PR DESCRIPTION
### Fixed
* [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Remove theme directory confirmation during tests and make confirmation dialogue respect `SHOPIFY_CLI_TTY` (from cli#1369)
* [#2737](https://github.com/Shopify/shopify-cli/pull/2737): Do not inject hot-reload code into web-pixels-manager sandbox (from cli#1568)

### Added
* [#2735](https://github.com/Shopify/shopify-cli/pull/2735): Pass development theme from CLI 3’s to CLI 2’s local storage (from cli#1410)
